### PR TITLE
Fix dependency versioning: use exact pinning for asset packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.7"
+version = "0.4.8"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -18,23 +18,23 @@ classifiers = [
 ]
 
 dependencies = [
-    "comfyui-workflow-templates-core>=0.3.1",
-    "comfyui-workflow-templates-media-api>=0.3.6",
-    "comfyui-workflow-templates-media-video>=0.3.1",
-    "comfyui-workflow-templates-media-image>=0.3.1",
-    "comfyui-workflow-templates-media-other>=0.3.1",
+    "comfyui-workflow-templates-core==0.3.2",
+    "comfyui-workflow-templates-media-api==0.3.6",
+    "comfyui-workflow-templates-media-video==0.3.1",
+    "comfyui-workflow-templates-media-image==0.3.1",
+    "comfyui-workflow-templates-media-other==0.3.1",
 ]
 
 [project.optional-dependencies]
-api = ["comfyui-workflow-templates-media-api>=0.3.4"]
-video = ["comfyui-workflow-templates-media-video>=0.3.1"]
-image = ["comfyui-workflow-templates-media-image>=0.3.1"]
-other = ["comfyui-workflow-templates-media-other>=0.3.1"]
+api = ["comfyui-workflow-templates-media-api==0.3.6"]
+video = ["comfyui-workflow-templates-media-video==0.3.1"]
+image = ["comfyui-workflow-templates-media-image==0.3.1"]
+other = ["comfyui-workflow-templates-media-other==0.3.1"]
 all = [
-    "comfyui-workflow-templates-media-api>=0.3.6",
-    "comfyui-workflow-templates-media-video>=0.3.1",
-    "comfyui-workflow-templates-media-image>=0.3.1",
-    "comfyui-workflow-templates-media-other>=0.3.1",
+    "comfyui-workflow-templates-media-api==0.3.6",
+    "comfyui-workflow-templates-media-video==0.3.1",
+    "comfyui-workflow-templates-media-image==0.3.1",
+    "comfyui-workflow-templates-media-other==0.3.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/ci_version_manager.py
+++ b/scripts/ci_version_manager.py
@@ -114,8 +114,8 @@ def update_dependencies() -> None:
             
             for pkg, version in versions.items():
                 pip_name = f"comfyui-workflow-templates-{pkg.replace('_', '-')}"
-                pattern = rf'("{re.escape(pip_name)}>=)[^"]+(")'
-                replacement = rf'\g<1>{version}\g<2>'
+                pattern = rf'("{re.escape(pip_name)})[>!=]+[^"]+(")'
+                replacement = rf'\g<1>=={version}\g<2>'
                 text = re.sub(pattern, replacement, text)
             
             Path(meta_path).write_text(text)


### PR DESCRIPTION
## Summary

Fix the fundamental flaw in dependency versioning by switching from  to  for exact version pinning.

## Problem

Using  allows pip to use any version 0.3.4 or higher, but won't automatically upgrade to newer versions. This causes issues where:
- User installs 0.4.7 meta package
- Gets media-api 0.3.5 (satisfies >=0.3.4) 
- But nano banana assets are in 0.3.6
- Assets are missing even though install "succeeds"

## Solution

- Change all dependencies from  to  for exact version pinning
- Update CI script to use  when updating dependencies  
- Bump to 0.4.8 to test the fix

## Benefits

- Users get exact package versions with correct assets
- No more "missing assets" issues from version mismatches
- Predictable, deterministic installs
- Forces proper coordination between package versions

## Test plan

- [ ] Merge this PR
- [ ] Verify 0.4.8 publishes with exact dependencies
- [ ] Test that fresh install gets correct asset versions
- [ ] Verify nano banana assets are accessible