### PR TITLE
Fix dependencies to use actual published versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.4.9"
+version = "0.5.0"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -19,19 +19,19 @@ classifiers = [
 
 dependencies = [
     "comfyui-workflow-templates-core==0.3.2",
-    "comfyui-workflow-templates-media-api==0.3.6",
+    "comfyui-workflow-templates-media-api==0.3.7",
     "comfyui-workflow-templates-media-video==0.3.1",
     "comfyui-workflow-templates-media-image==0.3.1",
     "comfyui-workflow-templates-media-other==0.3.1",
 ]
 
 [project.optional-dependencies]
-api = ["comfyui-workflow-templates-media-api==0.3.6"]
+api = ["comfyui-workflow-templates-media-api==0.3.7"]
 video = ["comfyui-workflow-templates-media-video==0.3.1"]
 image = ["comfyui-workflow-templates-media-image==0.3.1"]
 other = ["comfyui-workflow-templates-media-other==0.3.1"]
 all = [
-    "comfyui-workflow-templates-media-api==0.3.6",
+    "comfyui-workflow-templates-media-api==0.3.7",
     "comfyui-workflow-templates-media-video==0.3.1",
     "comfyui-workflow-templates-media-image==0.3.1",
     "comfyui-workflow-templates-media-other==0.3.1",


### PR DESCRIPTION
## Summary

Fix dependency versions to use packages that actually exist on PyPI.

## Problem

Version 0.4.9 was trying to install media-api==0.3.6, but that version was never successfully published to PyPI. Only these versions exist:
- 0.3.0, 0.3.1, 0.3.5, 0.3.7

## Solution

- Change media-api dependency from 0.3.6 → 0.3.7 (latest published version)
- Bump to 0.5.0 to test with correct versions

Version 0.3.7 should contain the nano banana assets since it was published after the nano banana was added.

## Test plan

- [ ] Merge this PR
- [ ] Verify 0.5.0 installs successfully with media-api 0.3.7
- [ ] Test nano banana assets are accessible