### PR TITLE
Fix filename in stable audio workflow

### DIFF
--- a/templates/stable_audio_example.json
+++ b/templates/stable_audio_example.json
@@ -86,7 +86,7 @@
       "properties": {
         "Node name for S&R": "CheckpointLoaderSimple"
       },
-      "widgets_values": ["stable_audio_open_1.0.safetensors"]
+      "widgets_values": ["model.safetensors"]
     },
     {
       "id": 6,
@@ -294,7 +294,7 @@
       "directory": "text_encoders"
     },
     {
-      "name": "stable_audio_open_1.0.safetensors",
+      "name": "model.safetensors",
       "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0/resolve/main/model.safetensors?download=true",
       "directory": "checkpoints"
     }


### PR DESCRIPTION
The downloaded file is named `model.safetensors`. Change the widget value to match, otherwise an error occurs even after downloading the model correctly.