### PR TITLE
fix: update media-api dependency to 0.3.13 for v0.7.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,20 +18,20 @@ classifiers = [
 ]
 
 dependencies = [
-    "comfyui-workflow-templates-core==0.3.8",
-    "comfyui-workflow-templates-media-api==0.3.13",
+    "comfyui-workflow-templates-core==0.3.9",
+    "comfyui-workflow-templates-media-api==0.3.14",
     "comfyui-workflow-templates-media-video==0.3.12",
     "comfyui-workflow-templates-media-image==0.3.13",
     "comfyui-workflow-templates-media-other==0.3.8",
 ]
 
 [project.optional-dependencies]
-api = ["comfyui-workflow-templates-media-api==0.3.13"]
+api = ["comfyui-workflow-templates-media-api==0.3.14"]
 video = ["comfyui-workflow-templates-media-video==0.3.12"]
 image = ["comfyui-workflow-templates-media-image==0.3.13"]
 other = ["comfyui-workflow-templates-media-other==0.3.8"]
 all = [
-    "comfyui-workflow-templates-media-api==0.3.13",
+    "comfyui-workflow-templates-media-api==0.3.14",
     "comfyui-workflow-templates-media-video==0.3.12",
     "comfyui-workflow-templates-media-image==0.3.13",
     "comfyui-workflow-templates-media-other==0.3.8",


### PR DESCRIPTION
- Fix dependency issue where media-api==0.3.14 was not available on PyPI
- PyPI only has up to 0.3.13 version
- Bump version to 0.7.18 to resolve installation error