### PR TITLE
Bump version to 0.1.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.1.27"
+version = "0.1.28"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.1.27"
+version = "0.1.2"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
-    {name = "Comfy-Org"}
+    {name = "Comfy-Org"}8
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.1.2"
+version = "0.1.27"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
-    {name = "Comfy-Org"}8
+    {name = "Comfy-Org"}
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Release Summary 0.1.27 to 0.1.28

- [Revert thumbnails changes](https://github.com/Comfy-Org/workflow_templates/pull/88)
- [Add flux dev & schnell full version template](https://github.com/Comfy-Org/workflow_templates/pull/86)
- [Update VACE Inpainting workflow ](https://github.com/Comfy-Org/workflow_templates/pull/90)
