### PR TITLE
Use docs.comfy version of outpainting example workflow

### DIFF
--- a/templates/inpain_model_outpainting.json
+++ b/templates/inpain_model_outpainting.json
@@ -1,103 +1,12 @@
 {
-  "last_node_id": 31,
-  "last_link_id": 87,
+  "last_node_id": 34,
+  "last_link_id": 89,
   "nodes": [
-    {
-      "id": 6,
-      "type": "CLIPTextEncode",
-      "pos": [432, 158],
-      "size": [422.85, 164.31],
-      "flags": {},
-      "order": 3,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "clip",
-          "type": "CLIP",
-          "link": 81
-        }
-      ],
-      "outputs": [
-        {
-          "name": "CONDITIONING",
-          "type": "CONDITIONING",
-          "links": [4],
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "CLIPTextEncode"
-      },
-      "widgets_values": [
-        "outdoors in the yosemite national park mountains nature\n\n\n\n"
-      ]
-    },
-    {
-      "id": 7,
-      "type": "CLIPTextEncode",
-      "pos": [434, 371],
-      "size": [425.28, 180.61],
-      "flags": {},
-      "order": 4,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "clip",
-          "type": "CLIP",
-          "link": 82
-        }
-      ],
-      "outputs": [
-        {
-          "name": "CONDITIONING",
-          "type": "CONDITIONING",
-          "links": [6],
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "CLIPTextEncode"
-      },
-      "widgets_values": ["watermark, text\n"]
-    },
-    {
-      "id": 8,
-      "type": "VAEDecode",
-      "pos": [1422, 387],
-      "size": [210, 46],
-      "flags": {},
-      "order": 8,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "samples",
-          "type": "LATENT",
-          "link": 42
-        },
-        {
-          "name": "vae",
-          "type": "VAE",
-          "link": 83
-        }
-      ],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [22],
-          "slot_index": 0
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "VAEDecode"
-      },
-      "widgets_values": []
-    },
     {
       "id": 3,
       "type": "KSampler",
       "pos": [940, 180],
-      "size": [315, 262],
+      "size": [315, 474],
       "flags": {},
       "order": 7,
       "mode": 0,
@@ -127,126 +36,128 @@
         {
           "name": "LATENT",
           "type": "LATENT",
-          "links": [42],
-          "slot_index": 0
+          "slot_index": 0,
+          "links": [42]
         }
       ],
       "properties": {
-        "Node name for S&R": "KSampler"
+        "Node name for S&R": "KSampler",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
       },
       "widgets_values": [
-        152545289528694,
+        476514576444494,
         "randomize",
         20,
-        8,
-        "uni_pc_bh2",
-        "normal",
-        1
+        7,
+        "dpmpp_2m",
+        "karras",
+        1,
+        ""
       ]
     },
     {
-      "id": 29,
-      "type": "CheckpointLoaderSimple",
-      "pos": [17, 303],
-      "size": [315, 98],
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [432, 158],
+      "size": [422.81243896484375, 161.2169189453125],
       "flags": {},
-      "order": 0,
+      "order": 4,
       "mode": 0,
-      "inputs": [],
-      "outputs": [
+      "inputs": [
         {
-          "name": "MODEL",
-          "type": "MODEL",
-          "links": [80],
-          "slot_index": 0
-        },
-        {
-          "name": "CLIP",
+          "name": "clip",
           "type": "CLIP",
-          "links": [81, 82],
-          "slot_index": 1
-        },
-        {
-          "name": "VAE",
-          "type": "VAE",
-          "links": [83, 84],
-          "slot_index": 2
+          "link": 81
         }
       ],
-      "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
-      },
-      "widgets_values": ["512-inpainting-ema.safetensors"]
-    },
-    {
-      "id": 20,
-      "type": "LoadImage",
-      "pos": [-107, 726],
-      "size": [344, 346],
-      "flags": {},
-      "order": 1,
-      "mode": 0,
-      "inputs": [],
       "outputs": [
         {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [85],
-          "slot_index": 0
-        },
-        {
-          "name": "MASK",
-          "type": "MASK",
-          "links": [],
-          "slot_index": 1
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [4]
         }
       ],
       "properties": {
-        "Node name for S&R": "LoadImage"
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
       },
-      "widgets_values": ["yosemite_outpaint_example.png", "image"]
+      "widgets_values": [
+        "a close-up of a delicate pink rose with velvety petals,reflecting soft ambient light,Dark green-toned light\n\nThe background consists of blurred pink roses and green foliage, creating a dreamy and harmonious depth. \n\n(soft lighting, dim background, cinematic lighting, realistic shading, gentle contrast, warm tones), "
+      ]
     },
     {
-      "id": 30,
-      "type": "ImagePadForOutpaint",
-      "pos": [269, 727],
-      "size": [315, 174],
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [434, 371],
+      "size": [425.2799987792969, 180.61000061035156],
       "flags": {},
       "order": 5,
       "mode": 0,
       "inputs": [
         {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 85
+          "name": "clip",
+          "type": "CLIP",
+          "link": 82
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [6]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
+      },
+      "widgets_values": ["watermark, text"]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [1422, 387],
+      "size": [210, 46],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 42
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 83
         }
       ],
       "outputs": [
         {
           "name": "IMAGE",
           "type": "IMAGE",
-          "shape": 3,
-          "links": [87],
-          "slot_index": 0
-        },
-        {
-          "name": "MASK",
-          "type": "MASK",
-          "shape": 3,
-          "links": [86],
-          "slot_index": 1
+          "slot_index": 0,
+          "links": [22]
         }
       ],
       "properties": {
-        "Node name for S&R": "ImagePadForOutpaint"
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
       },
