### PR TITLE
Rebuild media-api package with nano banana assets

### DIFF
--- a/packages/media_api/pyproject.toml
+++ b/packages/media_api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-api"
-version = "0.3.4"
+version = "0.3.6"
 description = "Media bundle containing API-driven workflow assets"
 readme = {text = "Media bundle containing API-driven workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.6"
+version = "0.4.7"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "comfyui-workflow-templates-core>=0.3.1",
-    "comfyui-workflow-templates-media-api>=0.3.4",
+    "comfyui-workflow-templates-media-api>=0.3.6",
     "comfyui-workflow-templates-media-video>=0.3.1",
     "comfyui-workflow-templates-media-image>=0.3.1",
     "comfyui-workflow-templates-media-other>=0.3.1",
@@ -31,7 +31,7 @@ video = ["comfyui-workflow-templates-media-video>=0.3.1"]
 image = ["comfyui-workflow-templates-media-image>=0.3.1"]
 other = ["comfyui-workflow-templates-media-other>=0.3.1"]
 all = [
-    "comfyui-workflow-templates-media-api>=0.3.4",
+    "comfyui-workflow-templates-media-api>=0.3.6",
     "comfyui-workflow-templates-media-video>=0.3.1",
     "comfyui-workflow-templates-media-image>=0.3.1",
     "comfyui-workflow-templates-media-other>=0.3.1",


### PR DESCRIPTION
## Summary

Rebuild media-api package to include the nano banana assets that were missing.

- Bump media-api from 0.3.4 to 0.3.6 to trigger rebuild
- Bump meta package to 0.4.7 with updated dependency
- This will rebuild media-api with the nano banana templates that were added in PR #263

## Issue

The nano banana templates were added to the repo but the media-api package wasn't rebuilt, so the assets weren't available at the CDN endpoints like http://127.0.0.1:8188/templates/api_nano_banana_pro-2.webp

## Test plan

- [ ] Merge this PR
- [ ] Verify media-api 0.3.6 publishes successfully  
- [ ] Test that nano banana assets are accessible after installing new version