### PR TITLE
Fix CI script regex for exact version pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.8"
+version = "0.4.9"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/ci_version_manager.py
+++ b/scripts/ci_version_manager.py
@@ -114,7 +114,8 @@ def update_dependencies() -> None:
             
             for pkg, version in versions.items():
                 pip_name = f"comfyui-workflow-templates-{pkg.replace('_', '-')}"
-                pattern = rf'("{re.escape(pip_name)})[>!=]+[^"]+(")'
+                # Match the package name followed by any version specifier
+                pattern = rf'("{re.escape(pip_name)})[>!=]+[0-9.]+(")'
                 replacement = rf'\g<1>=={version}\g<2>'
                 text = re.sub(pattern, replacement, text)
             


### PR DESCRIPTION
## Summary

Fix the regex pattern in the CI script that was preventing exact version pinning from working correctly.

## Problem

The published 0.4.8 package still had  dependencies instead of  exact pinning because the CI script regex wasn't correctly matching and replacing the version specifiers.

The pattern  was too broad and wasn't properly replacing existing  versions.

## Solution

- Fix regex pattern to  to specifically match version numbers
- Bump to 0.4.9 to test the corrected exact version pinning

## Test plan

- [ ] Merge this PR
- [ ] Verify 0.4.9 publishes with actual  dependencies (not )
- [ ] Test that normal pip install gets exact versions and nano banana works