### PR TITLE
Fix syntax errors in sync-dependencies workflow

### DIFF
--- a/.github/workflows/sync-dependencies.yml
+++ b/.github/workflows/sync-dependencies.yml
@@ -275,7 +275,7 @@ No dependency updates were needed. All dependencies are already synchronized."
 **Status**: No action needed
 **Reason**: Main package version was not changed in this PR.
 
-The dependency sync workflow only runs when the main package version (in \`pyproject.toml\`) is updated.`;
+The dependency sync workflow only runs when the main package version (in \\\`pyproject.toml\\\`) is updated.`;
             } else if (syncJobStatus === 'success') {
               const summary = `${{ needs.sync-dependencies.outputs.sync-summary }}`;
               comment = summary + `
@@ -286,7 +286,7 @@ The dependency sync workflow only runs when the main package version (in \`pypro
               comment = `## ❌ Dependency Sync Failed
 
 **Status**: Failed to synchronize dependencies
-**Main Version**: \`${{ needs.check-main-version-change.outputs.new-version }}\`
+**Main Version**: \\\`${{ needs.check-main-version-change.outputs.new-version }}\\\`
 
 The dependency synchronization process encountered an error. Please check the workflow logs for details.
 
@@ -296,7 +296,7 @@ The dependency synchronization process encountered an error. Please check the wo
               comment = `## ⏭️ Dependency Sync Skipped
 
 **Status**: Sync job was skipped
-**Main Version**: \`${{ needs.check-main-version-change.outputs.new-version }}\`
+**Main Version**: \\\`${{ needs.check-main-version-change.outputs.new-version }}\\\`
 
 The dependency sync workflow was triggered but the sync job did not run. This may occur if there were issues with the workflow conditions.
 


### PR DESCRIPTION
## 🐛 Fix Workflow Syntax Errors

### Problem
The sync-dependencies workflow was failing due to JavaScript template string syntax errors:
- Invalid backtick escaping in template literals 
- Incorrect template literal syntax in GitHub Actions script

### Solution
- Fixed template string syntax in the PR comment generation script
- Removed invalid escaping that caused YAML parsing errors

### Testing
This should resolve the workflow failures seen in:
- Run #19865871464 (bump-version-0.7.31)
- Run #19865858153 (main branch)  
- Run #19865799196 (fix-dependency-sync branch)

The workflow should now execute successfully when main package version changes.

### Files Changed
- : Fixed JavaScript syntax errors

🤖 Generated with [Claude Code](https://claude.ai/code)