### PR TITLE
[fix] standardize model metadata format across all templates

### DIFF
--- a/templates/area_composition.json
+++ b/templates/area_composition.json
@@ -137,7 +137,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "vae-ft-mse-840000-ema-pruned.safetensors",
+            "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
     },
@@ -955,12 +962,5 @@
       "offset": [1558.38, 1652.18]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "vae-ft-mse-840000-ema-pruned.safetensors",
-      "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
-      "directory": "vae"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/area_composition_reversed.json
+++ b/templates/area_composition_reversed.json
@@ -137,7 +137,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "vae-ft-mse-840000-ema-pruned.safetensors",
+            "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
     },
@@ -956,12 +963,5 @@
       "offset": [1022.96, -230.7]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "vae-ft-mse-840000-ema-pruned.safetensors",
-      "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
-      "directory": "vae"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/area_composition_square_area_for_subject.json
+++ b/templates/area_composition_square_area_for_subject.json
@@ -492,7 +492,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "vae-ft-mse-840000-ema-pruned.safetensors",
+            "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["vae-ft-mse-840000-ema-pruned.safetensors"]
     },
@@ -609,12 +616,5 @@
       "offset": [1214.17, 1188.8]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "vae-ft-mse-840000-ema-pruned.safetensors",
-      "url": "https://huggingface.co/stabilityai/sd-vae-ft-mse-original/resolve/main/vae-ft-mse-840000-ema-pruned.safetensors?download=true",
-      "directory": "vae"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/audio_stable_audio_example.json
+++ b/templates/audio_stable_audio_example.json
@@ -84,7 +84,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "model.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0/resolve/main/model.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["model.safetensors"]
     },
@@ -167,7 +174,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CLIPLoader"
+        "Node name for S&R": "CLIPLoader",
+        "models": [
+          {
+            "name": "t5_base.safetensors",
+            "url": "https://huggingface.co/google-t5/t5-base/resolve/main/model.safetensors",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": ["t5_base.safetensors", "stable_audio", "default"]
     },
@@ -286,17 +300,5 @@
       "offset": [201.78, 380.0]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "t5_base.safetensors",
-      "url": "https://huggingface.co/google-t5/t5-base/resolve/main/model.safetensors",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "model.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-audio-open-1.0/resolve/main/model.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/default.json
+++ b/templates/default.json
@@ -264,7 +264,13 @@
           "slot_index": 2
         }
       ],
-      "properties": {},
+      "properties": {
+        "models": [{
+          "name": "v1-5-pruned-emaonly-fp16.safetensors",
+          "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly-fp16.safetensors?download=true",
+          "directory": "checkpoints"
+        }]
+      },
       "widgets_values": [
         "v1-5-pruned-emaonly-fp16.safetensors"
       ]
@@ -347,10 +353,5 @@
   "groups": [],
   "config": {},
   "extra": {},
-  "version": 0.4,
-  "models": [{
-    "name": "v1-5-pruned-emaonly-fp16.safetensors",
-    "url": "https://huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive/resolve/main/v1-5-pruned-emaonly-fp16.safetensors?download=true",
-    "directory": "checkpoints"
-  }]
+  "version": 0.4
 }

--- a/templates/embedding_example.json
+++ b/templates/embedding_example.json
@@ -123,7 +123,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "v2-1_768-ema-pruned.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-diffusion-2-1/resolve/main/v2-1_768-ema-pruned.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["v2-1_768-ema-pruned.safetensors"]
     },
@@ -256,12 +263,5 @@
       "offset": [498.31, 149.5]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "v2-1_768-ema-pruned.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-2-1/resolve/main/v2-1_768-ema-pruned.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/flux_canny_model_example.json
+++ b/templates/flux_canny_model_example.json
@@ -261,7 +261,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "ae.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["ae.safetensors"]
     },
@@ -344,7 +351,19 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "DualCLIPLoader"
+        "Node name for S&R": "DualCLIPLoader",
+        "models": [
+          {
+            "name": "clip_l.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
+            "directory": "text_encoders"
+          },
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": [
         "clip_l.safetensors",
@@ -371,7 +390,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "UNETLoader"
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "flux1-canny-dev.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-Canny-dev/resolve/main/flux1-canny-dev.safetensors?download=true",
+            "directory": "diffusion_models"
+          }
+        ]
       },
       "widgets_values": ["flux1-canny-dev.safetensors", "default"]
     },
