### PR TITLE
Fix deprecated license classifier error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,12 @@ version = "0.4.0"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
-license = "MIT"
-license-files = ["LICENSE"]
+license = {text = "MIT"}
 authors = [
     {name = "Comfy-Org"}
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 


### PR DESCRIPTION
## Summary

Fix build failure caused by deprecated license classifier format.

- Remove deprecated 'License :: OSI Approved :: MIT License' classifier  
- Use new PEP 639 license expression format: license = {text = "MIT"}
- Remove unused license-files field

## Test plan

- [ ] Merge this PR
- [ ] Rerun publish workflow to verify build succeeds