### PR TITLE
Bump version to 0.1.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.1.35"
+version = "0.1.36"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Release Summary

### Changes since v0.1.35:

**Template Updates & Fixes:**
- Fixed lotus template link issues (#130)
- Updated model links across multiple templates (#129)
- Updated image 2 image template (#128)
- Replaced model links (#127)
- Updated hunyuan 3d template links (#126)
- Updated template (#125)
- Updated notes and changed default frame count to 79 (#123)
- Updated all the links in VACE templates (#121)

**Infrastructure:**
- Added GitHub model links check action (#122)

This release primarily focuses on improving template reliability by fixing and updating various model links, along with template-specific improvements and adding automated link checking.

🤖 Generated with [Claude Code](https://claude.ai/code)