@@ -448,27 +474,5 @@
       "offset": [553.16, 455.34]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "ae.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
-      "directory": "vae"
-    },
-    {
-      "name": "flux1-canny-dev.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Canny-dev/resolve/main/flux1-canny-dev.safetensors?download=true",
-      "directory": "diffusion_models"
-    },
-    {
-      "name": "clip_l.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "text_encoders"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/flux_dev_checkpoint_example.json
+++ b/templates/flux_dev_checkpoint_example.json
@@ -145,7 +145,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "flux1-dev-fp8.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev-fp8.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["flux1-dev-fp8.safetensors"]
     },
@@ -321,12 +328,5 @@
       "offset": [350.72, 161.55]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "flux1-dev-fp8.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev-fp8.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/flux_fill_inpaint_example.json
+++ b/templates/flux_fill_inpaint_example.json
@@ -53,7 +53,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "ae.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["ae.safetensors"]
     },
@@ -103,7 +110,19 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "DualCLIPLoader"
+        "Node name for S&R": "DualCLIPLoader",
+        "models": [
+          {
+            "name": "clip_l.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
+            "directory": "text_encoders"
+          },
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": [
         "clip_l.safetensors",
@@ -321,7 +340,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "UNETLoader"
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "flux1-fill-dev.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-Fill-dev/blob/main/flux1-fill-dev.safetensors",
+            "directory": "diffusion_models"
+          }
+        ]
       },
       "widgets_values": ["flux1-fill-dev.safetensors", "default"]
     },
@@ -432,27 +458,5 @@
       "offset": [566.62, 207.73]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "clip_l.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "flux1-fill-dev.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Fill-dev/blob/main/flux1-fill-dev.safetensors",
-      "directory": "diffusion_models"
-    },
-    {
-      "name": "ae.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
-      "directory": "vae"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/flux_fill_outpaint_example.json
+++ b/templates/flux_fill_outpaint_example.json
@@ -53,7 +53,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "ae.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["ae.safetensors"]
     },
@@ -103,7 +110,19 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "DualCLIPLoader"
+        "Node name for S&R": "DualCLIPLoader",
+        "models": [
+          {
+            "name": "clip_l.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
+            "directory": "text_encoders"
+          },
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": [
         "clip_l.safetensors",
@@ -416,7 +435,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "UNETLoader"
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "flux1-fill-dev.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-Fill-dev/blob/main/flux1-fill-dev.safetensors",
+            "directory": "diffusion_models"
+          }
+        ]
       },
       "widgets_values": ["flux1-fill-dev.safetensors", "default"]
     },
@@ -465,27 +491,5 @@
       "offset": [240.64, 211.87]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "clip_l.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "flux1-fill-dev.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Fill-dev/blob/main/flux1-fill-dev.safetensors",
-      "directory": "diffusion_models"
-    },
-    {
-      "name": "ae.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
-      "directory": "vae"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/flux_redux_model_example.json
+++ b/templates/flux_redux_model_example.json
@@ -21,7 +21,19 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "DualCLIPLoader"
+        "Node name for S&R": "DualCLIPLoader",
+        "models": [
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          },
+          {
+            "name": "clip_l.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": [
         "t5xxl_fp16.safetensors",
@@ -392,7 +404,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "UNETLoader"
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "flux1-dev.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev/resolve/main/flux1-dev.safetensors?download=true",
+            "directory": "diffusion_models"
+          }
+        ]
       },
       "widgets_values": ["flux1-dev.safetensors", "default"],
       "color": "#223",
@@ -455,7 +474,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "ae.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["ae.safetensors"]
     },
@@ -554,7 +580,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "StyleModelLoader"
+        "Node name for S&R": "StyleModelLoader",
+        "models": [
+          {
+            "name": "flux1-redux-dev.safetensors",
+            "url": "https://huggingface.co/black-forest-labs/FLUX.1-Redux-dev/resolve/main/flux1-redux-dev.safetensors?download=true",
+            "directory": "style_models"
+          }
+        ]
       },
       "widgets_values": ["flux1-redux-dev.safetensors"]
     },
@@ -576,7 +609,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CLIPVisionLoader"
+        "Node name for S&R": "CLIPVisionLoader",
+        "models": [
+          {
+            "name": "sigclip_vision_patch14_384.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/sigclip_vision_384/resolve/main/sigclip_vision_patch14_384.safetensors?download=true",
+            "directory": "clip_vision"
+          }
+        ]
       },
       "widgets_values": ["sigclip_vision_patch14_384.safetensors"]
     },
