### PR TITLE
Add dependency synchronization workflow

### DIFF
--- a/.github/workflows/sync-dependencies.yml
+++ b/.github/workflows/sync-dependencies.yml
@@ -1,0 +1,315 @@
+name: Sync Package Dependencies
+
+# This workflow syncs main package dependencies when the main version is updated.
+# It runs as the final step AFTER version auto-bumping to ensure all dependencies 
+# match the latest subpackage versions (post auto-bump).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+
+jobs:
+  check-main-version-change:
+    runs-on: ubuntu-latest
+    outputs:
+      main-version-changed: ${{ steps.check.outputs.changed }}
+      new-version: ${{ steps.check.outputs.version }}
+      pr-number: ${{ steps.get-pr.outputs.pr-number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Get PR number from merge commit
+        id: get-pr
+        run: |
+          # Try to extract PR number from commit message (for merge commits)
+          PR_NUMBER=$(git log --format=%B -n 1 | grep -o '#[0-9]\+' | head -1 | sed 's/#//')
+          if [ -n "$PR_NUMBER" ]; then
+            echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "Found PR number: #$PR_NUMBER"
+          else
+            echo "pr-number=" >> $GITHUB_OUTPUT
+            echo "No PR number found in commit message"
+          fi
+
+      - name: Check if main package version changed
+        id: check
+        run: |
+          # Get the latest commits to ensure we're reading post auto-bump state
+          git pull origin main || true
+          
+          OLD_VERSION=$(git show HEAD~1:pyproject.toml | grep -E '^\s*version\s*=' | cut -d'"' -f2)
+          NEW_VERSION=$(grep -E '^\s*version\s*=' pyproject.toml | cut -d'"' -f2)
+          
+          echo "Previous main version: $OLD_VERSION"
+          echo "Current main version: $NEW_VERSION"
+          
+          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "✅ Main package version changed from $OLD_VERSION to $NEW_VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ Main package version unchanged ($NEW_VERSION)"
+          fi
+
+  sync-dependencies:
+    needs: check-main-version-change
+    if: needs.check-main-version-change.outputs.main-version-changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      dependencies-updated: ${{ steps.check-changes.outputs.dependencies-updated }}
+      sync-summary: ${{ steps.generate-summary.outputs.summary }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Sync dependencies to match current subpackage versions
+        run: |
+          echo "=== Syncing Main Package Dependencies ==="
+          echo "Main package version: ${{ needs.check-main-version-change.outputs.new-version }}"
+          
+          # Ensure we have the latest state (in case auto-bump made additional commits)
+          git pull origin main || true
+          
+          echo ""
+          echo "=== Reading Current Subpackage Versions ==="
+          
+          # Read current versions from all subpackages
+          declare -A CURRENT_VERSIONS
+          
+          for pkg_dir in packages/*/; do
+            if [ -f "$pkg_dir/pyproject.toml" ]; then
+              pkg_name=$(basename "$pkg_dir")
+              current_version=$(grep -E '^\s*version\s*=' "$pkg_dir/pyproject.toml" | cut -d'"' -f2)
+              CURRENT_VERSIONS[$pkg_name]=$current_version
+              echo "📦 Found $pkg_name version: $current_version"
+            fi
+          done
+          
+          # Update main package dependencies
+          echo ""
+          echo "=== Updating Dependencies ==="
+          
+          # Create a backup
+          cp pyproject.toml pyproject.toml.backup
+          
+          # Update dependencies in pyproject.toml
+          python3 << 'EOF'
+          import re
+          
+          # Package name mapping
+          package_mapping = {
+              'core': 'comfyui-workflow-templates-core',
+              'media_api': 'comfyui-workflow-templates-media-api', 
+              'media_video': 'comfyui-workflow-templates-media-video',
+              'media_image': 'comfyui-workflow-templates-media-image',
+              'media_other': 'comfyui-workflow-templates-media-other'
+          }
+          
+          # Read current subpackage versions
+          versions = {}
+          import os
+          for pkg in package_mapping.keys():
+              pyproject_path = f"packages/{pkg}/pyproject.toml"
+              if os.path.exists(pyproject_path):
+                  with open(pyproject_path) as f:
+                      content = f.read()
+                      match = re.search(r'version\s*=\s*"([^"]+)"', content)
+                      if match:
+                          versions[pkg] = match.group(1)
+                          print(f"Read {pkg}: {versions[pkg]}")
+          
+          # Update main pyproject.toml
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          
+          updated = False
+          for pkg, pip_name in package_mapping.items():
+              if pkg in versions:
+                  # Update in dependencies section
+                  pattern = rf'("{re.escape(pip_name)})==([0-9.]+)(")'
+                  replacement = rf'\g<1>=={versions[pkg]}\g<3>'
+                  new_content = re.sub(pattern, replacement, content)
+                  
+                  if new_content != content:
+                      print(f"Updated {pip_name}: {versions[pkg]}")
+                      content = new_content
+                      updated = True
+          
+          if updated:
+              with open('pyproject.toml', 'w') as f:
+                  f.write(content)
+              print("Dependencies updated successfully")
+          else:
+              print("No dependency updates needed")
+          EOF
+
+      - name: Check if dependencies were updated
+        id: check-changes
+        run: |
+          if ! diff -q pyproject.toml pyproject.toml.backup > /dev/null 2>&1; then
+            echo "dependencies-updated=true" >> $GITHUB_OUTPUT
+            echo "Dependencies were updated:"
+            diff pyproject.toml.backup pyproject.toml || true
+            
+            # Save diff for PR comment
+            diff pyproject.toml.backup pyproject.toml > dependency_changes.diff || true
+          else
+            echo "dependencies-updated=false" >> $GITHUB_OUTPUT
+            echo "No dependency changes made"
+            echo "" > dependency_changes.diff
+          fi
+          rm pyproject.toml.backup
+
+      - name: Generate sync summary
+        id: generate-summary
+        run: |
+          MAIN_VERSION="${{ needs.check-main-version-change.outputs.new-version }}"
+          
+          # Read current subpackage versions
+          SUBPACKAGE_INFO=""
+          for pkg_dir in packages/*/; do
+            if [ -f "$pkg_dir/pyproject.toml" ]; then
+              pkg_name=$(basename "$pkg_dir")
+              current_version=$(grep -E '^\s*version\s*=' "$pkg_dir/pyproject.toml" | cut -d'"' -f2)
+              SUBPACKAGE_INFO="$SUBPACKAGE_INFO- **$pkg_name**: \`$current_version\`\n"
+            fi
+          done
+          
+          # Create summary
+          if [ "${{ steps.check-changes.outputs.dependencies-updated }}" = "true" ]; then
+            SUMMARY="## 🔄 Package Dependencies Synchronized
+
+### Main Package Version
+- **comfyui-workflow-templates**: \`$MAIN_VERSION\`
+
+### Current Subpackage Versions
+$SUBPACKAGE_INFO
+
+### ✅ Status
+Dependencies have been **automatically updated** to match current subpackage versions.
+
+### Changes Made
+\`\`\`diff
+$(cat dependency_changes.diff)
+\`\`\`
+
+The main package dependencies are now in sync with the latest subpackage versions."
+          else
+            SUMMARY="## ✅ Package Dependencies Already in Sync
+
+### Main Package Version
+- **comfyui-workflow-templates**: \`$MAIN_VERSION\`
+
+### Current Subpackage Versions
+$SUBPACKAGE_INFO
+
+### Status
+No dependency updates were needed. All dependencies are already synchronized."
+          fi
+          
+          # Save summary to output (escape newlines for GitHub Actions)
+          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          echo "$SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Commit dependency updates
+        if: steps.check-changes.outputs.dependencies-updated == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+          git add pyproject.toml
+          git commit -m "Auto-sync dependencies for main package v${{ needs.check-main-version-change.outputs.new-version }}
+
+          🤖 Generated with [Claude Code](https://claude.ai/code)
+
+          Co-Authored-By: Claude <noreply@anthropic.com>"
+          
+          git push origin main
+          
+          echo "✅ Dependencies synchronized and committed"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "=== Dependency Sync Summary ==="
+          echo "Main version: ${{ needs.check-main-version-change.outputs.new-version }}"
+          echo "Dependencies updated: ${{ steps.check-changes.outputs.dependencies-updated }}"
+          echo "This workflow ensures all dependencies are in sync when main version changes."
+
+  comment-on-pr:
+    needs: [check-main-version-change, sync-dependencies]
+    if: always() && needs.check-main-version-change.outputs.pr-number != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment on PR with sync status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ needs.check-main-version-change.outputs.pr-number }};
+            const mainVersionChanged = '${{ needs.check-main-version-change.outputs.main-version-changed }}';
+            const syncJobStatus = '${{ needs.sync-dependencies.result }}';
+            const dependenciesUpdated = '${{ needs.sync-dependencies.outputs.dependencies-updated }}';
+            
+            let comment;
+            
+            if (mainVersionChanged === 'false') {
+              comment = `## 🔍 Dependency Sync Check
+              
+**Status**: No action needed
+**Reason**: Main package version was not changed in this PR.
+
+The dependency sync workflow only runs when the main package version (in \`pyproject.toml\`) is updated.`;
+            } else if (syncJobStatus === 'success') {
+              const summary = \`${{ needs.sync-dependencies.outputs.sync-summary }}\`;
+              comment = summary + `
+
+---
+*🤖 This comment was automatically generated by the Dependency Sync workflow*`;
+            } else if (syncJobStatus === 'failure') {
+              comment = `## ❌ Dependency Sync Failed
+
+**Status**: Failed to synchronize dependencies
+**Main Version**: \`${{ needs.check-main-version-change.outputs.new-version }}\`
+
+The dependency synchronization process encountered an error. Please check the workflow logs for details.
+
+---
+*🤖 This comment was automatically generated by the Dependency Sync workflow*`;
+            } else {
+              comment = `## ⏭️ Dependency Sync Skipped
+
+**Status**: Sync job was skipped
+**Main Version**: \`${{ needs.check-main-version-change.outputs.new-version }}\`
+
+The dependency sync workflow was triggered but the sync job did not run. This may occur if there were issues with the workflow conditions.
+
+---
+*🤖 This comment was automatically generated by the Dependency Sync workflow*`;
+            }
+
+            // Post comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: comment
+            });
+            
+            console.log(\`Posted comment to PR #\${prNumber}\`);


### PR DESCRIPTION
This workflow automatically syncs main package dependencies when the main version is updated:

- Triggers when pyproject.toml version changes on main branch
- Reads latest subpackage versions (post auto-bump)
- Updates main package dependencies to match current subpackage versions
- Posts detailed status comments to originating PRs
- Ensures dependency consistency before package publishing

Fixes the issue where subpackages get version-bumped but main package dependencies remain outdated, preventing proper publishing of new subpackage versions.

🤖 Generated with Claude Code