### PR TITLE
[feat] Consolidate API templates into GENERATION TYPE categories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.2.9"
+version = "0.3.0"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/templates/index.json
+++ b/templates/index.json
@@ -12,8 +12,13 @@
         "mediaSubtype": "webp",
         "description": "Generate images from text prompts using the Qwen-Image model",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Qwen-Image"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-10-17",
         "size": 31772020572
       },
@@ -24,8 +29,14 @@
         "mediaSubtype": "webp",
         "description": "Edit your images with Qwen-Image-Edit, the latest OSS model",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image-edit",
-        "tags": ["Image to Image", "Image Edit", "ControlNet"],
-        "models": ["Qwen-Image"],
+        "tags": [
+          "Image to Image",
+          "Image Edit",
+          "ControlNet"
+        ],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-10-17",
         "size": 31772020572
       },
@@ -36,8 +47,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2_2",
-        "tags": ["Image to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Image to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-10-17",
         "size": 38031935406
       },
@@ -47,8 +64,13 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate 3D models from single images using Hunyuan3D 2.1.",
-        "tags": ["Image to 3D", "3D"],
-        "models": ["Hunyuan3D"],
+        "tags": [
+          "Image to 3D",
+          "3D"
+        ],
+        "models": [
+          "Hunyuan3D"
+        ],
         "date": "2025-10-17",
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4928474972
@@ -59,8 +81,13 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate songs from text prompts using ACE-Step v1",
-        "tags": ["Text to Audio", "Audio"],
-        "models": ["ACE-Step"],
+        "tags": [
+          "Text to Audio",
+          "Audio"
+        ],
+        "models": [
+          "ACE-Step"
+        ],
         "date": "2025-10-17",
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878
@@ -72,8 +99,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images from text prompts.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/basic/text-to-image",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 2136746230,
         "vram": 3092376453
@@ -86,8 +119,14 @@
         "thumbnailVariant": "hoverDissolve",
         "description": "Transform existing images using text prompts.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/basic/image-to-image",
