### PR TITLE
Bump version to 0.7.32 and test dependency sync workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.7.30"
+version = "0.7.32"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## 🚀 Version Bump & Dependency Sync Test

### Purpose
This PR bumps the main package version to trigger the new dependency synchronization workflow and resolve the publishing issues.

### Background
After PR #358, subpackages were version-bumped but main package dependencies remained outdated:
- **core**: 0.3.16 (dependency was 0.3.12)
- **media_api**: 0.3.17 (dependency was 0.3.14)  
- **media_image**: 0.3.19 (dependency was 0.3.17)
- **media_other**: 0.3.24 (dependency was 0.3.19)
- **media_video**: 0.3.13 (dependency was 0.3.12)

### What This PR Does
1. **Bumps main version**: 0.7.30 → 0.7.32
2. **Triggers dependency sync**: The new workflow will automatically update dependencies
3. **Enables proper publishing**: All subpackages can now be published correctly
4. **Tests workflow**: Validates the fix for the publishing pipeline

### Expected Workflow Actions
1. ✅ Dependency sync workflow should trigger and run successfully
2. ✅ Main package dependencies will be updated to match subpackage versions
3. ✅ Publish workflow will run and publish all packages correctly
4. ✅ PR will receive automated status comment from sync workflow

### Testing the Fix
This PR serves as a test case for the complete publishing pipeline fix that resolves issues introduced in commit 56f49c789fb3383d78ad2890fd0d6683da71e74d.

🤖 Generated with [Claude Code](https://claude.ai/code)