@@ -915,37 +955,5 @@
       }
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "flux1-dev.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-dev/resolve/main/flux1-dev.safetensors?download=true",
-      "directory": "diffusion_models"
-    },
-    {
-      "name": "sigclip_vision_patch14_384.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/sigclip_vision_384/resolve/main/sigclip_vision_patch14_384.safetensors?download=true",
-      "directory": "clip_vision"
-    },
-    {
-      "name": "ae.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors?download=true",
-      "directory": "vae"
-    },
-    {
-      "name": "flux1-redux-dev.safetensors",
-      "url": "https://huggingface.co/black-forest-labs/FLUX.1-Redux-dev/resolve/main/flux1-redux-dev.safetensors?download=true",
-      "directory": "style_models"
-    },
-    {
-      "name": "clip_l.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "text_encoders"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/flux_schnell.json
+++ b/templates/flux_schnell.json
@@ -198,7 +198,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "flux1-schnell-fp8.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/flux1-schnell/resolve/main/flux1-schnell-fp8.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["flux1-schnell-fp8.safetensors"]
     },
@@ -291,12 +298,5 @@
       "offset": [0.68, 1.83]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "flux1-schnell-fp8.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/flux1-schnell/resolve/main/flux1-schnell-fp8.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/hunyuan_video_text_to_video.json
+++ b/templates/hunyuan_video_text_to_video.json
@@ -189,7 +189,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "hunyuan_video_vae_bf16.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_repackaged/resolve/main/split_files/vae/hunyuan_video_vae_bf16.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["hunyuan_video_vae_bf16.safetensors"]
     },
@@ -212,7 +219,19 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "DualCLIPLoader"
+        "Node name for S&R": "DualCLIPLoader",
+        "models": [
+          {
+            "name": "clip_l.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
+            "directory": "text_encoders"
+          },
+          {
+            "name": "llava_llama3_fp8_scaled.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_repackaged/resolve/main/split_files/text_encoders/llava_llama3_fp8_scaled.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": [
         "clip_l.safetensors",
@@ -323,7 +342,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "UNETLoader"
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "hunyuan_video_t2v_720p_bf16.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_repackaged/resolve/main/split_files/diffusion_models/hunyuan_video_t2v_720p_bf16.safetensors?download=true",
+            "directory": "diffusion_models"
+          }
+        ]
       },
       "widgets_values": ["hunyuan_video_t2v_720p_bf16.safetensors", "default"],
       "color": "#223",
@@ -527,27 +553,5 @@
       "offset": [315.94, 195.23]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "hunyuan_video_vae_bf16.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_repackaged/resolve/main/split_files/vae/hunyuan_video_vae_bf16.safetensors?download=true",
-      "directory": "vae"
-    },
-    {
-      "name": "llava_llama3_fp8_scaled.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_repackaged/resolve/main/split_files/text_encoders/llava_llama3_fp8_scaled.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "clip_l.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "hunyuan_video_t2v_720p_bf16.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_repackaged/resolve/main/split_files/diffusion_models/hunyuan_video_t2v_720p_bf16.safetensors?download=true",
-      "directory": "diffusion_models"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/image_to_video.json
+++ b/templates/image_to_video.json
@@ -223,7 +223,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "ImageOnlyCheckpointLoader"
+        "Node name for S&R": "ImageOnlyCheckpointLoader",
+        "models": [
+          {
+            "name": "svd.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid/resolve/main/svd.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["svd.safetensors"]
     },
@@ -303,12 +310,5 @@
       "offset": [255.53, 68.37]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "svd.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid/resolve/main/svd.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/ltxv_image_to_video.json
+++ b/templates/ltxv_image_to_video.json
@@ -119,7 +119,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CLIPLoader"
+        "Node name for S&R": "CLIPLoader",
+        "models": [
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": ["t5xxl_fp16.safetensors", "ltxv", "default"]
     },
@@ -171,7 +178,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "ltx-video-2b-v0.9.safetensors",
+            "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltx-video-2b-v0.9.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["ltx-video-2b-v0.9.safetensors"]
     },
@@ -466,17 +480,5 @@
       "offset": [-35.52, 153.62]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "ltx-video-2b-v0.9.safetensors",
-      "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltx-video-2b-v0.9.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/ltxv_text_to_video.json
+++ b/templates/ltxv_text_to_video.json
@@ -20,7 +20,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CLIPLoader"
+        "Node name for S&R": "CLIPLoader",
+        "models": [
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": ["t5xxl_fp16.safetensors", "ltxv", "default"]
     },
@@ -183,7 +190,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "ltx-video-2b-v0.9.safetensors",
+            "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltx-video-2b-v0.9.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["ltx-video-2b-v0.9.safetensors"]
     },