-        "tags": ["Image to Image", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Image to Image",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 2136746230,
         "vram": 3092376453
@@ -99,8 +138,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images with LoRA models for specialized styles or subjects.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/basic/lora",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 2437393940,
         "vram": 3092376453
@@ -112,8 +157,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images by combining multiple LoRA models.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/basic/lora",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 2437393940,
         "vram": 3350074491
@@ -126,8 +177,14 @@
         "description": "Edit specific parts of images seamlessly.",
         "thumbnailVariant": "compareSlider",
         "tutorialUrl": "https://docs.comfy.org/tutorials/basic/inpaint",
-        "tags": ["Inpainting", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Inpainting",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 5218385265,
         "vram": 4101693768
@@ -140,8 +197,14 @@
         "description": "Extend images beyond their original boundaries.",
         "thumbnailVariant": "compareSlider",
         "tutorialUrl": "https://docs.comfy.org/tutorials/basic/inpaint",
-        "tags": ["Outpainting", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Outpainting",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 5218385265,
         "vram": 4101693768
@@ -153,8 +216,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images using textual inversion for consistent styles.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/textual_inversion_embeddings/",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 5218385265,
         "vram": 4123168604
@@ -166,8 +235,13 @@
         "mediaSubtype": "webp",
         "description": "Generate images with precise object placement using text boxes.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/gligen/",
-        "tags": ["Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 2974264852,
         "vram": 4080218931
@@ -178,8 +252,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images by controlling composition with defined areas.",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/area_composition/",
         "size": 2469606195,
@@ -191,8 +271,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images with consistent subject placement using area composition.",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/area_composition/#increasing-consistency-of-images-with-area-composition",
         "size": 2469606195,
@@ -205,8 +291,14 @@
         "mediaSubtype": "webp",
         "description": "Upscale images by enhancing quality in latent space.",
         "thumbnailVariant": "compareSlider",
-        "tags": ["Upscale", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Upscale",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/2_pass_txt2img/",
         "size": 2136746230,
@@ -219,8 +311,14 @@
         "mediaSubtype": "webp",
         "description": "Upscale images using ESRGAN models to enhance quality.",
         "thumbnailVariant": "compareSlider",
-        "tags": ["Upscale", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Upscale",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/upscale_models/",
         "size": 2201170739,
@@ -233,8 +331,14 @@
         "mediaSubtype": "webp",
         "description": "Upscale images using ESRGAN models during intermediate generation steps.",
         "thumbnailVariant": "compareSlider",
-        "tags": ["Upscale", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Upscale",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/2_pass_txt2img/#non-latent-upscaling",
         "size": 2201170739,
@@ -247,8 +351,14 @@
         "mediaSubtype": "webp",
         "description": "Upscale images while changing prompts across generation passes.",
         "thumbnailVariant": "zoomHover",
-        "tags": ["Upscale", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Upscale",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/2_pass_txt2img/#more-examples",
         "size": 4262755041,
@@ -261,8 +371,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images guided by scribble reference images using ControlNet.",
         "thumbnailVariant": "hoverDissolve",
-        "tags": ["ControlNet", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "ControlNet",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/controlnet/",
         "size": 3189013217,
@@ -275,8 +391,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images guided by pose references using ControlNet.",
         "thumbnailVariant": "hoverDissolve",
-        "tags": ["ControlNet", "Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "ControlNet",
+          "Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#pose-controlnet",
         "size": 4660039516,
@@ -289,8 +411,15 @@
         "mediaSubtype": "webp",
         "description": "Generate images guided by depth information using ControlNet.",
         "thumbnailVariant": "hoverDissolve",
-        "tags": ["ControlNet", "Image", "Text to Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "ControlNet",
+          "Image",
+          "Text to Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#t2i-adapter-vs-controlnets",
         "size": 2888365507,
@@ -303,8 +432,15 @@
         "mediaSubtype": "webp",
         "description": "Generate images guided by depth information using T2I adapter.",
         "thumbnailVariant": "hoverDissolve",
-        "tags": ["ControlNet", "Image", "Text to Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "ControlNet",
+          "Image",
+          "Text to Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#t2i-adapter-vs-controlnets",
         "size": 2523293286,
@@ -317,8 +453,15 @@
         "mediaSubtype": "webp",
         "description": "Generate images by combining multiple ControlNet models.",
         "thumbnailVariant": "hoverDissolve",
-        "tags": ["ControlNet", "Image", "Text to Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "ControlNet",
+          "Image",
+          "Text to Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/controlnet/#mixing-controlnets",
         "size": 3328599654,
@@ -340,8 +483,13 @@
         "mediaSubtype": "webp",
         "description": "Generate images with exceptional multilingual text rendering and editing capabilities using Qwen-Image's 20B MMDiT model..",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Qwen-Image"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-08-05",
         "size": 31772020572
       },
@@ -351,9 +499,15 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images with Qwen-Image InstantX ControlNet, supporting canny, soft edge, depth, pose",
-        "tags": ["Image to Image", "Image", "ControlNet"],
+        "tags": [
+          "Image to Image",
+          "Image",
+          "ControlNet"
+        ],
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image",
-        "models": ["Qwen-Image"],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-08-23",
         "size": 35304631173
       },
@@ -364,9 +518,16 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "compareSlider",
         "description": "Professional inpainting and image editing with Qwen-Image InstantX ControlNet. Supports object replacement, text modification, background changes, and outpainting.",
-        "tags": ["Image to Image", "Image", "ControlNet", "Inpainting"],
+        "tags": [
+          "Image to Image",
+          "Image",
+          "ControlNet",
+          "Inpainting"
+        ],
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image",
-        "models": ["Qwen-Image"],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-09-12",
         "size": 36013300777
       },
@@ -376,9 +537,15 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate images with precise structural control using Qwen-Image's unified ControlNet LoRA. Supports multiple control types including canny, depth, lineart, softedge, normal, and openpose for diverse creative applications.",
-        "tags": ["Text to Image", "Image", "ControlNet"],
+        "tags": [
+          "Text to Image",
+          "Image",
+          "ControlNet"
+        ],
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image",
-        "models": ["Qwen-Image"],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-08-23",
         "size": 32716913377
       },
@@ -390,8 +557,14 @@
         "thumbnailVariant": "compareSlider",
         "description": "Control image generation using Qwen-Image ControlNet models. Supports canny, depth, and inpainting controls through model patching.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image",
-        "tags": ["Text to Image", "Image", "ControlNet"],
-        "models": ["Qwen-Image"],
+        "tags": [
+          "Text to Image",
+          "Image",
+          "ControlNet"
+        ],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-08-24",
         "size": 34037615821
       },
@@ -403,8 +576,14 @@
         "thumbnailVariant": "compareSlider",
         "description": "Advanced image editing with multi-image support, improved consistency, and ControlNet integration.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image-edit",
-        "tags": ["Image to Image", "Image Edit", "ControlNet"],
-        "models": ["Qwen-Image"],
+        "tags": [
+          "Image to Image",
+          "Image Edit",
+          "ControlNet"
+        ],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-09-25",
         "size": 31772020572
       },
@@ -416,8 +595,13 @@
         "thumbnailVariant": "compareSlider",
         "description": "Edit images with precise bilingual text editing and dual semantic/appearance editing capabilities using Qwen-Image-Edit's 20B MMDiT model.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/qwen/qwen-image-edit",
-        "tags": ["Image to Image", "Image Edit"],
-        "models": ["Qwen-Image"],
+        "tags": [
+          "Image to Image",
+          "Image Edit"
+        ],
+        "models": [
+          "Qwen-Image"
+        ],
         "date": "2025-08-18",
         "size": 31772020572
       },
@@ -429,8 +613,14 @@
         "thumbnailVariant": "hoverDissolve",
         "description": "Smart image editing that keeps characters consistent, edits specific parts without affecting others, and preserves original styles.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-kontext-dev",
-        "tags": ["Image Edit", "Image to Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Image Edit",
+          "Image to Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-06-26",
         "size": 17641578168,
         "vram": 19327352832
@@ -441,8 +631,13 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Chroma1-Radiance works directly with image pixels instead of compressed latents, delivering higher quality images with reduced artifacts and distortion.",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Chroma"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Chroma"
+        ],
         "date": "2025-09-18",
         "size": 23622320128,
         "vram": 23622320128
@@ -453,8 +648,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "High-quality anime-style image generation with enhanced character understanding and detailed textures. Fine-tuned from Neta Lumina on Danbooru dataset.",
-        "tags": ["Text to Image", "Image", "Anime"],
-        "models": ["OmniGen"],
+        "tags": [
+          "Text to Image",
+          "Image",
+          "Anime"
+        ],
+        "models": [
+          "OmniGen"
+        ],
         "date": "2025-10-10",
         "size": 10619306639
       },
@@ -464,8 +665,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Chroma - enhanced Flux model with improved image quality and better prompt understanding for stunning text-to-image generation.",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Chroma", "Flux"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Chroma",
+          "Flux"
+        ],
         "date": "2025-06-04",
         "size": 23289460163,
         "vram": 15569256448
@@ -477,8 +684,14 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "compareSlider",
         "description": "Supports various tasks such as image inpainting, outpainting, and object removal by bytedance-research team",
-        "tags": ["Inpainting", "Outpainting"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Inpainting",
+          "Outpainting"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-09-21",
         "size": 29001766666,
         "vram": 21474836480
@@ -490,8 +703,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images using Flux Dev fp8 quantized version. Suitable for devices with limited VRAM, requires only one model file, but image quality is slightly lower than the full version.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-text-to-image",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 17244293693,
         "vram": 18253611008
@@ -503,8 +722,14 @@
         "thumbnailVariant": "hoverDissolve",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Image to Image", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Image to Image",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-09-02",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18597208392,
@@ -517,8 +742,14 @@
         "mediaSubtype": "webp",
         "description": "Quickly generate images with Flux Schnell fp8 quantized version. Ideal for low-end hardware, requires only 4 steps to generate images.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-text-to-image",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008
@@ -530,8 +761,14 @@
         "mediaSubtype": "webp",
         "description": "A fine-tuned FLUX model pushing photorealism to the max",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux1-krea-dev",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-07-31",
         "size": 22269405430,
         "vram": 23085449216
@@ -543,8 +780,14 @@
         "mediaSubtype": "webp",
         "description": "Generate high-quality images with Flux Dev full version. Requires larger VRAM and multiple model files, but provides the best prompt following capability and image quality.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-text-to-image",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 23622320128
@@ -556,8 +799,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images quickly with Flux Schnell full version. Uses Apache2.0 license, requires only 4 steps to generate images while maintaining good image quality.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-text-to-image",
-        "tags": ["Text to Image", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 34155727421
       },
@@ -569,8 +818,15 @@
         "description": "Fill missing parts of images using Flux inpainting.",
         "thumbnailVariant": "compareSlider",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-fill-dev",
-        "tags": ["Image to Image", "Inpainting", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Image to Image",
+          "Inpainting",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 10372346020
       },
@@ -582,8 +838,15 @@
         "description": "Extend images beyond boundaries using Flux outpainting.",
         "thumbnailVariant": "compareSlider",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-fill-dev",
-        "tags": ["Outpainting", "Image", "Image to Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Outpainting",
+          "Image",
+          "Image to Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 10372346020
       },
@@ -595,8 +858,15 @@
         "description": "Generate images guided by edge detection using Flux Canny.",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-controlnet",
-        "tags": ["Image to Image", "ControlNet", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Image to Image",
+          "ControlNet",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 34177202258
       },
@@ -608,8 +878,15 @@
         "description": "Generate images guided by depth information using Flux LoRA.",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-controlnet",
-        "tags": ["Image to Image", "ControlNet", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Image to Image",
+          "ControlNet",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 35412005356
       },
@@ -620,8 +897,15 @@
         "mediaSubtype": "webp",
         "description": "Generate images by transferring style from reference images using Flux Redux.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-controlnet",
-        "tags": ["Image to Image", "ControlNet", "Image"],
-        "models": ["Flux", "BFL"],
+        "tags": [
+          "Image to Image",
+          "ControlNet",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
         "date": "2025-03-01",
         "size": 35154307318
       },
@@ -632,8 +916,13 @@
         "mediaSubtype": "webp",
         "description": "Generate high-quality images from text prompts using OmniGen2's unified 7B multimodal model with dual-path architecture.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/omnigen/omnigen2",
-        "tags": ["Text to Image", "Image"],
-        "models": ["OmniGen"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "OmniGen"
+        ],
         "date": "2025-06-30",
         "size": 15784004813
       },
@@ -645,8 +934,13 @@
         "thumbnailVariant": "hoverDissolve",
         "description": "Edit images with natural language instructions using OmniGen2's advanced image editing capabilities and text rendering support.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/omnigen/omnigen2",
-        "tags": ["Image Edit", "Image"],
-        "models": ["OmniGen"],
+        "tags": [
+          "Image Edit",
+          "Image"
+        ],
+        "models": [
+          "OmniGen"
+        ],
         "date": "2025-06-30",
         "size": 15784004813
       },
@@ -657,8 +951,13 @@
         "mediaSubtype": "webp",
         "description": "Generate images with HiDream I1 Dev - Balanced version with 28 inference steps, suitable for medium-range hardware.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/hidream/hidream-i1",
-        "tags": ["Text to Image", "Image"],
-        "models": ["HiDream"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "HiDream"
+        ],
         "date": "2025-04-17",
         "size": 33318208799
       },
@@ -669,8 +968,13 @@
         "mediaSubtype": "webp",
         "description": "Generate images quickly with HiDream I1 Fast - Lightweight version with 16 inference steps, ideal for rapid previews on lower-end hardware.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/hidream/hidream-i1",
-        "tags": ["Text to Image", "Image"],
-        "models": ["HiDream"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "HiDream"
+        ],
         "date": "2025-04-17",
         "size": 24234352968
       },
@@ -681,8 +985,13 @@
         "mediaSubtype": "webp",
         "description": "Generate images with HiDream I1 Full - Complete version with 50 inference steps for highest quality output.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/hidream/hidream-i1",
-        "tags": ["Text to Image", "Image"],
-        "models": ["HiDream"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "HiDream"
+        ],
         "date": "2025-04-17",
         "size": 24234352968
       },
@@ -694,8 +1003,13 @@
         "thumbnailVariant": "compareSlider",
         "description": "Edit images with HiDream E1.1 – it’s better in image quality and editing accuracy than HiDream-E1-Full.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/hidream/hidream-e1",
-        "tags": ["Image Edit", "Image"],
-        "models": ["HiDream"],
+        "tags": [
+          "Image Edit",
+          "Image"
+        ],
+        "models": [
+          "HiDream"
+        ],
         "date": "2025-07-21",
         "size": 50422916055
       },
@@ -707,8 +1021,13 @@
         "thumbnailVariant": "compareSlider",
         "description": "Edit images with HiDream E1 - Professional natural language image editing model.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/hidream/hidream-e1",
-        "tags": ["Image Edit", "Image"],
-        "models": ["HiDream"],
+        "tags": [
+          "Image Edit",
+          "Image"
+        ],
+        "models": [
+          "HiDream"
+        ],
         "date": "2025-05-01",
         "size": 34209414513
       },
