### PR TITLE
Fix PyPI publish workflow and bump to v0.1.34

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+          attestations: false
 
       - name: Extract version from pyproject.toml
         id: get_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.1.33"
+version = "0.1.34"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Fix PyPI publishing authentication conflict by disabling attestations
- Bump version to 0.1.34 (skipping 0.1.33 which failed to publish)

## Problem
Recent publish attempts failed due to conflict between API token authentication and the new attestations feature. The error was:
> "The workflow was run with 'attestations: true' input, but an explicit password was also set, disabling Trusted Publishing"

## Solution
Added `attestations: false` to the publish workflow to explicitly disable the attestations feature while keeping the existing API token authentication.

## Changes
1. `.github/workflows/publish.yml`: Add `attestations: false` to PyPI publish step
2. `pyproject.toml`: Bump version from 0.1.33 → 0.1.34

This will allow the package to publish successfully to PyPI.

Fixes the failed workflows:
- https://github.com/Comfy-Org/workflow_templates/actions/runs/16132533983
- https://github.com/Comfy-Org/workflow_templates/actions/runs/16132587974