### PR TITLE
Fix flux depth lora template uses flux-depth base model

### DIFF
--- a/templates/flux_depth_lora_example.json
+++ b/templates/flux_depth_lora_example.json
@@ -85,7 +85,19 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "DualCLIPLoader"
+        "Node name for S&R": "DualCLIPLoader",
+        "models": [
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          },
+          {
+            "name": "clip_l.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": [
         "clip_l.safetensors",
@@ -225,7 +237,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "ae.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["ae.safetensors"]
     },
@@ -272,7 +291,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "LoraLoaderModelOnly"
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "models": [
+          {
+            "name": "flux1-depth-dev-lora.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-Depth-dev-lora/resolve/main/flux1-depth-dev-lora.safetensors?download=true",
+            "directory": "loras"
+          }
+        ]
       },
       "widgets_values": ["flux1-depth-dev-lora.safetensors", 1]
     },
@@ -376,9 +402,16 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "UNETLoader"
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "flux1-dev.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev/resolve/main/flux1-dev.safetensors?download=true",
+            "directory": "diffusion_models"
+          }
+        ]
       },
-      "widgets_values": ["flux1-depth-dev.safetensors", "default"]
+      "widgets_values": ["flux1-dev.safetensors", "default"]
     },
     {
       "id": 40,
@@ -423,32 +456,5 @@
       "offset": [724.57, 776.23]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "ae.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
-      "directory": "vae"
-    },
-    {
-      "name": "flux1-depth-dev.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Depth-dev/resolve/main/flux1-depth-dev.safetensors?download=true",
-      "directory": "diffusion_models"
-    },
-    {
-      "name": "clip_l.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "flux1-depth-dev-lora.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Depth-dev-lora/resolve/main/flux1-depth-dev-lora.safetensors?download=true",
-      "directory": "loras"
-    }
-  ]
+  "version": 0.4
 }


### PR DESCRIPTION
Resolves https://github.com/comfyanonymous/ComfyUI/issues/7407.

When using the lora format of the flux depth model, the base model should just be flux dev, rather than flux depth. This error occurs in the templates but not in the [example workflows page](https://comfyanonymous.github.io/ComfyUI_examples/flux/).

Related fix to prevent this error from occurring accidentally in future: https://github.com/comfyanonymous/ComfyUI_examples/pull/53