### PR TITLE
feat: add includeOnDistributions and fileByDistribution to blueprint schema

### DIFF
--- a/blueprints/index.schema.json
+++ b/blueprints/index.schema.json
@@ -127,24 +127,12 @@
           },
           "description": "Distributions on which the blueprint is included. If omitted, the blueprint is included on all distributions."
         },
-        "fileByDistribution": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "cloud": {
-              "type": "string",
-              "description": "Filename override for cloud distribution"
-            },
-            "localhost": {
-              "type": "string",
-              "description": "Filename override for localhost distribution"
-            },
-            "desktop": {
-              "type": "string",
-              "description": "Filename override for desktop distribution"
-            }
+        "requiresCustomNodes": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "description": "Per-distribution filename overrides. If absent, or if a key is missing, defaults to {name}.json"
+          "description": "Custom node package IDs required for this blueprint. Blueprints with this field are hidden on non-cloud distributions."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Adds two new optional fields to `blueprintInfo` in `index.schema.json`:

- **`includeOnDistributions`**: Array of distribution names (`cloud`, `localhost`, `desktop`) controlling which distributions include a blueprint. Omitted = included everywhere.
- **`fileByDistribution`**: Per-distribution filename overrides. Falls back to `{name}.json` if absent.

Both fields have `additionalProperties: false` to match the parent schema pattern.

**Must merge first** — other repos depend on this schema update (the parent `blueprintInfo` has `additionalProperties: false`).