### PR TITLE
Bump version to 0.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.3"
+version = "0.4.5"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Bump version to 0.4.5 to trigger publish workflow with the corrected dependency versions.

This version will have the fixed dependencies:
- media-image: >=0.3.1 (instead of >=0.3.4)  
- media-other: >=0.3.1 (instead of >=0.3.4)

Should resolve the pip install dependency resolution errors.

## Test plan

- [ ] Merge this PR
- [ ] Verify 0.4.5 publishes successfully  
- [ ] Test pip install comfyui-workflow-templates==0.4.5