@@ -719,8 +1038,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images using SD 3.5.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SD3.5", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SD3.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 14935748772
       },
@@ -732,8 +1057,15 @@
         "description": "Generate images guided by edge detection using SD 3.5 Canny ControlNet.",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets",
-        "tags": ["Image to Image", "Image", "ControlNet"],
-        "models": ["SD3.5", "Stability"],
+        "tags": [
+          "Image to Image",
+          "Image",
+          "ControlNet"
+        ],
+        "models": [
+          "SD3.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 23590107873
       },
@@ -745,8 +1077,15 @@
         "description": "Generate images guided by depth information using SD 3.5.",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets",
-        "tags": ["Image to Image", "Image", "ControlNet"],
-        "models": ["SD3.5", "Stability"],
+        "tags": [
+          "Image to Image",
+          "Image",
+          "ControlNet"
+        ],
+        "models": [
+          "SD3.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 23590107873
       },
@@ -758,8 +1097,14 @@
         "description": "Generate images guided by blurred reference images using SD 3.5.",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sd3/#sd35-controlnets",
-        "tags": ["Image to Image", "Image"],
-        "models": ["SD3.5", "Stability"],
+        "tags": [
+          "Image to Image",
+          "Image"
+        ],
+        "models": [
+          "SD3.5",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 23590107873
       },
@@ -770,8 +1115,14 @@
         "mediaSubtype": "webp",
         "description": "Generate high-quality images using SDXL.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SDXL", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SDXL",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 13013750907
       },
@@ -782,8 +1133,14 @@
         "mediaSubtype": "webp",
         "description": "Enhance SDXL images using refiner models.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SDXL", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SDXL",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 13013750907
       },
@@ -794,8 +1151,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images by transferring concepts from reference images using SDXL Revision.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdxl/#revision",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SDXL", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SDXL",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 10630044058
       },
@@ -806,8 +1169,14 @@
         "mediaSubtype": "webp",
         "description": "Generate images in a single step using SDXL Turbo.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/sdturbo/",
-        "tags": ["Text to Image", "Image"],
-        "models": ["SDXL", "Stability"],
+        "tags": [
+          "Text to Image",
+          "Image"
+        ],
+        "models": [
+          "SDXL",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 6936372183
       },
@@ -818,10 +1187,550 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "compareSlider",
         "description": "Run Lotus Depth in ComfyUI for zero-shot, efficient monocular depth estimation with high detail retention.",
-        "tags": ["Image", "Text to Image"],
-        "models": ["SD1.5", "Stability"],
+        "tags": [
+          "Image",
+          "Text to Image"
+        ],
+        "models": [
+          "SD1.5",
+          "Stability"
+        ],
         "date": "2025-05-21",
         "size": 2072321720
+      },
+      {
+        "name": "api_bytedance_seedream4",
+        "title": "ByteDance Seedream 4.0",
+        "description": "Multi-modal AI model for text-to-image and image editing. Generate 2K images in under 2 seconds with natural language control.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image Edit",
+          "Image",
+          "API",
+          "Text to Image"
+        ],
+        "models": [
+          "Seedream 4.0",
+          "ByteDance"
+        ],
+        "date": "2025-09-11",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_google_gemini_image",
+        "title": "Google Gemini Image",
+        "description": "Nano-banana (Gemini-2.5-Flash Image) - image editing with consistency.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image Edit",
+          "Image",
+          "API",
+          "Text to Image"
+        ],
+        "models": [
+          "Gemini-2.5-Flash",
+          "nano-banana",
+          "Google"
+        ],
+        "date": "2025-08-27",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_bfl_flux_1_kontext_multiple_images_input",
+        "title": "BFL Flux.1 Kontext Multiple Image Input",
+        "description": "Input multiple images and edit them with Flux.1 Kontext.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-kontext",
+        "tags": [
+          "Image Edit",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "Kontext",
+          "BFL"
+        ],
+        "date": "2025-05-29",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_bfl_flux_1_kontext_pro_image",
+        "title": "BFL Flux.1 Kontext Pro",
+        "description": "Edit images with Flux.1 Kontext pro image.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-kontext",
+        "tags": [
+          "Image Edit",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "Kontext",
+          "BFL"
+        ],
+        "date": "2025-05-29",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_bfl_flux_1_kontext_max_image",
+        "title": "BFL Flux.1 Kontext Max",
+        "description": "Edit images with Flux.1 Kontext max image.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-kontext",
+        "tags": [
+          "Image Edit",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "Kontext",
+          "BFL"
+        ],
+        "date": "2025-05-29",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_wan_text_to_image",
+        "title": "Wan2.5: Text to Image",
+        "description": "Generate images with excellent prompt following and visual quality using FLUX.1 Pro.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Wan2.5",
+          "Wan"
+        ],
+        "date": "2025-09-25",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_bfl_flux_pro_t2i",
+        "title": "BFL Flux[Pro]: Text to Image",
+        "description": "Generate images with excellent prompt following and visual quality using FLUX.1 Pro.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
+        "tags": [
+          "Image Edit",
+          "Image"
+        ],
+        "models": [
+          "Flux",
+          "BFL"
+        ],
+        "date": "2025-05-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_luma_photon_i2i",
+        "title": "Luma Photon: Image to Image",
+        "description": "Guide image generation using a combination of images and prompt.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tags": [
+          "Image to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Luma"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_luma_photon_style_ref",
+        "title": "Luma Photon: Style Reference",
+        "description": "Generate images by blending style references with precise control using Luma Photon.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Luma"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_recraft_image_gen_with_color_control",
+        "title": "Recraft: Color Control Image Generation",
+        "description": "Generate images with custom color palettes and brand-specific visuals using Recraft.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Recraft"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_recraft_image_gen_with_style_control",
+        "title": "Recraft: Style Control Image Generation",
+        "description": "Control style with visual examples, align positioning, and fine-tune objects. Store and share styles for perfect brand consistency.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Recraft"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_recraft_vector_gen",
+        "title": "Recraft: Vector Generation",
+        "description": "Generate high-quality vector images from text prompts using Recraft's AI vector generator.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API",
+          "Vector"
+        ],
+        "models": [
+          "Recraft"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_runway_text_to_image",
+        "title": "Runway: Text to Image",
+        "description": "Generate high-quality images from text prompts using Runway's AI model.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Runway"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_runway_reference_to_image",
+        "title": "Runway: Reference to Image",
+        "description": "Generate new images based on reference styles and compositions with Runway's AI.",
+        "mediaType": "image",
+        "thumbnailVariant": "compareSlider",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Runway"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_stability_ai_stable_image_ultra_t2i",
+        "title": "Stability AI: Stable Image Ultra Text to Image",
+        "description": "Generate high quality images with excellent prompt adherence. Perfect for professional GENERATION TYPE at 1 megapixel resolution.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Stability"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_stability_ai_i2i",
+        "title": "Stability AI: Image to Image",
+        "description": "Transform images with high-quality generation using Stability AI, perfect for professional editing and style transfer.",
+        "mediaType": "image",
+        "thumbnailVariant": "compareSlider",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Stability"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_stability_ai_sd3.5_t2i",
+        "title": "Stability AI: SD3.5 Text to Image",
+        "description": "Generate high quality images with excellent prompt adherence. Perfect for professional GENERATION TYPE at 1 megapixel resolution.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Stability"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_stability_ai_sd3.5_i2i",
+        "title": "Stability AI: SD3.5 Image to Image",
+        "description": "Generate high quality images with excellent prompt adherence. Perfect for professional GENERATION TYPE at 1 megapixel resolution.",
+        "mediaType": "image",
+        "thumbnailVariant": "compareSlider",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Stability"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_ideogram_v3_t2i",
+        "title": "Ideogram V3: Text to Image",
+        "description": "Generate professional-quality images with excellent prompt alignment, photorealism, and text rendering using Ideogram V3.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Ideogram"
+        ],
+        "date": "2025-03-01",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_openai_image_1_t2i",
+        "title": "OpenAI: GPT-Image-1 Text to Image",
+        "description": "Generate images from text prompts using OpenAI GPT Image 1 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "GPT-Image-1",
+          "OpenAI"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_openai_image_1_i2i",
+        "title": "OpenAI: GPT-Image-1 Image to Image",
+        "description": "Generate images from input images using OpenAI GPT Image 1 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tags": [
+          "Image to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "GPT-Image-1",
+          "OpenAI"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_openai_image_1_inpaint",
+        "title": "OpenAI: GPT-Image-1 Inpaint",
+        "description": "Edit images using inpainting with OpenAI GPT Image 1 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tags": [
+          "Inpainting",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "GPT-Image-1",
+          "OpenAI"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_openai_image_1_multi_inputs",
+        "title": "OpenAI: GPT-Image-1 Multi Inputs",
+        "description": "Generate images from multiple inputs using OpenAI GPT Image 1 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "GPT-Image-1",
+          "OpenAI"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_openai_dall_e_2_t2i",
+        "title": "OpenAI: Dall-E 2 Text to Image",
+        "description": "Generate images from text prompts using OpenAI Dall-E 2 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Dall-E",
+          "OpenAI"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/dall-e-2",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_openai_dall_e_2_inpaint",
+        "title": "OpenAI: Dall-E 2 Inpaint",
+        "description": "Edit images using inpainting with OpenAI Dall-E 2 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "thumbnailVariant": "compareSlider",
+        "tags": [
+          "Inpainting",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Dall-E",
+          "OpenAI"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/dall-e-2",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_openai_dall_e_3_t2i",
+        "title": "OpenAI: Dall-E 3 Text to Image",
+        "description": "Generate images from text prompts using OpenAI Dall-E 3 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Image",
+          "Image",
+          "API"
+        ],
+        "models": [
+          "Dall-E",
+          "OpenAI"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/dall-e-3",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
       }
     ]
   },
