### PR TITLE
chore: bump version to 7.35

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.7.30"
+version = "7.35"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Version Bump to 7.35

This PR bumps the package version from `0.7.30` to `7.35`.

### What's Changed
- Updated version in `pyproject.toml`

### Next Steps
After merging this PR:
1. GitHub Actions will automatically publish to PyPI
2. The ComfyUI dependency will be updated automatically

---
*This PR was created by the auto-pr-script*