### PR TITLE
Recategorize templates

### DIFF
--- a/templates/index.json
+++ b/templates/index.json
@@ -125,6 +125,97 @@
   },
   {
     "moduleName": "default",
+    "title": "Image",
+    "type": "image",
+    "templates": [
+      {
+        "name": "hidream_i1_dev",
+        "mediaType": "image",
+        "mediaSubtype": "png",
+        "description": "Generate images with HiDream I1 Dev."
+      },
+      {
+        "name": "hidream_i1_fast",
+        "mediaType": "image",
+        "mediaSubtype": "png",
+        "description": "Generate images quickly with HiDream I1."
+      },
+      {
+        "name": "hidream_i1_full",
+        "mediaType": "image",
+        "mediaSubtype": "png",
+        "description": "Generate images with HiDream I1."
+      },
+      {
+        "name": "sd3.5_simple_example",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Generate images with SD 3.5.",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35"
+      },
+      {
+        "name": "sd3.5_large_canny_controlnet_example",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Use edge detection to guide image generation with SD 3.5.",
+        "thumbnailVariant": "hoverDissolve",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets"
+      },
+      {
+        "name": "sd3.5_large_depth",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Create depth-aware images with SD 3.5.",
+        "thumbnailVariant": "hoverDissolve",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets"
+      },
+      {
+        "name": "sd3.5_large_blur",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Generate images from blurred reference images with SD 3.5.",
+        "thumbnailVariant": "hoverDissolve",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets"
+      },
+      {
+        "name": "sdxl_simple_example",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Create high-quality images with SDXL.",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/"
+      },
+      {
+        "name": "sdxl_refiner_prompt_example",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Enhance SDXL outputs with refiners.",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/"
+      },
+      {
+        "name": "sdxl_revision_text_prompts",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Transfer concepts from reference images to guide image generation with SDXL.",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/#revision"
+      },
+      {
+        "name": "sdxl_revision_zero_positive",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Add text prompts alongside reference images to guide image generation with SDXL.",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/#revision"
+      },
+      {
+        "name": "sdxlturbo_example",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "description": "Generate images in a single step with SDXL Turbo.",
+        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdturbo/"
+      }
+    ]
+  },
+  {
+    "moduleName": "default",
     "title": "ControlNet",
     "type": "image",
     "templates": [
@@ -283,86 +374,6 @@
         "mediaSubtype": "webp",
         "description": "Generate images from text and then convert them into videos.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/video/#image-to-video"
-      }
-    ]
-  },
-  {
-    "moduleName": "default",
-    "title": "SD3.5",
-    "type": "image",
-    "templates": [
-      {
-        "name": "sd3.5_simple_example",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Generate images with SD 3.5.",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35"
-      },
-      {
-        "name": "sd3.5_large_canny_controlnet_example",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Use edge detection to guide image generation with SD 3.5.",
-        "thumbnailVariant": "hoverDissolve",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets"
-      },
-      {
-        "name": "sd3.5_large_depth",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Create depth-aware images with SD 3.5.",
-        "thumbnailVariant": "hoverDissolve",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets"
-      },
-      {
-        "name": "sd3.5_large_blur",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Generate images from blurred reference images with SD 3.5.",
-        "thumbnailVariant": "hoverDissolve",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets"
-      }
-    ]
-  },
-  {
-    "moduleName": "default",
-    "title": "SDXL",
-    "type": "image",
-    "templates": [
-      {
-        "name": "sdxl_simple_example",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Create high-quality images with SDXL.",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/"
-      },
-      {
-        "name": "sdxl_refiner_prompt_example",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Enhance SDXL outputs with refiners.",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/"
-      },
-      {
-        "name": "sdxl_revision_text_prompts",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Transfer concepts from reference images to guide image generation with SDXL.",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/#revision"
-      },
-      {
-        "name": "sdxl_revision_zero_positive",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Add text prompts alongside reference images to guide image generation with SDXL.",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/#revision"
-      },
-      {
-        "name": "sdxlturbo_example",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "description": "Generate images in a single step with SDXL Turbo.",
-        "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdturbo/"
       }
     ]
   },


### PR DESCRIPTION
Moves SD3.5 and SDXL templates from their own categories into the "Image" category. Then adds HiDream templates from https://github.com/Comfy-Org/workflow_templates/pull/30 into the "Image" category.

Further recategorizing may be done in near future.