@@ -839,8 +1748,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2_2",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-07-29",
         "size": 38031935406
       },
@@ -852,8 +1767,14 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2_2",
-        "tags": ["Image to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Image to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-07-29",
         "size": 38031935406
       },
@@ -865,8 +1786,14 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2_2",
-        "tags": ["FLF2V", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "FLF2V",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-08-02",
         "size": 38031935406
       },
@@ -877,8 +1804,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2-2-animate",
-        "tags": ["Video", "Image to Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Video",
+          "Image to Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-09-22",
         "size": 27417997476
       },
@@ -889,8 +1822,13 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2-2-s2v",
-        "tags": ["Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-08-02",
         "size": 25254407700
       },
@@ -900,8 +1838,12 @@
         "description": "Generate videos basic on audio, image, and text, keep the character's lip sync.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Video"],
-        "models": ["HuMo"],
+        "tags": [
+          "Video"
+        ],
+        "models": [
+          "HuMo"
+        ],
         "date": "2025-09-21",
         "size": 27895812588
       },
@@ -912,8 +1854,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2-2-fun-inp",
-        "tags": ["FLF2V", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "FLF2V",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-08-12",
         "size": 38031935406
       },
@@ -924,8 +1872,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2-2-fun-control",
-        "tags": ["Video to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Video to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-08-12",
         "size": 38031935406
       },
@@ -936,8 +1890,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan2-2-fun-camera",
-        "tags": ["Video to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Video to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-08-17",
         "size": 40050570035
       },
@@ -947,8 +1907,14 @@
         "description": "Fast text-to-video and image-to-video generation with 5B parameters. Optimized for rapid prototyping and creative exploration.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-07-29",
         "size": 18146236826
       },
@@ -958,8 +1924,14 @@
         "description": "Efficient video inpainting from start and end frames. 5B model delivers quick iterations for testing workflows.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-07-29",
         "size": 18146236826
       },
@@ -969,8 +1941,14 @@
         "description": "Multi-condition video control with pose, depth, and edge guidance. Compact 5B size for experimental development.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.2", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.2",
+          "Wan"
+        ],
         "date": "2025-07-29",
         "size": 18146236826
       },
@@ -981,8 +1959,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/vace",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-05-21",
         "size": 57756572713
       },
@@ -993,8 +1977,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/vace",
-        "tags": ["Video", "Image to Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Video",
+          "Image to Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-05-21",
         "size": 57756572713
       },
@@ -1006,8 +1996,14 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "compareSlider",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/vace",
-        "tags": ["Video to Video", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Video to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-05-21",
         "size": 57756572713
       },
@@ -1019,8 +2015,14 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "compareSlider",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/vace",
-        "tags": ["Outpainting", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Outpainting",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-05-21",
         "size": 57756572713
       },
@@ -1031,8 +2033,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/vace",
-        "tags": ["FLF2V", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "FLF2V",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-05-21",
         "size": 57756572713
       },
@@ -1044,8 +2052,14 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "compareSlider",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/vace",
-        "tags": ["Inpainting", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Inpainting",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-05-21",
         "size": 57756572713
       },
@@ -1055,8 +2069,14 @@
         "description": "Generate text-to-video with alpha channel support for transparent backgrounds and semi-transparent objects.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-10-06",
         "size": 22494891213
       },
@@ -1068,8 +2088,13 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan-ati",
-        "tags": ["Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-05-21",
         "size": 25393994138
       },
@@ -1080,8 +2105,13 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/fun-control",
-        "tags": ["Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-04-15",
         "size": 11489037517
       },
@@ -1092,8 +2122,13 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/fun-control",
-        "tags": ["Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-04-15",
         "size": 42047729828
       },
@@ -1104,8 +2139,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan-video",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-03-01",
         "size": 9824737690
       },
@@ -1116,8 +2157,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan-video",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-03-01",
         "size": 41049149932
       },
@@ -1128,8 +2175,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/fun-inp",
-        "tags": ["Inpainting", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Inpainting",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-04-15",
         "size": 11381663334
       },
@@ -1141,8 +2194,14 @@
         "mediaSubtype": "webp",
         "thumbnailVariant": "hoverDissolve",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/fun-control",
-        "tags": ["Video to Video", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "Video to Video",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-04-15",
         "size": 11381663334
       },
@@ -1153,8 +2212,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/wan/wan-flf",
-        "tags": ["FLF2V", "Video"],
-        "models": ["Wan2.1", "Wan"],
+        "tags": [
+          "FLF2V",
+          "Video"
+        ],
+        "models": [
+          "Wan2.1",
+          "Wan"
+        ],
         "date": "2025-04-15",
         "size": 41049149932
       },
@@ -1165,8 +2230,13 @@
         "mediaSubtype": "webp",
         "description": "Generate videos from text prompts.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/ltxv",
-        "tags": ["Text to Video", "Video"],
-        "models": ["LTXV"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "LTXV"
+        ],
         "date": "2025-03-01",
         "size": 19155554140
       },
@@ -1177,8 +2247,13 @@
         "mediaSubtype": "webp",
         "description": "Generate videos from still images.",
         "tutorialUrl": "https://docs.comfy.org/tutorials/video/ltxv",
-        "tags": ["Image to Video", "Video"],
-        "models": ["LTXV"],
+        "tags": [
+          "Image to Video",
+          "Video"
+        ],
+        "models": [
+          "LTXV"
+        ],
         "date": "2025-03-01",
         "size": 19155554140
       },
@@ -1189,8 +2264,13 @@
         "mediaSubtype": "webp",
         "description": "Generate videos from text prompts using Mochi model.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/mochi/",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Mochi"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Mochi"
+        ],
         "date": "2025-03-01",
         "size": 30762703258
       },
@@ -1201,8 +2281,14 @@
         "mediaSubtype": "webp",
         "description": "Generate videos from text prompts using Hunyuan model.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/hunyuan_video/",
-        "tags": ["Text to Video", "Video"],
-        "models": ["Hunyuan Video", "Tencent"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "Hunyuan Video",
+          "Tencent"
+        ],
         "date": "2025-03-01",
         "size": 35476429865
       },
@@ -1213,8 +2299,14 @@
         "mediaSubtype": "webp",
         "description": "Generate videos from still images.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/video/#image-to-video",
-        "tags": ["Image to Video", "Video"],
-        "models": ["SVD", "Stability"],
+        "tags": [
+          "Image to Video",
+          "Video"
+        ],
+        "models": [
+          "SVD",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 9556302234
       },
@@ -1225,10 +2317,700 @@
         "mediaSubtype": "webp",
         "description": "Generate videos by first creating images from text prompts.",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/video/#image-to-video",
