### PR TITLE
Fix Wan i2v model display name

### DIFF
--- a/templates/image_to_video_wan.json
+++ b/templates/image_to_video_wan.json
@@ -429,7 +429,7 @@
         "Node name for S&R": "UNETLoader",
         "models": [
           {
-            "name": "wan2.1_t2v_1.3B_fp16.safetensors",
+            "name": "wan2.1_i2v_480p_14B_fp16.safetensors",
             "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/resolve/main/split_files/diffusion_models/wan2.1_i2v_480p_14B_fp16.safetensors?download=true",
             "directory": "diffusion_models"
           }


### PR DESCRIPTION
Fixes model name metadata so wrong value is not displayed in UI. Download URL is still correct.