-      "widgets_values": [0, 128, 0, 128, 40]
+      "widgets_values": []
     },
     {
       "id": 9,
       "type": "SaveImage",
       "pos": [1671, 384],
-      "size": [360.55, 441.53],
+      "size": [360.54998779296875, 441.5299987792969],
       "flags": {},
       "order": 9,
       "mode": 0,
@@ -258,14 +169,47 @@
         }
       ],
       "outputs": [],
-      "properties": {},
-      "widgets_values": ["ComfyUI"]
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
+      },
+      "widgets_values": ["ComfyUI", ""]
+    },
+    {
+      "id": 20,
+      "type": "LoadImage",
+      "pos": [-115.77914428710938, 726.8905029296875],
+      "size": [344, 346],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [85]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
+      },
+      "widgets_values": ["input (1).png", "image", ""]
     },
     {
       "id": 26,
       "type": "VAEEncodeForInpaint",
       "pos": [617, 720],
-      "size": [226.8, 98],
+      "size": [226.8000030517578, 98],
       "flags": {},
       "order": 6,
       "mode": 0,
@@ -290,20 +234,103 @@
         {
           "name": "LATENT",
           "type": "LATENT",
-          "links": [72],
-          "slot_index": 0
+          "slot_index": 0,
+          "links": [72]
         }
       ],
       "properties": {
-        "Node name for S&R": "VAEEncodeForInpaint"
+        "Node name for S&R": "VAEEncodeForInpaint",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
       },
-      "widgets_values": [8]
+      "widgets_values": [10]
     },
     {
-      "id": 31,
+      "id": 29,
+      "type": "CheckpointLoaderSimple",
+      "pos": [17, 303],
+      "size": [315, 98],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [80]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": [81, 82]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": [83, 84]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18",
+        "models": [
+          {
+            "name": "512-inpainting-ema.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-diffusion-2-inpainting/resolve/main/512-inpainting-ema.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
+      },
+      "widgets_values": ["512-inpainting-ema.safetensors"]
+    },
+    {
+      "id": 30,
+      "type": "ImagePadForOutpaint",
+      "pos": [252.03269958496094, 726.62841796875],
+      "size": [315, 174],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 85
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "shape": 3,
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [87]
+        },
+        {
+          "name": "MASK",
+          "shape": 3,
+          "type": "MASK",
+          "slot_index": 1,
+          "links": [86]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ImagePadForOutpaint",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.18"
+      },
+      "widgets_values": [40, 40, 40, 128, 10]
+    },
+    {
+      "id": 34,
       "type": "MarkdownNote",
-      "pos": [30, 465],
-      "size": [225, 60],
+      "pos": [16, 448],
+      "size": [336, 128],
       "flags": {},
       "order": 2,
       "mode": 0,
@@ -311,7 +338,7 @@
       "outputs": [],
       "properties": {},
       "widgets_values": [
-        "\ud83d\udec8 [Learn more about this workflow](https://comfyanonymous.github.io/ComfyUI_examples/inpaint/#outpainting)"
+        "### Learn more about this workflow\n\n> [Outpaint - ComfyUI_examples](https://comfyanonymous.github.io/ComfyUI_examples/inpaint/#outpainting) — Overview\n> \n> [Outpainting - docs.comfy.org](https://docs.comfy.org/tutorials/basic/outpaint) — Explanation of concepts and step-by-step tutorial"
       ],
       "color": "#432",
       "bgcolor": "#653"
@@ -343,18 +370,6 @@
     }
   ],
   "config": {},
-  "extra": {
-    "ds": {
-      "scale": 0.86,
-      "offset": [491.92, 146.6]
-    }
-  },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "512-inpainting-ema.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-2-inpainting/resolve/main/512-inpainting-ema.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "extra": {},
+  "version": 0.4
 }


### PR DESCRIPTION
- Use the version of the basic outpaint workflow from https://docs.comfy.org/tutorials/basic/outpaint
  - https://github.com/Comfy-Org/docs/pull/57
- Update docs markdown note
- Move models metadata to node properties so it is serialized

![Selection_1065](https://github.com/user-attachments/assets/31f1477e-a952-40d5-bfbf-3d0bb3224a3a)
