### PR TITLE
Implement versioned template uploads to GCS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,36 @@ on:
       - "pyproject.toml"
 
 jobs:
-  publish:
+  check-version-change:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    outputs:
+      version-changed: ${{ steps.check.outputs.changed }}
+      new-version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version actually changed
+        id: check
+        run: |
+          CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          PREVIOUS_VERSION=$(git show HEAD~1:pyproject.toml | python -c "import tomllib, sys; print(tomllib.load(sys.stdin.buffer)['project']['version'])")
+
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "Version unchanged: $CURRENT_VERSION"
+          fi
+
+  publish:
+    needs: check-version-change
+    if: needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,16 +64,10 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
           attestations: false
 
-      - name: Extract version from pyproject.toml
-        id: get_version
-        run: |
-          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v${{ steps.get_version.outputs.VERSION }}" \
-          --title "v${{ steps.get_version.outputs.VERSION }}" \
+          gh release create "v${{ needs.check-version-change.outputs.new-version }}" \
+          --title "v${{ needs.check-version-change.outputs.new-version }}" \
           --generate-notes

--- a/.github/workflows/sync-gcs.yml
+++ b/.github/workflows/sync-gcs.yml
@@ -1,11 +1,14 @@
 name: Sync Templates to GCS
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "templates/**"
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to sync (e.g., 0.1.41). Leave empty to sync current templates to "latest" only.'
+        required: false
+        type: string
 
 jobs:
   sync-to-gcs:
@@ -13,7 +16,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,5 +30,37 @@ jobs:
 
       - name: Sync templates to GCS
         run: |
-          gsutil -m rsync -r -d -c templates/ gs://cloud-workflow-templates/
-          echo "Templates synced to GCS bucket successfully"
+          UPDATE_LATEST=false
+
+          if [ "${{ github.event_name }}" == "release" ]; then
+            VERSION=${{ github.event.release.tag_name }}
+            VERSION_DIR=${VERSION#v}
+            echo "Release trigger: Syncing templates for version $VERSION_DIR"
+            gsutil -m rsync -r -d -c templates/ gs://cloud-workflow-templates/versions/$VERSION_DIR/
+            echo "✅ Templates synced to gs://cloud-workflow-templates/versions/$VERSION_DIR/"
+            UPDATE_LATEST=true
+          elif [ -n "${{ inputs.version }}" ]; then
+            VERSION_DIR=${{ inputs.version }}
+            echo "Manual trigger: Syncing templates to version $VERSION_DIR"
+            gsutil -m rsync -r -d -c templates/ gs://cloud-workflow-templates/versions/$VERSION_DIR/
+            echo "✅ Templates synced to gs://cloud-workflow-templates/versions/$VERSION_DIR/"
+
+            CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+            if [ "$VERSION_DIR" == "$CURRENT_VERSION" ]; then
+              UPDATE_LATEST=true
+              echo "This version ($VERSION_DIR) matches current version in pyproject.toml"
+            else
+              echo "⚠️  Skipping latest update: $VERSION_DIR does not match current version $CURRENT_VERSION"
+            fi
+          else
+            echo "Manual trigger: No version specified, only syncing to latest"
+            UPDATE_LATEST=true
+          fi
+
+          if [ "$UPDATE_LATEST" == "true" ]; then
+            echo "Syncing templates to 'latest' path"
+            gsutil -m rsync -r -d -c templates/ gs://cloud-workflow-templates/latest/
+            echo "✅ Templates synced to gs://cloud-workflow-templates/latest/"
+          else
+            echo "⏭️  Skipped updating 'latest' path"
+          fi


### PR DESCRIPTION
## Summary
- Modified publish workflow to only create releases on actual version changes, preventing duplicate release attempts
- Unified GCS sync workflows into a single `sync-gcs.yml` that handles both automatic releases and manual triggers
- Added intelligent logic to only update the 'latest' path when appropriate, preventing older versions from overwriting newer content

## Changes
1. **publish.yml**: Added version change detection to prevent creating releases for non-version changes to pyproject.toml
2. **sync-gcs.yml**: New unified workflow that:
   - Triggers automatically on GitHub releases
   - Supports manual triggering with optional version parameter
   - Syncs to versioned paths: `gs://cloud-workflow-templates/versions/{version}/`
   - Only updates `latest/` when it's actually the latest version

## Benefits
- Prevents version misalignment between releases and GCS content
- Supports historical version access
- Maintains backward compatibility with `latest/` path
- Flexible manual override for hotfixes or testing

## Test plan
After merging, we can test by:
1. Manually triggering the workflow with version `0.1.41` to sync current templates
2. Verifying templates appear at `gs://cloud-workflow-templates/versions/0.1.41/`
3. Confirming `latest/` is also updated (since 0.1.41 is the current version)



Here's the new structure:
https://console.cloud.google.com/storage/browser/cloud-workflow-templates
<img width="1047" height="833" alt="Screenshot 2025-07-29 at 7 55 39 PM" src="https://github.com/user-attachments/assets/95124456-2dfb-414f-a77a-bf822fbd80b4" />
