### PR TITLE
Split workflow responsibilities to prevent false publish triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,6 +112,11 @@ jobs:
             echo "No packages to build"
           fi
 
+      - name: Update main dependencies to match current subpackage versions
+        run: |
+          source .venv/bin/activate
+          python scripts/ci_version_manager.py --update-dependencies-only
+          
       - name: Sync manifest and bundle assets
         run: |
           source .venv/bin/activate

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -27,23 +27,23 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Auto-bump versions if needed
+      - name: Auto-bump subpackage versions if needed
         run: |
-          python scripts/ci_version_manager.py
+          python scripts/ci_version_manager.py --subpackages-only
           
       - name: Sync manifests and bundles
         run: |
           python scripts/sync_bundles.py
           
-      - name: Commit version bumps and manifest updates to PR
+      - name: Commit subpackage version bumps and manifest updates to PR
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add packages/*/pyproject.toml pyproject.toml packages/*/src/*/manifest.json
+          git add packages/*/pyproject.toml packages/*/src/*/manifest.json
           if ! git diff --cached --quiet; then
-            git commit -m "Auto-bump package versions and sync manifests for template changes"
+            git commit -m "Auto-bump subpackage versions and sync manifests for template changes"
             git push origin HEAD
-            echo "✅ Version bumps and manifest updates committed to PR"
+            echo "✅ Subpackage version bumps and manifest updates committed to PR"
           else
-            echo "✅ No version or manifest changes needed"
+            echo "✅ No subpackage version or manifest changes needed"
           fi

--- a/scripts/ci_version_manager.py
+++ b/scripts/ci_version_manager.py
@@ -217,17 +217,34 @@ def update_dependencies() -> None:
         Path(meta_path).write_text(text)
 
 if __name__ == "__main__":
-    packages = get_changed_packages()
-    print(f"Detected changed packages: {sorted(packages)}")
+    import sys
     
-    non_meta_packages = packages - {"meta"}
+    # Check for special flags
+    subpackages_only = "--subpackages-only" in sys.argv
+    update_deps_only = "--update-dependencies-only" in sys.argv
     
-    if non_meta_packages:
-        bump_versions(packages)
+    if update_deps_only:
+        print("Updating main dependencies to match current subpackage versions...")
         update_dependencies()
-        print(f"Auto-bumped individual packages: {sorted(non_meta_packages)}")
+        print("✅ Main dependencies updated")
+        packages = set()  # No packages to build in this mode
+    else:
+        packages = get_changed_packages()
+        print(f"Detected changed packages: {sorted(packages)}")
         
-    # Output all packages that need building (including meta if changed)
+        non_meta_packages = packages - {"meta"}
+        
+        if non_meta_packages:
+            bump_versions(packages)
+            
+            if subpackages_only:
+                print(f"Auto-bumped subpackages only: {sorted(non_meta_packages)}")
+                print("Skipping main dependency updates (--subpackages-only mode)")
+            else:
+                update_dependencies()
+                print(f"Auto-bumped packages and updated dependencies: {sorted(non_meta_packages)}")
+        
+    # Output all packages that need building (including meta if changed)  
     if packages:
         print(" ".join(sorted(packages)))
     else:


### PR DESCRIPTION
## Summary
- Fixed workflow design flaw where subpackage changes would falsely trigger publish workflow
- Split responsibilities: version-check.yml only bumps subpackages, publish.yml updates dependencies when main version actually changes
- Prevents publish workflow from running when only subpackages changed but main version unchanged

## Changes
- **version-check.yml**: Added `--subpackages-only` flag to prevent main dependency updates in PR workflow
- **ci_version_manager.py**: Added flag support for `--subpackages-only` and `--update-dependencies-only` operation modes
- **publish.yml**: Added step to update main dependencies before publishing when main version actually changes

## Test plan
- [x] Verify workflow split prevents false publish triggers
- [ ] Test PR workflow only bumps subpackages without updating main dependencies  
- [ ] Test publish workflow updates dependencies when main version changes
- [ ] Confirm no false publish triggers on subpackage-only PRs