### PR TITLE
Add English human-readable names as fallback titles

### DIFF
--- a/templates/index.json
+++ b/templates/index.json
@@ -6,12 +6,14 @@
     "templates": [
       {
         "name": "default",
+        "title": "Image Generation",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images from text descriptions."
       },
       {
         "name": "image2image",
+        "title": "Image to Image",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Transform existing images using text prompts.",
@@ -19,6 +21,7 @@
       },
       {
         "name": "lora",
+        "title": "Lora",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Apply LoRA models for specialized styles or subjects.",
@@ -26,6 +29,7 @@
       },
       {
         "name": "inpaint_example",
+        "title": "Inpaint",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Edit specific parts of images seamlessly.",
@@ -34,6 +38,7 @@
       },
       {
         "name": "inpain_model_outpainting",
+        "title": "Outpaint",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Extend images beyond their original boundaries.",
@@ -42,6 +47,7 @@
       },
       {
         "name": "embedding_example",
+        "title": "Embedding",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Use textual inversion for consistent styles.",
@@ -49,6 +55,7 @@
       },
       {
         "name": "gligen_textbox_example",
+        "title": "Gligen Textbox",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Specify the location and size of objects.",
@@ -56,6 +63,7 @@
       },
       {
         "name": "lora_multiple",
+        "title": "Lora Multiple",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Combine multiple LoRA models for unique results.",
@@ -70,6 +78,7 @@
     "templates": [
       {
         "name": "flux_dev_checkpoint_example",
+        "title": "Flux Dev",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Create images using Flux development models.",
@@ -77,6 +86,7 @@
       },
       {
         "name": "flux_schnell",
+        "title": "Flux Schnell",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images quickly with Flux Schnell.",
@@ -84,6 +94,7 @@
       },
       {
         "name": "flux_fill_inpaint_example",
+        "title": "Flux Inpaint",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Fill in missing parts of images.",
@@ -92,6 +103,7 @@
       },
       {
         "name": "flux_fill_outpaint_example",
+        "title": "Flux Outpaint",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Extend images using Flux outpainting.",
@@ -100,6 +112,7 @@
       },
       {
         "name": "flux_canny_model_example",
+        "title": "Flux Canny Model",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images from edge detection.",
@@ -108,6 +121,7 @@
       },
       {
         "name": "flux_depth_lora_example",
+        "title": "Flux Depth Lora",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Create images with depth-aware LoRA.",
@@ -116,6 +130,7 @@
       },
       {
         "name": "flux_redux_model_example",
+        "title": "Flux Redux Model",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Transfer style from a reference image to guide image generation with Flux.",
@@ -130,24 +145,28 @@
     "templates": [
       {
         "name": "hidream_i1_dev",
+        "title": "HiDream I1 Dev",
         "mediaType": "image",
         "mediaSubtype": "png",
         "description": "Generate images with HiDream I1 Dev."
       },
       {
         "name": "hidream_i1_fast",
+        "title": "HiDream I1 Fast",
         "mediaType": "image",
         "mediaSubtype": "png",
         "description": "Generate images quickly with HiDream I1."
       },
       {
         "name": "hidream_i1_full",
+        "title": "HiDream I1 Full",
         "mediaType": "image",
         "mediaSubtype": "png",
         "description": "Generate images with HiDream I1."
       },
       {
         "name": "sd3.5_simple_example",
+        "title": "SD3.5 Simple",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images with SD 3.5.",
@@ -155,6 +174,7 @@
       },
       {
         "name": "sd3.5_large_canny_controlnet_example",
+        "title": "SD3.5 Large Canny ControlNet",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Use edge detection to guide image generation with SD 3.5.",
@@ -163,6 +183,7 @@
       },
       {
         "name": "sd3.5_large_depth",
+        "title": "SD3.5 Large Depth",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Create depth-aware images with SD 3.5.",
@@ -171,6 +192,7 @@
       },
       {
         "name": "sd3.5_large_blur",
+        "title": "SD3.5 Large Blur",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images from blurred reference images with SD 3.5.",
@@ -179,6 +201,7 @@
       },
       {
         "name": "sdxl_simple_example",
+        "title": "SDXL Simple",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Create high-quality images with SDXL.",
@@ -186,6 +209,7 @@
       },
       {
         "name": "sdxl_refiner_prompt_example",
+        "title": "SDXL Refiner Prompt",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Enhance SDXL outputs with refiners.",
@@ -193,6 +217,7 @@
       },
       {
         "name": "sdxl_revision_text_prompts",
+        "title": "SDXL Revision Text Prompts",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Transfer concepts from reference images to guide image generation with SDXL.",
@@ -200,6 +225,7 @@
       },
       {
         "name": "sdxl_revision_zero_positive",
+        "title": "SDXL Revision Zero Positive",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Add text prompts alongside reference images to guide image generation with SDXL.",
@@ -207,6 +233,7 @@
       },
       {
         "name": "sdxlturbo_example",
+        "title": "SDXL Turbo",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images in a single step with SDXL Turbo.",
@@ -221,6 +248,7 @@
     "templates": [
       {
         "name": "controlnet_example",
+        "title": "Scribble ControlNet",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Control image generation with reference images.",
@@ -229,6 +257,7 @@
       },
       {
         "name": "2_pass_pose_worship",
+        "title": "Pose ControlNet 2 Pass",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images from pose references.",
@@ -237,6 +266,7 @@
       },
       {
         "name": "depth_controlnet",
+        "title": "Depth ControlNet",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Create images with depth-aware generation.",
@@ -245,6 +275,7 @@
       },
       {
         "name": "depth_t2i_adapter",
+        "title": "Depth T2I Adapter",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Quickly generate depth-aware images with a T2I adapter.",
@@ -253,6 +284,7 @@
       },
       {
         "name": "mixing_controlnets",
+        "title": "Mixing ControlNets",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Combine multiple ControlNet models together.",
@@ -268,6 +300,7 @@
     "templates": [
       {
         "name": "hiresfix_latent_workflow",
+        "title": "Upscale",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Enhance image quality in latent space.",
@@ -276,6 +309,7 @@
       },
       {
         "name": "esrgan_example",
+        "title": "ESRGAN",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Use upscale models to enhance image quality.",
@@ -284,6 +318,7 @@
       },
       {
         "name": "hiresfix_esrgan_workflow",
+        "title": "HiresFix ESRGAN Workflow",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Use upscale models during intermediate steps.",
@@ -292,6 +327,7 @@
       },
       {
         "name": "latent_upscale_different_prompt_model",
+        "title": "Latent Upscale Different Prompt Model",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Upscale and change prompt across passes.",
@@ -307,6 +343,7 @@
     "templates": [
       {
         "name": "text_to_video_wan",
+        "title": "Wan 2.1 Text to Video",
         "description": "Quickly Generate videos from text descriptions.",
         "mediaType": "image",
         "mediaSubtype": "webp",
@@ -314,6 +351,7 @@
       },
       {
         "name": "image_to_video_wan",
+        "title": "Wan 2.1 Image to Video",
         "description": "Quickly Generate videos from images.",
         "mediaType": "image",
         "mediaSubtype": "webp",
@@ -321,6 +359,7 @@
       },
       {
         "name": "wan2.1_fun_inp",
+        "title": "Wan 2.1 Inpainting",
         "description": "Create videos from start and end frames.",
         "mediaType": "image",
         "mediaSubtype": "webp",
@@ -328,13 +367,16 @@
       },
       {
         "name": "wan2.1_fun_control",
+        "title": "Wan 2.1 ControlNet",
         "description": "Guide video generation with pose, depth, edge controls and more.",
         "mediaType": "image",
         "mediaSubtype": "webp",
+        "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/fun-control"
       },
       {
         "name": "ltxv_text_to_video",
+        "title": "LTXV Text to Video",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate videos from text descriptions.",
@@ -342,6 +384,7 @@
       },
       {
         "name": "ltxv_image_to_video",
+        "title": "LTXV Image to Video",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Convert still images into videos.",
@@ -349,6 +392,7 @@
       },
       {
         "name": "mochi_text_to_video_example",
+        "title": "Mochi Text to Video",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Create videos with Mochi model.",
@@ -356,6 +400,7 @@
       },
       {
         "name": "hunyuan_video_text_to_video",
+        "title": "Hunyuan Video Text to Video",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate videos using Hunyuan model.",
@@ -363,6 +408,7 @@
       },
       {
         "name": "image_to_video",
+        "title": "SVD Image to Video",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Transform images into animated videos.",
@@ -370,6 +416,7 @@
       },
       {
         "name": "txt_to_image_to_video",
+        "title": "SVD Text to Image to Video",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images from text and then convert them into videos.",
@@ -384,6 +431,7 @@
     "templates": [
       {
         "name": "area_composition",
+        "title": "Area Composition",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Control image composition with areas.",
@@ -391,6 +439,7 @@
       },
       {
         "name": "area_composition_reversed",
+        "title": "Area Composition Reversed",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Reverse area composition workflow.",
@@ -398,6 +447,7 @@
       },
       {
         "name": "area_composition_square_area_for_subject",
+        "title": "Area Composition Square Area for Subject",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Create consistent subject placement.",
@@ -412,6 +462,7 @@
     "templates": [
       {
         "name": "hunyuan3d-non-multiview-train",
+        "title": "Hunyuan3D 2.0",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Use Hunyuan3D 2.0 to generate models from a single view.",
@@ -419,6 +470,7 @@
       },
       {
         "name": "hunyuan-3d-multiview-elf",
+        "title": "Hunyuan3D 2.0 MV",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": " Use Hunyuan3D 2mv to generate models from multiple views.",
@@ -427,6 +479,7 @@
       },
       {
         "name": "hunyuan-3d-turbo",
+        "title": "Hunyuan3D 2.0 MV Turbo",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Use Hunyuan3D 2mv turbo to generate models from multiple views.",
@@ -435,6 +488,7 @@
       },
       {
         "name": "stable_zero123_example",
+        "title": "Stable Zero123",
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate 3D views from single images.",
@@ -449,6 +503,7 @@
     "templates": [
       {
         "name": "stable_audio_example",
+        "title": "Stable Audio",
         "mediaType": "audio",
         "mediaSubtype": "mp3",
         "description": "Generate audio from text descriptions.",


### PR DESCRIPTION

The locales might not exist when the templates are updated, as they are generated on the ComfyUI_frontend side (so there might be week or two de-sync). This PR adds English human-readable names as fallback titles to all templates, preventing the need to fallback to the key (filename).

Resolves https://github.com/Comfy-Org/workflow_templates/issues/35.