-        "tags": ["Text to Video", "Video"],
-        "models": ["SVD", "Stability"],
+        "tags": [
+          "Text to Video",
+          "Video"
+        ],
+        "models": [
+          "SVD",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "size": 16492674417
+      },
+      {
+        "name": "api_openai_sora_video",
+        "title": "Sora 2: Text & Image to Video",
+        "description": "OpenAI's Sora-2 and Sora-2 Pro video generation with synchronized audio.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Text to Video",
+          "API"
+        ],
+        "models": [
+          "OpenAI"
+        ],
+        "date": "2025-10-08",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_ltxv_text_to_video",
+        "title": "LTX-2: Text to Video",
+        "description": "Generate high-quality videos from text prompts using Lightricks LTX-2 with synchronized audio. Supports up to 4K resolution at 50fps with Fast, Pro, and Ultra modes for various production needs.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "LTX-2",
+          "Lightricks"
+        ],
+        "date": "2025-10-28",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_ltxv_image_to_video",
+        "title": "LTX-2: Image to Video",
+        "description": "Transform static images into dynamic videos with LTX-2 Pro. Generate cinematic video sequences with natural motion, synchronized audio, and support for up to 4K resolution at 50fps.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "LTX-2",
+          "Lightricks"
+        ],
+        "date": "2025-10-28",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_wan_text_to_video",
+        "title": "Wan2.5: Text to Video",
+        "description": "Generate videos with synchronized audio, enhanced motion, and superior quality.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Wan2.5",
+          "Wan"
+        ],
+        "date": "2025-09-27",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_wan_image_to_video",
+        "title": "Wan2.5: Image to Video",
+        "description": "Transform images into videos with synchronized audio, enhanced motion, and superior quality.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Wan2.5",
+          "Wan"
+        ],
+        "date": "2025-09-27",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_kling_i2v",
+        "title": "Kling: Image to Video",
+        "description": "Generate videos with excellent prompt adherence for actions, expressions, and camera movements using Kling.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Kling"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_kling_effects",
+        "title": "Kling: Video Effects",
+        "description": "Generate dynamic videos by applying visual effects to images using Kling.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Kling"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_kling_flf",
+        "title": "Kling: FLF2V",
+        "description": "Generate videos through controlling the first and last frames.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "API",
+          "FLF2V"
+        ],
+        "models": [
+          "Kling"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_vidu_text_to_video",
+        "title": "Vidu: Text to Video",
+        "description": "Generate high-quality 1080p videos from text prompts with adjustable movement amplitude and duration control using Vidu's advanced AI model.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Vidu"
+        ],
+        "date": "2025-08-23",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_vidu_image_to_video",
+        "title": "Vidu: Image to Video",
+        "description": "Transform static images into dynamic 1080p videos with precise motion control and customizable movement amplitude using Vidu.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Vidu"
+        ],
+        "date": "2025-08-23",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_vidu_reference_to_video",
+        "title": "Vidu: Reference to Video",
+        "description": "Generate videos with consistent subjects using multiple reference images (up to 7) for character and style continuity across the video sequence.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "Image to Video",
+          "API"
+        ],
+        "models": [
+          "Vidu"
+        ],
+        "date": "2025-08-23",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_vidu_start_end_to_video",
+        "title": "Vidu: Start End to Video",
+        "description": "Create smooth video transitions between defined start and end frames with natural motion interpolation and consistent visual quality.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "API",
+          "FLF2V"
+        ],
+        "models": [
+          "Vidu"
+        ],
+        "date": "2025-08-23",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_bytedance_text_to_video",
+        "title": "ByteDance: Text to Video",
+        "description": "Generate high-quality videos directly from text prompts using ByteDance's Seedance model. Supports multiple resolutions and aspect ratios with natural motion and cinematic quality.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "API",
+          "Text to Video"
+        ],
+        "models": [
+          "ByteDance"
+        ],
+        "date": "2025-10-6",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_bytedance_image_to_video",
+        "title": "ByteDance: Image to Video",
+        "description": "Transform static images into dynamic videos using ByteDance's Seedance model. Analyzes image structure and generates natural motion with consistent visual style and coherent video sequences.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "API",
+          "Image to Video"
+        ],
+        "models": [
+          "ByteDance"
+        ],
+        "date": "2025-10-6",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_bytedance_flf2v",
+        "title": "ByteDance: Start End to Video",
+        "description": "Generate cinematic video transitions between start and end frames with fluid motion, scene consistency, and professional polish using ByteDance's Seedance model.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "API",
+          "FLF2V"
+        ],
+        "models": [
+          "ByteDance"
+        ],
+        "date": "2025-10-6",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_luma_i2v",
+        "title": "Luma: Image to Video",
+        "description": "Take static images and instantly create magical high quality animations.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Luma"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_luma_t2v",
+        "title": "Luma: Text to Video",
+        "description": "High-quality videos can be generated using simple prompts.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Luma"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_moonvalley_text_to_video",
+        "title": "Moonvalley: Text to Video",
+        "description": "Generate cinematic, 1080p videos from text prompts through a model trained exclusively on licensed data.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Moonvalley"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_moonvalley_image_to_video",
+        "title": "Moonvalley: Image to Video",
+        "description": "Generate cinematic, 1080p videos with an image through a model trained exclusively on licensed data.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Moonvalley"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_moonvalley_video_to_video_motion_transfer",
+        "title": "Moonvalley: Motion Transfer",
+        "description": "Apply motion from one video to another.",
+        "mediaType": "image",
+        "thumbnailVariant": "hoverDissolve",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Moonvalley"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_moonvalley_video_to_video_pose_control",
+        "title": "Moonvalley: Pose Control",
+        "description": "Apply human pose and movement from one video to another.",
+        "mediaType": "image",
+        "thumbnailVariant": "hoverDissolve",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Moonvalley"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_hailuo_minimax_video",
+        "title": "MiniMax: Video",
+        "description": "Generate high-quality videos from text prompts with optional first-frame control using MiniMax Hailuo-02 model. Supports multiple resolutions (768P/1080P) and durations (6/10s) with intelligent prompt optimization.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "MiniMax"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_hailuo_minimax_t2v",
+        "title": "MiniMax: Text to Video",
+        "description": "Generate high-quality videos directly from text prompts. Explore MiniMax's advanced AI capabilities to create diverse visual narratives with professional CGI effects and stylistic elements to bring your descriptions to life.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "MiniMax"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_hailuo_minimax_i2v",
+        "title": "MiniMax: Image to Video",
+        "description": "Generate refined videos from images and text with CGI integration using MiniMax.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "MiniMax"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_pixverse_i2v",
+        "title": "PixVerse: Image to Video",
+        "description": "Generate dynamic videos from static images with motion and effects using PixVerse.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "PixVerse"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_pixverse_template_i2v",
+        "title": "PixVerse Templates: Image to Video",
+        "description": "Generate dynamic videos from static images with motion and effects using PixVerse.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "PixVerse"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_pixverse_t2v",
+        "title": "PixVerse: Text to Video",
+        "description": "Generate videos with accurate prompt interpretation and stunning video dynamics.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Text to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "PixVerse"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_runway_gen3a_turbo_image_to_video",
+        "title": "Runway: Gen3a Turbo Image to Video",
+        "description": "Generate cinematic videos from static images using Runway Gen3a Turbo.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Runway"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_runway_gen4_turo_image_to_video",
+        "title": "Runway: Gen4 Turbo Image to Video",
+        "description": "Generate dynamic videos from images using Runway Gen4 Turbo.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Runway"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_runway_first_last_frame",
+        "title": "Runway: First Last Frame to Video",
+        "description": "Generate smooth video transitions between two keyframes with Runway's precision.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Video",
+          "API",
+          "FLF2V"
+        ],
+        "models": [
+          "Runway"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_pika_i2v",
+        "title": "Pika: Image to Video",
+        "description": "Generate smooth animated videos from single static images using Pika AI.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Pika"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_pika_scene",
+        "title": "Pika Scenes: Images to Video",
+        "description": "Generate videos that incorporate multiple input images using Pika Scenes.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Pika"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_veo2_i2v",
+        "title": "Veo2: Image to Video",
+        "description": "Generate videos from images using Google Veo2 API.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Video",
+          "API"
+        ],
+        "models": [
+          "Veo",
+          "Google"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_veo3",
+        "title": "Veo3: Image to Video",
+        "description": "Generate high-quality 8-second videos from text prompts or images using Google's advanced Veo 3 API. Features audio generation, prompt enhancement, and dual model options for speed or quality.",
+        "mediaType": "image",
+        "mediaSubtype": "webp",
+        "tags": [
+          "Image to Video",
+          "Text to Video",
+          "API"
+        ],
+        "models": [
+          "Veo",
+          "Google"
+        ],
+        "date": "2025-03-01",
+        "tutorialUrl": "",
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
       }
     ]
   },
@@ -1245,8 +3027,14 @@
         "mediaType": "audio",
         "mediaSubtype": "mp3",
         "description": "Generate audio from text prompts using Stable Audio.",
