### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.0"
+version = "0.4.1"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Bump version to 0.4.1 to trigger fresh publish workflow with all recent fixes:

- Fixed package publishing dependency order
- Fixed deprecated license classifier error
- Updated CI workflow for proper twine publishing

This will trigger a new workflow run that should publish successfully.