### PR TITLE
Use docs.comfy version of scribble controlnet example workflow

### DIFF
--- a/templates/controlnet_example.json
+++ b/templates/controlnet_example.json
@@ -1,50 +1,97 @@
 {
-  "last_node_id": 15,
-  "last_link_id": 21,
+  "last_node_id": 33,
+  "last_link_id": 56,
   "nodes": [
     {
-      "id": 8,
-      "type": "VAEDecode",
-      "pos": [1210, 250],
-      "size": [210, 46],
+      "id": 3,
+      "type": "KSampler",
+      "pos": [1060, 160],
+      "size": [315, 474],
       "flags": {},
-      "order": 10,
+      "order": 9,
       "mode": 0,
       "inputs": [
         {
-          "name": "samples",
-          "type": "LATENT",
-          "link": 7
+          "label": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 19
         },
         {
-          "name": "vae",
-          "type": "VAE",
-          "link": 14
+          "label": "positive",
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 55
+        },
+        {
+          "label": "negative",
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 56
+        },
+        {
+          "label": "latent_image",
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 2
         }
       ],
       "outputs": [
         {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [9],
-          "slot_index": 0
+          "label": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [7]
         }
       ],
       "properties": {
-        "Node name for S&R": "VAEDecode"
+        "Node name for S&R": "KSampler"
       },
-      "widgets_values": []
+      "widgets_values": [
+        776509832134660,
+        "randomize",
+        20,
+        6,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [730, 420],
+      "size": [300, 110],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [2]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [1024, 1024, 1]
     },
     {
       "id": 6,
       "type": "CLIPTextEncode",
-      "pos": [-42, -147],
-      "size": [422.85, 164.31],
+      "pos": [270, 150],
+      "size": [422.84503173828125, 164.31304931640625],
       "flags": {},
       "order": 7,
       "mode": 0,
       "inputs": [
         {
+          "label": "clip",
           "name": "clip",
           "type": "CLIP",
           "link": 21
@@ -52,51 +99,31 @@
       ],
       "outputs": [
         {
+          "label": "CONDITIONING",
           "name": "CONDITIONING",
           "type": "CONDITIONING",
-          "links": [10],
-          "slot_index": 0
+          "slot_index": 0,
+          "links": [53]
         }
       ],
       "properties": {
         "Node name for S&R": "CLIPTextEncode"
       },
       "widgets_values": [
-        "(solo) girl (flat chest:0.9), (fennec ears:1.1)\u00a0 (fox ears:1.1), (blonde hair:1.0), messy hair, sky clouds, standing in a grass field, (chibi), blue eyes"
+        "Masterpiece,best quality,high definition,high level of detail,3D,3D style,cute Q-version,Chibi,a vibrant product photo created for innovative advertising,featuring a little boy with black hair and a big laugh,Solo,holding a wooden crate,wooden crate,pasture,blue sky,white clouds,brick paved path,with pleasant houses in the background,chimneys,big trees,maple leaves,maple trees,and a lot of wheat,wheat,wheat ears along the roadside,The atmosphere of autumn,yellow grass and leaves,fallen leaves,fences,barriers,orange and yellow colors,autumn,windows,doors,gravel roads,captured using a Sony Alpha A7R IV camera with a 35mm f/1.4 lens,aperture set to f/2.8,shutter speed of 1/100 second,"
       ]
-    },
-    {
-      "id": 12,
-      "type": "ControlNetLoader",
-      "pos": [-50, 69],
-      "size": [422, 58],
-      "flags": {},
-      "order": 0,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "CONTROL_NET",
-          "type": "CONTROL_NET",
-          "links": [13],
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "ControlNetLoader"
-      },
-      "widgets_values": ["control_v11p_sd15_scribble_fp16.safetensors"]
     },
     {
       "id": 7,
       "type": "CLIPTextEncode",
-      "pos": [355, 213],
-      "size": [425.28, 180.61],
+      "pos": [270, 360],
+      "size": [425.27801513671875, 180.6060791015625],
       "flags": {},
       "order": 6,
       "mode": 0,
       "inputs": [
         {
+          "label": "clip",
           "name": "clip",
           "type": "CLIP",
           "link": 20
@@ -104,10 +131,11 @@
       ],
       "outputs": [
         {
+          "label": "CONDITIONING",
           "name": "CONDITIONING",
           "type": "CONDITIONING",
-          "links": [16],
-          "slot_index": 0
+          "slot_index": 0,
+          "links": [54]
         }
       ],
       "properties": {
@@ -118,230 +146,272 @@
       ]
     },
     {
-      "id": 5,
-      "type": "EmptyLatentImage",
-      "pos": [439, 446],
-      "size": [315, 106],
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [1420, 160],
+      "size": [210, 46],
       "flags": {},
-      "order": 1,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "LATENT",
-          "type": "LATENT",
-          "links": [2],
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "EmptyLatentImage"
-      },
-      "widgets_values": [512, 512, 1]
-    },
-    {
-      "id": 13,
-      "type": "VAELoader",
-      "pos": [833, 484],
-      "size": [315, 58],
-      "flags": {},
-      "order": 2,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "VAE",
-          "type": "VAE",
-          "links": [14],
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "VAELoader"
-      },
-      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
-    },
-    {
-      "id": 10,
-      "type": "ControlNetApply",
-      "pos": [459, 51],
-      "size": [317.4, 98],
-      "flags": {},
-      "order": 8,
+      "order": 10,
       "mode": 0,
       "inputs": [
         {
-          "name": "conditioning",
-          "type": "CONDITIONING",
-          "link": 10
+          "label": "samples",
+          "name": "samples",
+          "type": "LATENT",
+          "link": 7
         },
         {
-          "name": "control_net",
-          "type": "CONTROL_NET",
-          "link": 13
-        },
-        {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 12
+          "label": "vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 14
         }
       ],
       "outputs": [
         {
-          "name": "CONDITIONING",
-          "type": "CONDITIONING",
-          "links": [18],
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "ControlNetApply"
-      },
-      "widgets_values": [0.9]
-    },
-    {
-      "id": 11,
-      "type": "LoadImage",
-      "pos": [-70, 177],
-      "size": [387.97, 465.51],
-      "flags": {},
-      "order": 3,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
+          "label": "IMAGE",
           "name": "IMAGE",
           "type": "IMAGE",
-          "links": [12],
-          "slot_index": 0
-        },
-        {
-          "name": "MASK",
-          "type": "MASK",
-          "links": null
+          "slot_index": 0,
+          "links": [9]
         }
       ],
       "properties": {
-        "Node name for S&R": "LoadImage"
+        "Node name for S&R": "VAEDecode"
       },
-      "widgets_values": ["input_scribble_example.png", "image"]
-    },
-    {
-      "id": 14,
-      "type": "CheckpointLoaderSimple",
-      "pos": [-448, 231],
-      "size": [315, 98],
-      "flags": {},
-      "order": 4,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "MODEL",
-          "type": "MODEL",
-          "links": [19],
-          "slot_index": 0
-        },
-        {
-          "name": "CLIP",
-          "type": "CLIP",
-          "links": [20, 21],
-          "slot_index": 1
-        },
-        {
-          "name": "VAE",
-          "type": "VAE",
-          "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
-      },
-      "widgets_values": ["Anything-V3.0.ckpt"]
+      "widgets_values": []
     },
     {
       "id": 9,
       "type": "SaveImage",
-      "pos": [1453, 247],
-      "size": [393.62, 449.16],
+      "pos": [1420, 250],
+      "size": [580, 650],
       "flags": {},
       "order": 11,
       "mode": 0,
       "inputs": [
         {
+          "label": "images",
           "name": "images",
           "type": "IMAGE",
           "link": 9
         }
       ],
       "outputs": [],
-      "properties": {},
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
       "widgets_values": ["ComfyUI"]
     },
     {
-      "id": 3,
-      "type": "KSampler",
-      "pos": [842, 150],
-      "size": [315, 262],
+      "id": 11,
+      "type": "LoadImage",
+      "pos": [-160, 400],
+      "size": [387.97003173828125, 465.5097961425781],
       "flags": {},
-      "order": 9,
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [52]
+        },
+        {
+          "label": "MASK",
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": ["scribble_input.png", "image", ""]
+    },
+    {
+      "id": 12,
+      "type": "ControlNetLoader",
+      "pos": [281.73468017578125, 636.84765625],
+      "size": [340, 60],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "CONTROL_NET",
+          "name": "CONTROL_NET",
+          "type": "CONTROL_NET",
+          "slot_index": 0,
+          "links": [51]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ControlNetLoader",
+        "models": [
+          {
+            "name": "control_v11p_sd15_scribble_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11p_sd15_scribble_fp16.safetensors?download=true",
+            "directory": "controlnet"
+          }
+        ]
+      },
+      "widgets_values": ["control_v11p_sd15_scribble_fp16.safetensors"]
+    },
+    {
+      "id": 13,
+      "type": "VAELoader",
+      "pos": [-160, 290],
+      "size": [380, 58],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "VAE",
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [14]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "vae-ft-mse-840000-ema-pruned.safetensors",
+            "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
+      },
+      "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
+    },
+    {
+      "id": 14,
+      "type": "CheckpointLoaderSimple",
+      "pos": [-160, 150],
+      "size": [380, 100],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "MODEL",
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [19]
+        },
+        {
+          "label": "CLIP",
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": [20, 21]
+        },
+        {
+          "label": "VAE",
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "dreamCreationVirtual3DECommerce_v10.safetensors",
+            "url": "https://civitai.com/api/download/models/731340?type=Model&format=SafeTensor&size=full&fp=fp16",
+            "directory": "checkpoints"
+          }
+        ]
+      },
+      "widgets_values": ["dreamCreationVirtual3DECommerce_v10.safetensors"]
+    },
+    {
+      "id": 32,
+      "type": "ControlNetApplyAdvanced",
+      "pos": [721.2879028320312, -52.88718032836914],
+      "size": [315, 186],
+      "flags": {},
+      "order": 8,
       "mode": 0,
       "inputs": [
         {
-          "name": "model",
-          "type": "MODEL",
-          "link": 19
-        },
-        {
+          "label": "positive",
           "name": "positive",
           "type": "CONDITIONING",
-          "link": 18
+          "link": 53
         },
         {
+          "label": "negative",
           "name": "negative",
           "type": "CONDITIONING",
-          "link": 16
+          "link": 54
         },
         {
-          "name": "latent_image",
-          "type": "LATENT",
-          "link": 2
+          "label": "control_net",
+          "name": "control_net",
+          "type": "CONTROL_NET",
+          "link": 51
+        },
+        {
+          "label": "image",
+          "name": "image",
+          "type": "IMAGE",
+          "link": 52
+        },
+        {
+          "label": "vae",
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
         }
       ],
       "outputs": [
         {
-          "name": "LATENT",
-          "type": "LATENT",
-          "links": [7],
-          "slot_index": 0
+          "label": "positive",
+          "name": "positive",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [55]
+        },
+        {
+          "label": "negative",
+          "name": "negative",
+          "type": "CONDITIONING",
+          "slot_index": 1,
+          "links": [56]
         }
       ],
       "properties": {
-        "Node name for S&R": "KSampler"
+        "Node name for S&R": "ControlNetApplyAdvanced"
       },
-      "widgets_values": [
-        1002496614778823,
-        "randomize",
-        16,
-        6,
-        "uni_pc",
-        "normal",
-        1
-      ]
+      "widgets_values": [1, 0, 1]
     },
     {
-      "id": 15,
+      "id": 33,
       "type": "MarkdownNote",
-      "pos": [-450, 375],
-      "size": [225, 60],
+      "pos": [-160, 920],
+      "size": [336, 152],
       "flags": {},
-      "order": 5,
+      "order": 4,
       "mode": 0,
       "inputs": [],
       "outputs": [],
       "properties": {},
       "widgets_values": [
-        "\ud83d\udec8 [Learn more about this workflow](https://comfyanonymous.github.io/ComfyUI_examples/controlnet/)"
+        "### Learn more about this workflow\n\n> [ControlNet - ComfyUI_examples](https://comfyanonymous.github.io/ComfyUI_examples/controlnet/) — Overview\n> \n> [ControlNet Usage - docs.comfy.org](https://docs.comfy.org/tutorials/controlnet/controlnet) — Explanation of concepts and step-by-step tutorial"
       ],
       "color": "#432",
       "bgcolor": "#653"
@@ -351,35 +421,23 @@
     [2, 5, 0, 3, 3, "LATENT"],
     [7, 3, 0, 8, 0, "LATENT"],
     [9, 8, 0, 9, 0, "IMAGE"],
-    [10, 6, 0, 10, 0, "CONDITIONING"],
-    [12, 11, 0, 10, 2, "IMAGE"],
-    [13, 12, 0, 10, 1, "CONTROL_NET"],
     [14, 13, 0, 8, 1, "VAE"],
-    [16, 7, 0, 3, 2, "CONDITIONING"],
-    [18, 10, 0, 3, 1, "CONDITIONING"],
     [19, 14, 0, 3, 0, "MODEL"],
     [20, 14, 1, 7, 0, "CLIP"],
-    [21, 14, 1, 6, 0, "CLIP"]
+    [21, 14, 1, 6, 0, "CLIP"],
+    [51, 12, 0, 32, 2, "CONTROL_NET"],
+    [52, 11, 0, 32, 3, "IMAGE"],
+    [53, 6, 0, 32, 0, "CONDITIONING"],
+    [54, 7, 0, 32, 1, "CONDITIONING"],
+    [55, 32, 0, 3, 1, "CONDITIONING"],
+    [56, 32, 1, 3, 2, "CONDITIONING"]
   ],
   "groups": [],
   "config": {},
   "extra": {
-    "ds": {
-      "scale": 0.8,
-      "offset": [843.77, 555.93]
+    "node_versions": {
+      "comfy-core": "0.3.14"
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "control_v11p_sd15_scribble_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11p_sd15_scribble_fp16.safetensors?download=true",
-      "directory": "controlnet"
-    },
-    {
-      "name": "vae-ft-mse-840000-ema-pruned.safetensors",
-      "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
-      "directory": "vae"
-    }
-  ]
+  "version": 0.4
 }


### PR DESCRIPTION
- Use the version of the scribble controlnets template (just called "ControlNet" in the UI at the moment) from https://docs.comfy.org/tutorials/controlnet/controlnet
  - Added in https://github.com/Comfy-Org/docs/pull/60
- Update docs markdown note
- Move models metadata to node properties so it is serialized

![Selection_1061](https://github.com/user-attachments/assets/b3478428-54c4-4ee2-ba73-29658968feba)