-        "tags": ["Text to Audio", "Audio"],
-        "models": ["Stable Audio", "Stability"],
+        "tags": [
+          "Text to Audio",
+          "Audio"
+        ],
+        "models": [
+          "Stable Audio",
+          "Stability"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5744518758
@@ -1257,8 +3045,13 @@
         "mediaType": "audio",
         "mediaSubtype": "mp3",
         "description": "Generate instrumental music from text prompts using ACE-Step v1.",
-        "tags": ["Text to Audio", "Audio"],
-        "models": ["ACE-Step"],
+        "tags": [
+          "Text to Audio",
+          "Audio"
+        ],
+        "models": [
+          "ACE-Step"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878
@@ -1269,8 +3062,13 @@
         "mediaType": "audio",
         "mediaSubtype": "mp3",
         "description": "Generate songs with vocals from text prompts using ACE-Step v1, supporting multilingual and style customization.",
-        "tags": ["Text to Audio", "Audio"],
-        "models": ["ACE-Step"],
+        "tags": [
+          "Text to Audio",
+          "Audio"
+        ],
+        "models": [
+          "ACE-Step"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878
@@ -1281,11 +3079,76 @@
         "mediaType": "audio",
         "mediaSubtype": "mp3",
         "description": "Edit existing songs to change style and lyrics using ACE-Step v1 M2M.",
-        "tags": ["Audio Editing", "Audio"],
-        "models": ["ACE-Step"],
+        "tags": [
+          "Audio Editing",
+          "Audio"
+        ],
+        "models": [
+          "ACE-Step"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878
+      },
+      {
+        "name": "api_stability_ai_text_to_audio",
+        "title": "Stability AI: Text to Audio",
+        "description": "Generate music from text using Stable Audio 2.5. Create minutes-long tracks in seconds.",
+        "mediaType": "audio",
+        "mediaSubtype": "mp3",
+        "tags": [
+          "Text to Audio",
+          "Audio",
+          "API"
+        ],
+        "date": "2025-09-09",
+        "models": [
+          "Stability",
+          "Stable Audio"
+        ],
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_stability_ai_audio_to_audio",
+        "title": "Stability AI: Audio to Audio",
+        "description": "Transform audio into new compositions using Stable Audio 2.5. Upload audio and AI creates complete tracks.",
+        "mediaType": "audio",
+        "mediaSubtype": "mp3",
+        "tags": [
+          "Audio to Audio",
+          "Audio",
+          "API"
+        ],
+        "date": "2025-09-09",
+        "models": [
+          "Stability",
+          "Stable Audio"
+        ],
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
+      },
+      {
+        "name": "api_stability_ai_audio_inpaint",
+        "title": "Stability AI: Audio Inpainting",
+        "description": "Complete or extend audio tracks using Stable Audio 2.5. Upload audio and AI generates the rest.",
+        "mediaType": "audio",
+        "mediaSubtype": "mp3",
+        "tags": [
+          "Audio to Audio",
+          "Audio",
+          "API"
+        ],
+        "date": "2025-09-09",
+        "models": [
+          "Stability",
+          "Stable Audio"
+        ],
+        "OpenSource": false,
+        "size": 0,
+        "vram": 0
       }
     ]
   },
@@ -1302,8 +3165,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate 3D models from single images using Hunyuan3D 2.0.",
-        "tags": ["Image to 3D", "3D"],
-        "models": ["Hunyuan3D", "Tencent"],
+        "tags": [
+          "Image to 3D",
+          "3D"
+        ],
+        "models": [
+          "Hunyuan3D",
+          "Tencent"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "size": 4928474972
@@ -1314,8 +3183,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate 3D models from single images using Hunyuan3D 2.0.",
-        "tags": ["Image to 3D", "3D"],
-        "models": ["Hunyuan3D", "Tencent"],
+        "tags": [
+          "Image to 3D",
+          "3D"
+        ],
+        "models": [
+          "Hunyuan3D",
+          "Tencent"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "size": 4928474972
@@ -1326,8 +3201,14 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate 3D models from multiple views using Hunyuan3D 2.0 MV.",
-        "tags": ["3D", "Image to 3D"],
-        "models": ["Hunyuan3D", "Tencent"],
+        "tags": [
+          "3D",
+          "Image to 3D"
+        ],
+        "models": [
+          "Hunyuan3D",
+          "Tencent"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "thumbnailVariant": "hoverDissolve",
@@ -1339,884 +3220,33 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "description": "Generate 3D models from multiple views using Hunyuan3D 2.0 MV Turbo.",
-        "tags": ["Image to 3D", "3D"],
-        "models": ["Hunyuan3D", "Tencent"],
+        "tags": [
+          "Image to 3D",
+          "3D"
+        ],
+        "models": [
+          "Hunyuan3D",
+          "Tencent"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972
-      }
-    ]
-  },
-  {
-    "moduleName": "default",
-    "category": "CLOSED SOURCE MODELS",
-    "title": "Image API",
-    "icon": "icon-[lucide--hand-coins]",
-    "type": "image",
-    "templates": [
-      {
-        "name": "api_bytedance_seedream4",
-        "title": "ByteDance Seedream 4.0",
-        "description": "Multi-modal AI model for text-to-image and image editing. Generate 2K images in under 2 seconds with natural language control.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image Edit", "Image", "API", "Text to Image"],
-        "models": ["Seedream 4.0", "ByteDance"],
-        "date": "2025-09-11",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
       },
-      {
-        "name": "api_google_gemini_image",
-        "title": "Google Gemini Image",
-        "description": "Nano-banana (Gemini-2.5-Flash Image) - image editing with consistency.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image Edit", "Image", "API", "Text to Image"],
-        "models": ["Gemini-2.5-Flash", "nano-banana", "Google"],
-        "date": "2025-08-27",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_bfl_flux_1_kontext_multiple_images_input",
-        "title": "BFL Flux.1 Kontext Multiple Image Input",
-        "description": "Input multiple images and edit them with Flux.1 Kontext.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-kontext",
-        "tags": ["Image Edit", "Image"],
-        "models": ["Flux", "Kontext", "BFL"],
-        "date": "2025-05-29",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_bfl_flux_1_kontext_pro_image",
-        "title": "BFL Flux.1 Kontext Pro",
-        "description": "Edit images with Flux.1 Kontext pro image.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-kontext",
-        "tags": ["Image Edit", "Image"],
-        "models": ["Flux", "Kontext", "BFL"],
-        "date": "2025-05-29",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_bfl_flux_1_kontext_max_image",
-        "title": "BFL Flux.1 Kontext Max",
-        "description": "Edit images with Flux.1 Kontext max image.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-kontext",
-        "tags": ["Image Edit", "Image"],
-        "models": ["Flux", "Kontext", "BFL"],
-        "date": "2025-05-29",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_wan_text_to_image",
-        "title": "Wan2.5: Text to Image",
-        "description": "Generate images with excellent prompt following and visual quality using FLUX.1 Pro.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Wan2.5", "Wan"],
-        "date": "2025-09-25",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_bfl_flux_pro_t2i",
-        "title": "BFL Flux[Pro]: Text to Image",
-        "description": "Generate images with excellent prompt following and visual quality using FLUX.1 Pro.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/black-forest-labs/flux-1-1-pro-ultra-image",
-        "tags": ["Image Edit", "Image"],
-        "models": ["Flux", "BFL"],
-        "date": "2025-05-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_luma_photon_i2i",
-        "title": "Luma Photon: Image to Image",
-        "description": "Guide image generation using a combination of images and prompt.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tags": ["Image to Image", "Image", "API"],
-        "models": ["Luma"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_luma_photon_style_ref",
-        "title": "Luma Photon: Style Reference",
-        "description": "Generate images by blending style references with precise control using Luma Photon.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Luma"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_recraft_image_gen_with_color_control",
-        "title": "Recraft: Color Control Image Generation",
-        "description": "Generate images with custom color palettes and brand-specific visuals using Recraft.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Recraft"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_recraft_image_gen_with_style_control",
-        "title": "Recraft: Style Control Image Generation",
-        "description": "Control style with visual examples, align positioning, and fine-tune objects. Store and share styles for perfect brand consistency.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Recraft"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_recraft_vector_gen",
-        "title": "Recraft: Vector Generation",
-        "description": "Generate high-quality vector images from text prompts using Recraft's AI vector generator.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API", "Vector"],
-        "models": ["Recraft"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_runway_text_to_image",
-        "title": "Runway: Text to Image",
-        "description": "Generate high-quality images from text prompts using Runway's AI model.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Runway"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_runway_reference_to_image",
-        "title": "Runway: Reference to Image",
-        "description": "Generate new images based on reference styles and compositions with Runway's AI.",
-        "mediaType": "image",
-        "thumbnailVariant": "compareSlider",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Image", "Image", "API"],
-        "models": ["Runway"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_stability_ai_stable_image_ultra_t2i",
-        "title": "Stability AI: Stable Image Ultra Text to Image",
-        "description": "Generate high quality images with excellent prompt adherence. Perfect for professional GENERATION TYPE at 1 megapixel resolution.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Stability"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_stability_ai_i2i",
-        "title": "Stability AI: Image to Image",
-        "description": "Transform images with high-quality generation using Stability AI, perfect for professional editing and style transfer.",
-        "mediaType": "image",
-        "thumbnailVariant": "compareSlider",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Image", "Image", "API"],
-        "models": ["Stability"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_stability_ai_sd3.5_t2i",
-        "title": "Stability AI: SD3.5 Text to Image",
-        "description": "Generate high quality images with excellent prompt adherence. Perfect for professional GENERATION TYPE at 1 megapixel resolution.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Stability"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_stability_ai_sd3.5_i2i",
-        "title": "Stability AI: SD3.5 Image to Image",
-        "description": "Generate high quality images with excellent prompt adherence. Perfect for professional GENERATION TYPE at 1 megapixel resolution.",
-        "mediaType": "image",
-        "thumbnailVariant": "compareSlider",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Image", "Image", "API"],
-        "models": ["Stability"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_ideogram_v3_t2i",
-        "title": "Ideogram V3: Text to Image",
-        "description": "Generate professional-quality images with excellent prompt alignment, photorealism, and text rendering using Ideogram V3.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Ideogram"],
-        "date": "2025-03-01",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_openai_image_1_t2i",
-        "title": "OpenAI: GPT-Image-1 Text to Image",
-        "description": "Generate images from text prompts using OpenAI GPT Image 1 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["GPT-Image-1", "OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_openai_image_1_i2i",
-        "title": "OpenAI: GPT-Image-1 Image to Image",
-        "description": "Generate images from input images using OpenAI GPT Image 1 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tags": ["Image to Image", "Image", "API"],
-        "models": ["GPT-Image-1", "OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_openai_image_1_inpaint",
-        "title": "OpenAI: GPT-Image-1 Inpaint",
-        "description": "Edit images using inpainting with OpenAI GPT Image 1 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tags": ["Inpainting", "Image", "API"],
-        "models": ["GPT-Image-1", "OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_openai_image_1_multi_inputs",
-        "title": "OpenAI: GPT-Image-1 Multi Inputs",
-        "description": "Generate images from multiple inputs using OpenAI GPT Image 1 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["GPT-Image-1", "OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/gpt-image-1",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_openai_dall_e_2_t2i",
-        "title": "OpenAI: Dall-E 2 Text to Image",
-        "description": "Generate images from text prompts using OpenAI Dall-E 2 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Dall-E", "OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/dall-e-2",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_openai_dall_e_2_inpaint",
-        "title": "OpenAI: Dall-E 2 Inpaint",
-        "description": "Edit images using inpainting with OpenAI Dall-E 2 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "thumbnailVariant": "compareSlider",
-        "tags": ["Inpainting", "Image", "API"],
-        "models": ["Dall-E", "OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/dall-e-2",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_openai_dall_e_3_t2i",
-        "title": "OpenAI: Dall-E 3 Text to Image",
-        "description": "Generate images from text prompts using OpenAI Dall-E 3 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Image", "Image", "API"],
-        "models": ["Dall-E", "OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "https://docs.comfy.org/tutorials/api-nodes/openai/dall-e-3",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      }
-    ]
-  },
-  {
-    "moduleName": "default",
-    "category": "CLOSED SOURCE MODELS",
-    "title": "Video API",
-    "icon": "icon-[lucide--film]",
-    "type": "video",
-    "templates": [
-      {
-        "name": "api_openai_sora_video",
-        "title": "Sora 2: Text & Image to Video",
-        "description": "OpenAI's Sora-2 and Sora-2 Pro video generation with synchronized audio.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Text to Video", "API"],
-        "models": ["OpenAI"],
-        "date": "2025-10-08",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_ltxv_text_to_video",
-        "title": "LTX-2: Text to Video",
-        "description": "Generate high-quality videos from text prompts using Lightricks LTX-2 with synchronized audio. Supports up to 4K resolution at 50fps with Fast, Pro, and Ultra modes for various production needs.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video", "API"],
-        "models": ["LTX-2", "Lightricks"],
-        "date": "2025-10-28",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_ltxv_image_to_video",
-        "title": "LTX-2: Image to Video",
-        "description": "Transform static images into dynamic videos with LTX-2 Pro. Generate cinematic video sequences with natural motion, synchronized audio, and support for up to 4K resolution at 50fps.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["LTX-2", "Lightricks"],
-        "date": "2025-10-28",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_wan_text_to_video",
-        "title": "Wan2.5: Text to Video",
-        "description": "Generate videos with synchronized audio, enhanced motion, and superior quality.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Wan2.5", "Wan"],
-        "date": "2025-09-27",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_wan_image_to_video",
-        "title": "Wan2.5: Image to Video",
-        "description": "Transform images into videos with synchronized audio, enhanced motion, and superior quality.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Wan2.5", "Wan"],
-        "date": "2025-09-27",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_kling_i2v",
-        "title": "Kling: Image to Video",
-        "description": "Generate videos with excellent prompt adherence for actions, expressions, and camera movements using Kling.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Kling"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_kling_effects",
-        "title": "Kling: Video Effects",
-        "description": "Generate dynamic videos by applying visual effects to images using Kling.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "API"],
-        "models": ["Kling"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_kling_flf",
-        "title": "Kling: FLF2V",
-        "description": "Generate videos through controlling the first and last frames.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "API", "FLF2V"],
-        "models": ["Kling"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_vidu_text_to_video",
-        "title": "Vidu: Text to Video",
-        "description": "Generate high-quality 1080p videos from text prompts with adjustable movement amplitude and duration control using Vidu's advanced AI model.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video", "API"],
-        "models": ["Vidu"],
-        "date": "2025-08-23",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_vidu_image_to_video",
-        "title": "Vidu: Image to Video",
-        "description": "Transform static images into dynamic 1080p videos with precise motion control and customizable movement amplitude using Vidu.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Vidu"],
-        "date": "2025-08-23",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_vidu_reference_to_video",
-        "title": "Vidu: Reference to Video",
-        "description": "Generate videos with consistent subjects using multiple reference images (up to 7) for character and style continuity across the video sequence.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "Image to Video", "API"],
-        "models": ["Vidu"],
-        "date": "2025-08-23",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_vidu_start_end_to_video",
-        "title": "Vidu: Start End to Video",
-        "description": "Create smooth video transitions between defined start and end frames with natural motion interpolation and consistent visual quality.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "API", "FLF2V"],
-        "models": ["Vidu"],
-        "date": "2025-08-23",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_bytedance_text_to_video",
-        "title": "ByteDance: Text to Video",
-        "description": "Generate high-quality videos directly from text prompts using ByteDance's Seedance model. Supports multiple resolutions and aspect ratios with natural motion and cinematic quality.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "API", "Text to Video"],
-        "models": ["ByteDance"],
-        "date": "2025-10-6",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_bytedance_image_to_video",
-        "title": "ByteDance: Image to Video",
-        "description": "Transform static images into dynamic videos using ByteDance's Seedance model. Analyzes image structure and generates natural motion with consistent visual style and coherent video sequences.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "API", "Image to Video"],
-        "models": ["ByteDance"],
-        "date": "2025-10-6",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_bytedance_flf2v",
-        "title": "ByteDance: Start End to Video",
-        "description": "Generate cinematic video transitions between start and end frames with fluid motion, scene consistency, and professional polish using ByteDance's Seedance model.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "API", "FLF2V"],
-        "models": ["ByteDance"],
-        "date": "2025-10-6",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_luma_i2v",
-        "title": "Luma: Image to Video",
-        "description": "Take static images and instantly create magical high quality animations.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Luma"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_luma_t2v",
-        "title": "Luma: Text to Video",
-        "description": "High-quality videos can be generated using simple prompts.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video", "API"],
-        "models": ["Luma"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_moonvalley_text_to_video",
-        "title": "Moonvalley: Text to Video",
-        "description": "Generate cinematic, 1080p videos from text prompts through a model trained exclusively on licensed data.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video", "API"],
-        "models": ["Moonvalley"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_moonvalley_image_to_video",
-        "title": "Moonvalley: Image to Video",
-        "description": "Generate cinematic, 1080p videos with an image through a model trained exclusively on licensed data.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Moonvalley"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_moonvalley_video_to_video_motion_transfer",
-        "title": "Moonvalley: Motion Transfer",
-        "description": "Apply motion from one video to another.",
-        "mediaType": "image",
-        "thumbnailVariant": "hoverDissolve",
-        "mediaSubtype": "webp",
-        "tags": ["Video to Video", "Video", "API"],
-        "models": ["Moonvalley"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_moonvalley_video_to_video_pose_control",
-        "title": "Moonvalley: Pose Control",
-        "description": "Apply human pose and movement from one video to another.",
-        "mediaType": "image",
-        "thumbnailVariant": "hoverDissolve",
-        "mediaSubtype": "webp",
-        "tags": ["Video to Video", "Video", "API"],
-        "models": ["Moonvalley"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_hailuo_minimax_video",
-        "title": "MiniMax: Video",
-        "description": "Generate high-quality videos from text prompts with optional first-frame control using MiniMax Hailuo-02 model. Supports multiple resolutions (768P/1080P) and durations (6/10s) with intelligent prompt optimization.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video", "API"],
-        "models": ["MiniMax"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_hailuo_minimax_t2v",
-        "title": "MiniMax: Text to Video",
-        "description": "Generate high-quality videos directly from text prompts. Explore MiniMax's advanced AI capabilities to create diverse visual narratives with professional CGI effects and stylistic elements to bring your descriptions to life.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video", "API"],
-        "models": ["MiniMax"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_hailuo_minimax_i2v",
-        "title": "MiniMax: Image to Video",
-        "description": "Generate refined videos from images and text with CGI integration using MiniMax.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["MiniMax"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_pixverse_i2v",
-        "title": "PixVerse: Image to Video",
-        "description": "Generate dynamic videos from static images with motion and effects using PixVerse.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["PixVerse"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_pixverse_template_i2v",
-        "title": "PixVerse Templates: Image to Video",
-        "description": "Generate dynamic videos from static images with motion and effects using PixVerse.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["PixVerse"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_pixverse_t2v",
-        "title": "PixVerse: Text to Video",
-        "description": "Generate videos with accurate prompt interpretation and stunning video dynamics.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Text to Video", "Video", "API"],
-        "models": ["PixVerse"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_runway_gen3a_turbo_image_to_video",
-        "title": "Runway: Gen3a Turbo Image to Video",
-        "description": "Generate cinematic videos from static images using Runway Gen3a Turbo.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Runway"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_runway_gen4_turo_image_to_video",
-        "title": "Runway: Gen4 Turbo Image to Video",
-        "description": "Generate dynamic videos from images using Runway Gen4 Turbo.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Runway"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_runway_first_last_frame",
-        "title": "Runway: First Last Frame to Video",
-        "description": "Generate smooth video transitions between two keyframes with Runway's precision.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Video", "API", "FLF2V"],
-        "models": ["Runway"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_pika_i2v",
-        "title": "Pika: Image to Video",
-        "description": "Generate smooth animated videos from single static images using Pika AI.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Pika"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_pika_scene",
-        "title": "Pika Scenes: Images to Video",
-        "description": "Generate videos that incorporate multiple input images using Pika Scenes.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Pika"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_veo2_i2v",
-        "title": "Veo2: Image to Video",
-        "description": "Generate videos from images using Google Veo2 API.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Video", "API"],
-        "models": ["Veo", "Google"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_veo3",
-        "title": "Veo3: Image to Video",
-        "description": "Generate high-quality 8-second videos from text prompts or images using Google's advanced Veo 3 API. Features audio generation, prompt enhancement, and dual model options for speed or quality.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["Image to Video", "Text to Video", "API"],
-        "models": ["Veo", "Google"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      }
-    ]
-  },
-  {
-    "moduleName": "default",
-    "category": "CLOSED SOURCE MODELS",
-    "title": "3D API",
-    "icon": "icon-[lucide--box]",
-    "type": "image",
-    "templates": [
       {
         "name": "api_rodin_gen2",
         "title": "Rodin: Gen-2 Image to Model",
         "description": "Generate detailed 4X mesh quality 3D models from photos using Rodin Gen2",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Image to 3D", "3D", "API"],
-        "models": ["Rodin"],
+        "tags": [
+          "Image to 3D",
+          "3D",
+          "API"
+        ],
+        "models": [
+          "Rodin"
+        ],
         "date": "2025-09-27",
         "tutorialUrl": "",
         "OpenSource": false,
@@ -2229,8 +3259,14 @@
         "description": "Generate detailed 3D models from single photos using Rodin AI.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Image to 3D", "3D", "API"],
-        "models": ["Rodin"],
+        "tags": [
+          "Image to 3D",
+          "3D",
+          "API"
+        ],
+        "models": [
+          "Rodin"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "OpenSource": false,
@@ -2243,8 +3279,14 @@
         "description": "Sculpt comprehensive 3D models using Rodin's multi-angle reconstruction.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Image to 3D", "3D", "API"],
-        "models": ["Rodin"],
+        "tags": [
+          "Image to 3D",
+          "3D",
+          "API"
+        ],
+        "models": [
+          "Rodin"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "OpenSource": false,
@@ -2257,8 +3299,14 @@
         "description": "Craft 3D objects from descriptions with Tripo's text-driven modeling.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Text to Model", "3D", "API"],
-        "models": ["Tripo"],
+        "tags": [
+          "Text to Model",
+          "3D",
+          "API"
+        ],
+        "models": [
+          "Tripo"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "OpenSource": false,
@@ -2271,8 +3319,14 @@
         "description": "Generate professional 3D assets from 2D images using Tripo engine.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Image to 3D", "3D", "API"],
-        "models": ["Tripo"],
+        "tags": [
+          "Image to 3D",
+          "3D",
+          "API"
+        ],
+        "models": [
+          "Tripo"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "OpenSource": false,
@@ -2285,93 +3339,14 @@
         "description": "Build 3D models from multiple angles with Tripo's advanced scanner.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["Image to 3D", "3D", "API"],
-        "models": ["Tripo"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      }
-    ]
-  },
-  {
-    "moduleName": "default",
-    "category": "CLOSED SOURCE MODELS",
-    "title": "Audio API",
-    "type": "audio",
-    "icon": "icon-[lucide--volume-2]",
-    "templates": [
-      {
-        "name": "api_stability_ai_text_to_audio",
-        "title": "Stability AI: Text to Audio",
-        "description": "Generate music from text using Stable Audio 2.5. Create minutes-long tracks in seconds.",
-        "mediaType": "audio",
-        "mediaSubtype": "mp3",
-        "tags": ["Text to Audio", "Audio", "API"],
-        "date": "2025-09-09",
-        "models": ["Stability", "Stable Audio"],
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_stability_ai_audio_to_audio",
-        "title": "Stability AI: Audio to Audio",
-        "description": "Transform audio into new compositions using Stable Audio 2.5. Upload audio and AI creates complete tracks.",
-        "mediaType": "audio",
-        "mediaSubtype": "mp3",
-        "tags": ["Audio to Audio", "Audio", "API"],
-        "date": "2025-09-09",
-        "models": ["Stability", "Stable Audio"],
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_stability_ai_audio_inpaint",
-        "title": "Stability AI: Audio Inpainting",
-        "description": "Complete or extend audio tracks using Stable Audio 2.5. Upload audio and AI generates the rest.",
-        "mediaType": "audio",
-        "mediaSubtype": "mp3",
-        "tags": ["Audio to Audio", "Audio", "API"],
-        "date": "2025-09-09",
-        "models": ["Stability", "Stable Audio"],
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      }
-    ]
-  },
-  {
-    "moduleName": "default",
-    "category": "CLOSED SOURCE MODELS",
-    "title": "LLM API",
-    "icon": "icon-[lucide--message-square-text]",
-    "type": "image",
-    "templates": [
-      {
-        "name": "api_openai_chat",
-        "title": "OpenAI: Chat",
-        "description": "Engage with OpenAI's advanced language models for intelligent conversations.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
-        "models": ["OpenAI"],
-        "date": "2025-03-01",
-        "tutorialUrl": "",
-        "OpenSource": false,
-        "size": 0,
-        "vram": 0
-      },
-      {
-        "name": "api_google_gemini",
-        "title": "Google Gemini: Chat",
-        "description": "Experience Google's multimodal AI with Gemini's reasoning capabilities.",
-        "mediaType": "image",
-        "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
-        "models": ["Google Gemini", "Google"],
+        "tags": [
+          "Image to 3D",
+          "3D",
+          "API"
+        ],
+        "models": [
+          "Tripo"
+        ],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "OpenSource": false,


### PR DESCRIPTION
This PR migrates all 71 Partner Node (API) templates from CLOSED SOURCE MODELS categories into their corresponding GENERATION TYPE categories (Image, Video, 3D Model, Audio, LLMs). Each API template now has OpenSource: false field added, enabling the frontend to filter and display them in the new Partner Nodes virtual category. The CLOSED SOURCE MODELS category group has been removed entirely. Version bumped from 0.2.9 to 0.3.0 for PyPI release. This coordinates with frontend PR #6542 which implements the Partner Nodes filtering UI.