@@ -403,17 +417,5 @@
       "offset": [1490.32, 926.49]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "ltx-video-2b-v0.9.safetensors",
-      "url": "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltx-video-2b-v0.9.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/mochi_text_to_video_example.json
+++ b/templates/mochi_text_to_video_example.json
@@ -203,7 +203,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "UNETLoader"
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "mochi_preview_bf16.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/mochi_preview_repackaged/resolve/main/split_files/diffusion_models/mochi_preview_bf16.safetensors?download=true",
+            "directory": "diffusion_models"
+          }
+        ]
       },
       "widgets_values": ["mochi_preview_bf16.safetensors", "default"]
     },
@@ -225,7 +232,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CLIPLoader"
+        "Node name for S&R": "CLIPLoader",
+        "models": [
+          {
+            "name": "t5xxl_fp16.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+            "directory": "text_encoders"
+          }
+        ]
       },
       "widgets_values": ["t5xxl_fp16.safetensors", "mochi", "default"]
     },
@@ -246,7 +260,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "VAELoader"
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "mochi_vae.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/mochi_preview_repackaged/resolve/main/split_files/vae/mochi_vae.safetensors?download=true",
+            "directory": "vae"
+          }
+        ]
       },
       "widgets_values": ["mochi_vae.safetensors"]
     },
@@ -287,22 +308,5 @@
       "offset": [35.42, 115.48]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "mochi_vae.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/mochi_preview_repackaged/resolve/main/split_files/vae/mochi_vae.safetensors?download=true",
-      "directory": "vae"
-    },
-    {
-      "name": "t5xxl_fp16.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-      "directory": "text_encoders"
-    },
-    {
-      "name": "mochi_preview_bf16.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/mochi_preview_repackaged/resolve/main/split_files/diffusion_models/mochi_preview_bf16.safetensors?download=true",
-      "directory": "diffusion_models"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/sd3.5_large_canny_controlnet_example.json
+++ b/templates/sd3.5_large_canny_controlnet_example.json
@@ -382,7 +382,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "sd3.5_large_fp8_scaled.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/resolve/main/sd3.5_large_fp8_scaled.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["sd3.5_large_fp8_scaled.safetensors"]
     },
@@ -405,7 +412,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "ControlNetLoader"
+        "Node name for S&R": "ControlNetLoader",
+        "models": [
+          {
+            "name": "sd3.5_large_controlnet_canny.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-controlnets/resolve/main/sd3.5_large_controlnet_canny.safetensors?download=true",
+            "directory": "controlnet"
+          }
+        ]
       },
       "widgets_values": ["sd3.5_large_controlnet_canny.safetensors"]
     },
@@ -454,17 +468,5 @@
       "offset": [686.52, 188.52]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "sd3.5_large_controlnet_canny.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-controlnets/resolve/main/sd3.5_large_controlnet_canny.safetensors?download=true",
-      "directory": "controlnet"
-    },
-    {
-      "name": "sd3.5_large_fp8_scaled.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/resolve/main/sd3.5_large_fp8_scaled.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/sd3.5_simple_example.json
+++ b/templates/sd3.5_simple_example.json
@@ -141,7 +141,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "sd3.5_large_fp8_scaled.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/resolve/main/sd3.5_large_fp8_scaled.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["sd3.5_large_fp8_scaled.safetensors"]
     },
@@ -267,12 +274,5 @@
       "offset": [93.35, -1.71]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "sd3.5_large_fp8_scaled.safetensors",
-      "url": "https://huggingface.co/Comfy-Org/stable-diffusion-3.5-fp8/resolve/main/sd3.5_large_fp8_scaled.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/sdxl_revision_text_prompts.json
+++ b/templates/sdxl_revision_text_prompts.json
@@ -244,7 +244,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "sd_xl_base_1.0.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["sd_xl_base_1.0.safetensors"]
     },
