### PR TITLE
Revert workflow split, use simple version check approach

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,16 +23,15 @@ jobs:
       - name: Check if version actually changed
         id: check
         run: |
-          CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          PREVIOUS_VERSION=$(git show HEAD~1:pyproject.toml | python -c "import tomllib, sys; print(tomllib.load(sys.stdin.buffer)['project']['version'])")
-
-          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
-          else
+          OLD_VERSION=$(git show HEAD~1:pyproject.toml | grep 'version = ' | cut -d'"' -f2)
+          NEW_VERSION=$(grep 'version = ' pyproject.toml | cut -d'"' -f2)
+          if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
             echo "changed=false" >> $GITHUB_OUTPUT
-            echo "Version unchanged: $CURRENT_VERSION"
+            echo "Main version unchanged ($NEW_VERSION), skipping publish"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "Version changed from $OLD_VERSION to $NEW_VERSION"
           fi
 
   publish:
@@ -112,11 +111,6 @@ jobs:
             echo "No packages to build"
           fi
 
-      - name: Update main dependencies to match current subpackage versions
-        run: |
-          source .venv/bin/activate
-          python scripts/ci_version_manager.py --update-dependencies-only
-          
       - name: Sync manifest and bundle assets
         run: |
           source .venv/bin/activate

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -27,23 +27,23 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Auto-bump subpackage versions if needed
+      - name: Auto-bump package versions if needed
         run: |
-          python scripts/ci_version_manager.py --subpackages-only
+          python scripts/ci_version_manager.py
           
       - name: Sync manifests and bundles
         run: |
           python scripts/sync_bundles.py
           
-      - name: Commit subpackage version bumps and manifest updates to PR
+      - name: Commit version bumps and manifest updates to PR
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add packages/*/pyproject.toml packages/*/src/*/manifest.json
+          git add pyproject.toml packages/*/pyproject.toml packages/*/src/*/manifest.json
           if ! git diff --cached --quiet; then
-            git commit -m "Auto-bump subpackage versions and sync manifests for template changes"
+            git commit -m "Auto-bump package versions and sync manifests for template changes"
             git push origin HEAD
-            echo "✅ Subpackage version bumps and manifest updates committed to PR"
+            echo "✅ Package version bumps and manifest updates committed to PR"
           else
-            echo "✅ No subpackage version or manifest changes needed"
+            echo "✅ No package version or manifest changes needed"
           fi

--- a/scripts/ci_version_manager.py
+++ b/scripts/ci_version_manager.py
@@ -217,32 +217,15 @@ def update_dependencies() -> None:
         Path(meta_path).write_text(text)
 
 if __name__ == "__main__":
-    import sys
+    packages = get_changed_packages()
+    print(f"Detected changed packages: {sorted(packages)}")
     
-    # Check for special flags
-    subpackages_only = "--subpackages-only" in sys.argv
-    update_deps_only = "--update-dependencies-only" in sys.argv
+    non_meta_packages = packages - {"meta"}
     
-    if update_deps_only:
-        print("Updating main dependencies to match current subpackage versions...")
+    if non_meta_packages:
+        bump_versions(packages)
         update_dependencies()
-        print("✅ Main dependencies updated")
-        packages = set()  # No packages to build in this mode
-    else:
-        packages = get_changed_packages()
-        print(f"Detected changed packages: {sorted(packages)}")
-        
-        non_meta_packages = packages - {"meta"}
-        
-        if non_meta_packages:
-            bump_versions(packages)
-            
-            if subpackages_only:
-                print(f"Auto-bumped subpackages only: {sorted(non_meta_packages)}")
-                print("Skipping main dependency updates (--subpackages-only mode)")
-            else:
-                update_dependencies()
-                print(f"Auto-bumped packages and updated dependencies: {sorted(non_meta_packages)}")
+        print(f"Auto-bumped packages and updated dependencies: {sorted(non_meta_packages)}")
         
     # Output all packages that need building (including meta if changed)  
     if packages:


### PR DESCRIPTION
## Summary
Reverts the complex workflow split (#307) and implements the simpler version check approach.

## Changes
- **version-check.yml**: Back to normal operation - updates both subpackages and main dependencies
- **ci_version_manager.py**: Removed flag-based operation modes
- **publish.yml**: Added simple version comparison to skip publish when main version unchanged

## How it works
1. PRs bump subpackages AND update main dependencies (like before)
2. Publish workflow checks if main version actually changed since last commit
3. If main version unchanged, publish workflow exits early
4. If main version changed, publish workflow runs normally

This prevents false publish triggers when only subpackages changed but main version stays the same.