### PR TITLE
Fix version check grep pattern

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Check if version actually changed
         id: check
         run: |
-          OLD_VERSION=$(git show HEAD~1:pyproject.toml | grep 'version = ' | cut -d'"' -f2)
-          NEW_VERSION=$(grep 'version = ' pyproject.toml | cut -d'"' -f2)
+          OLD_VERSION=$(git show HEAD~1:pyproject.toml | grep -E '^\s*version\s*=' | cut -d'"' -f2)
+          NEW_VERSION=$(grep -E '^\s*version\s*=' pyproject.toml | cut -d'"' -f2)
           if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "Main version unchanged ($NEW_VERSION), skipping publish"


### PR DESCRIPTION
## Summary
Fixes the version check in publish workflow that was failing with "invalid format 'py312'" error.

## Problem
The grep pattern `grep 'version = '` was matching both:
- `version = "0.7.10"` (project version)
- `target-version = "py312"` (ruff config)

When using `cut -d'"' -f2`, it was getting "py312" instead of the actual version number.

## Solution
Changed to `grep -E '^\s*version\s*='` to only match the project version line at the start of a line.

## Test
```bash
$ grep -E '^\s*version\s*=' pyproject.toml  < /dev/null |  cut -d'"' -f2
0.7.10
```

This fixes the workflow failure from https://github.com/Comfy-Org/workflow_templates/actions/runs/19605536625/job/56143843335