### PR TITLE
Fix: multiple loras template missing `widgets_values` on 2nd Lora Loader node

### DIFF
--- a/templates/lora_multiple.json
+++ b/templates/lora_multiple.json
@@ -310,7 +310,8 @@
             "directory": "loras"
           }
         ]
-      }
+      },
+      "widgets_values": ["MoXinV1.safetensors", 0.9, 1]
     },
     {
       "id": 11,


### PR DESCRIPTION
The error was added in https://github.com/Comfy-Org/workflow_templates/pull/14 (accidental removal of `widgets_values`:

![Selection_1464](https://github.com/user-attachments/assets/9aca38e6-9240-4f91-9ef0-6bf2d1dc871d)