### PR TITLE
Fix dependency versions to use existing packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.1"
+version = "0.4.3"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -21,20 +21,20 @@ dependencies = [
     "comfyui-workflow-templates-core>=0.3.1",
     "comfyui-workflow-templates-media-api>=0.3.4",
     "comfyui-workflow-templates-media-video>=0.3.1",
-    "comfyui-workflow-templates-media-image>=0.3.4",
-    "comfyui-workflow-templates-media-other>=0.3.4",
+    "comfyui-workflow-templates-media-image>=0.3.1",
+    "comfyui-workflow-templates-media-other>=0.3.1",
 ]
 
 [project.optional-dependencies]
 api = ["comfyui-workflow-templates-media-api>=0.3.4"]
 video = ["comfyui-workflow-templates-media-video>=0.3.1"]
-image = ["comfyui-workflow-templates-media-image>=0.3.4"]
-other = ["comfyui-workflow-templates-media-other>=0.3.4"]
+image = ["comfyui-workflow-templates-media-image>=0.3.1"]
+other = ["comfyui-workflow-templates-media-other>=0.3.1"]
 all = [
     "comfyui-workflow-templates-media-api>=0.3.4",
     "comfyui-workflow-templates-media-video>=0.3.1",
-    "comfyui-workflow-templates-media-image>=0.3.4",
-    "comfyui-workflow-templates-media-other>=0.3.4",
+    "comfyui-workflow-templates-media-image>=0.3.1",
+    "comfyui-workflow-templates-media-other>=0.3.1",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

Fix dependency resolution failure by updating package versions to match what exists on PyPI:

- Change media-image dependency from >=0.3.4 to >=0.3.1 (0.3.4 doesn't exist)
- Change media-other dependency from >=0.3.4 to >=0.3.1 (0.3.4 doesn't exist)  
- Bump version to 0.4.3

This resolves the pip install error where required versions weren't available.

## Test plan

- [ ] Merge this PR
- [ ] Test pip install comfyui-workflow-templates==0.4.3