### PR TITLE
Fix: publish to PyPi action is run twice on closed PRs to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,6 @@ on:
     branches: [main]
     paths:
       - "pyproject.toml"
-  pull_request:
-    types: [closed]
-    branches: [main]
-    paths:
-      - "pyproject.toml"
 
 jobs:
   publish:


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/workflow_templates/issues/48.