@@ -267,7 +274,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CLIPVisionLoader"
+        "Node name for S&R": "CLIPVisionLoader",
+        "models": [
+          {
+            "name": "clip_vision_g.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/clip_vision_g/resolve/main/clip_vision_g.safetensors?download=true",
+            "directory": "clip_vision"
+          }
+        ]
       },
       "widgets_values": ["clip_vision_g.safetensors"]
     },
@@ -474,17 +488,5 @@
       "offset": [962.72, 417.65]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "sd_xl_base_1.0.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "clip_vision_g.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/clip_vision_g/resolve/main/clip_vision_g.safetensors?download=true",
-      "directory": "clip_vision"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/sdxl_revision_zero_positive.json
+++ b/templates/sdxl_revision_zero_positive.json
@@ -188,7 +188,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "sd_xl_base_1.0.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["sd_xl_base_1.0.safetensors"]
     },
@@ -211,7 +218,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CLIPVisionLoader"
+        "Node name for S&R": "CLIPVisionLoader",
+        "models": [
+          {
+            "name": "clip_vision_g.safetensors",
+            "url": "https://huggingface.co/comfyanonymous/clip_vision_g/resolve/main/clip_vision_g.safetensors?download=true",
+            "directory": "clip_vision"
+          }
+        ]
       },
       "widgets_values": ["clip_vision_g.safetensors"]
     },
@@ -478,17 +492,5 @@
       "offset": [1046.06, 311.39]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "sd_xl_base_1.0.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "clip_vision_g.safetensors",
-      "url": "https://huggingface.co/comfyanonymous/clip_vision_g/resolve/main/clip_vision_g.safetensors?download=true",
-      "directory": "clip_vision"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/sdxlturbo_example.json
+++ b/templates/sdxlturbo_example.json
@@ -63,7 +63,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "sd_xl_turbo_1.0_fp16.safetensors",
+            "url": "https://huggingface.co/stabilityai/sdxl-turbo/resolve/main/sd_xl_turbo_1.0_fp16.safetensors",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["sd_xl_turbo_1.0_fp16.safetensors"]
     },
@@ -361,12 +368,5 @@
       "offset": [311.24, 325.56]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "sd_xl_turbo_1.0_fp16.safetensors",
-      "url": "https://huggingface.co/stabilityai/sdxl-turbo/resolve/main/sd_xl_turbo_1.0_fp16.safetensors",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/stable_zero123_example.json
+++ b/templates/stable_zero123_example.json
@@ -220,7 +220,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "ImageOnlyCheckpointLoader"
+        "Node name for S&R": "ImageOnlyCheckpointLoader",
+        "models": [
+          {
+            "name": "stable_zero123.ckpt",
+            "url": "https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["stable_zero123.ckpt"]
     },
@@ -262,12 +269,5 @@
       "offset": [439.73, 40.67]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "stable_zero123.ckpt",
-      "url": "https://huggingface.co/stabilityai/stable-zero123/resolve/main/stable_zero123.ckpt",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }

--- a/templates/txt_to_image_to_video.json
+++ b/templates/txt_to_image_to_video.json
@@ -223,7 +223,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "ImageOnlyCheckpointLoader"
+        "Node name for S&R": "ImageOnlyCheckpointLoader",
+        "models": [
+          {
+            "name": "svd_xt.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt/resolve/main/svd_xt.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["svd_xt.safetensors"]
     },
@@ -259,7 +266,14 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "CheckpointLoaderSimple"
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "models": [
+          {
+            "name": "sd_xl_base_1.0.safetensors",
+            "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors?download=true",
+            "directory": "checkpoints"
+          }
+        ]
       },
       "widgets_values": ["sd_xl_base_1.0.safetensors"]
     },
@@ -519,17 +533,5 @@
       "offset": [502.97, -29.59]
     }
   },
-  "version": 0.4,
-  "models": [
-    {
-      "name": "sd_xl_base_1.0.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/resolve/main/sd_xl_base_1.0.safetensors?download=true",
-      "directory": "checkpoints"
-    },
-    {
-      "name": "svd_xt.safetensors",
-      "url": "https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt/resolve/main/svd_xt.safetensors?download=true",
-      "directory": "checkpoints"
-    }
-  ]
+  "version": 0.4
 }


### PR DESCRIPTION
Converts 22 workflow templates from inconsistent top-level models arrays to the standardized node properties format, resolving the model warning modal display inconsistency. Also enhances the validation script to prevent future format violations and detect missing widget values.

Fixes #72