### PR TITLE
Fix package versions and CI script dependency overwriting

### DIFF
--- a/packages/media_image/pyproject.toml
+++ b/packages/media_image/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-image"
-version = "0.3.4"
+version = "0.3.1"
 description = "Media bundle containing image workflow assets"
 readme = {text = "Media bundle containing image workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/packages/media_other/pyproject.toml
+++ b/packages/media_other/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-other"
-version = "0.3.4"
+version = "0.3.1"
 description = "Media bundle containing audio/3D/misc workflow assets"
 readme = {text = "Media bundle containing audio, 3D, and other workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.5"
+version = "0.4.6"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/ci_version_manager.py
+++ b/scripts/ci_version_manager.py
@@ -82,6 +82,9 @@ def bump_versions(packages: Set[str]) -> None:
                 path.write_text(updated)
 
 def update_dependencies() -> None:
+    """Update dependencies only for packages that were actually bumped"""
+    changed_packages = get_changed_packages()
+    
     version_re = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
     versions = {}
     
@@ -93,12 +96,17 @@ def update_dependencies() -> None:
         "media_other": "packages/media_other/pyproject.toml",
     }
     
+    # Only get versions for packages that were actually changed
     for pkg, path in pyprojects.items():
-        if Path(path).exists():
+        if pkg in changed_packages and Path(path).exists():
             text = Path(path).read_text()
             match = version_re.search(text)
             if match:
                 versions[pkg] = match.group(1)
+    
+    # Only update dependencies if we have changed packages
+    if not versions:
+        return
     
     for meta_path in ["pyproject.toml", "packages/meta/pyproject.toml"]:
         if Path(meta_path).exists():


### PR DESCRIPTION
## Summary

This PR fixes the root cause of the dependency resolution failures:

1. **Reset unpublished package versions**: Reset media-image and media-other from 0.3.4 back to 0.3.1 to match what's actually published on PyPI
2. **Fix CI script overwriting**: Modify CI script to only update dependencies for packages that were actually changed, preventing it from overwriting manually corrected dependency versions
3. **Bump version**: Bump to 0.4.6 to trigger the corrected workflow

## Root Cause

The CI script was automatically updating ALL package dependencies based on their individual pyproject.toml versions, even when those versions were never successfully published to PyPI. This caused it to overwrite manually corrected dependency constraints.

## Test plan

- [ ] Merge this PR
- [ ] Verify 0.4.6 publishes successfully with correct dependencies
- [ ] Test pip install comfyui-workflow-templates==0.4.6 works without errors