### PR TITLE
feat(knowledge): extract blog content from blog.comfy.org

### DIFF
--- a/site/knowledge/blog/_index.json
+++ b/site/knowledge/blog/_index.json
@@ -1,0 +1,776 @@
+[
+  {
+    "title": "The Complete AI Upscaling Handbook: All in ComfyUI",
+    "url": "https://blog.comfy.org/p/upscaling-in-comfyui",
+    "date": "2026-02-06",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ACE-Step 1.5 is Now Available in ComfyUI",
+    "url": "https://blog.comfy.org/p/ace-step-15-is-now-available-in-comfyui",
+    "date": "2026-02-04",
+    "category": "model-release"
+  },
+  {
+    "title": "Grok Imagine Now Available in ComfyUI",
+    "url": "https://blog.comfy.org/p/grok-imagine-now-available-in-comfyui",
+    "date": "2026-01-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Z-Image Day-0 Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/z-image-day-0-support-in-comfyui",
+    "date": "2026-01-28",
+    "category": "model-release"
+  },
+  {
+    "title": "Vidu Q2 Now Live in ComfyUI",
+    "url": "https://blog.comfy.org/p/vidu-q2-now-live-in-comfyui",
+    "date": "2026-01-22",
+    "category": "model-release"
+  },
+  {
+    "title": "Seedance 1.5 Pro Now in ComfyUI",
+    "url": "https://blog.comfy.org/p/seedance-1-5-pro-now-in-comfyui",
+    "date": "2026-01-21",
+    "category": "model-release"
+  },
+  {
+    "title": "Meshy 6 Now Available in ComfyUI",
+    "url": "https://blog.comfy.org/p/meshy-6-now-available-in-comfyui",
+    "date": "2026-01-21",
+    "category": "model-release"
+  },
+  {
+    "title": "Introducing FIBO Edit: Precision Image Editing",
+    "url": "https://blog.comfy.org/p/introducing-bria-fibo-edit-precision-image",
+    "date": "2026-01-21",
+    "category": "model-release"
+  },
+  {
+    "title": "WAN 2.6 Reference-to-Video",
+    "url": "https://blog.comfy.org/p/wan26-reference-to-video",
+    "date": "2026-01-16",
+    "category": "model-release"
+  },
+  {
+    "title": "FLUX.2 [klein] 4B - Fast Local Image Editing",
+    "url": "https://blog.comfy.org/p/flux2-klein-4b-fast-local-image-editing",
+    "date": "2026-01-16",
+    "category": "model-release"
+  },
+  {
+    "title": "Preprocessor and Frame Interpolation Workflows in ComfyUI",
+    "url": "https://blog.comfy.org/p/preprocessor-and-frame-interpolation",
+    "date": "2026-01-14",
+    "category": "tutorial"
+  },
+  {
+    "title": "Kling 2.6 Motion Control in ComfyUI",
+    "url": "https://blog.comfy.org/p/kling-26-motion-control",
+    "date": "2026-01-13",
+    "category": "model-release"
+  },
+  {
+    "title": "Upscaler 4K & Malicious Node Pack Post-Mortem",
+    "url": "https://blog.comfy.org/p/upscaler-4k-malicious-node-pack-post",
+    "date": "2026-01-11",
+    "category": "other"
+  },
+  {
+    "title": "Made with ComfyUI 2025: From Open Source to the World Stage",
+    "url": "https://blog.comfy.org/p/made-with-comfyui-2025-from-open",
+    "date": "2026-01-09",
+    "category": "community"
+  },
+  {
+    "title": "New ComfyUI Optimizations for NVIDIA",
+    "url": "https://blog.comfy.org/p/new-comfyui-optimizations-for-nvidia",
+    "date": "2026-01-09",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "LTX 2 Open Source Audio Video AI",
+    "url": "https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai",
+    "date": "2026-01-08",
+    "category": "model-release"
+  },
+  {
+    "title": "New Template Library and Partner Nodes",
+    "url": "https://blog.comfy.org/p/new-template-library-and-partner",
+    "date": "2026-01-08",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Official AMD ROCm Support Arrives",
+    "url": "https://blog.comfy.org/p/official-amd-rocm-support-arrives",
+    "date": "2026-01-06",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ComfyUI Repo Will Move to Comfy Org Account",
+    "url": "https://blog.comfy.org/p/comfyui-repo-will-moved-to-comfy",
+    "date": "2025-12-29",
+    "category": "other"
+  },
+  {
+    "title": "Generate High-Fidelity 3D Models",
+    "url": "https://blog.comfy.org/p/generate-high-fidelity-3d-model",
+    "date": "2025-12-25",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Qwen Image Edit 2511 and Qwen Image",
+    "url": "https://blog.comfy.org/p/qwen-image-edit-2511-and-qwen-image",
+    "date": "2025-12-25",
+    "category": "model-release"
+  },
+  {
+    "title": "Meet the New ComfyUI Manager",
+    "url": "https://blog.comfy.org/p/meet-the-new-comfyui-manager",
+    "date": "2025-12-19",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ComfyUI User Survey",
+    "url": "https://blog.comfy.org/p/comfyui-user-survey",
+    "date": "2025-12-13",
+    "category": "community"
+  },
+  {
+    "title": "Comfy Cloud Update: Unified Credit System",
+    "url": "https://blog.comfy.org/p/comfy-cloud-update-unified-credit-system",
+    "date": "2025-12-12",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Ubisoft Open Sources the Chord Model",
+    "url": "https://blog.comfy.org/p/ubisoft-open-sources-the-chord-model",
+    "date": "2025-12-10",
+    "category": "model-release"
+  },
+  {
+    "title": "Kling O1 in ComfyUI: Video Editing",
+    "url": "https://blog.comfy.org/p/kling-o1-in-comfyui-the-video-editing",
+    "date": "2025-12-08",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI Node 2.0",
+    "url": "https://blog.comfy.org/p/comfyui-node-2-0",
+    "date": "2025-12-05",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Echoes of Time: Lighting Up a Historic",
+    "url": "https://blog.comfy.org/p/echoes-of-time-lighting-up-a-historic",
+    "date": "2025-12-11",
+    "category": "community"
+  },
+  {
+    "title": "Z-Image Turbo in ComfyUI: Realism",
+    "url": "https://blog.comfy.org/p/z-image-turbo-in-comfyui-realism",
+    "date": "2025-11-27",
+    "category": "model-release"
+  },
+  {
+    "title": "Topaz Flagship Upscale Models in ComfyUI",
+    "url": "https://blog.comfy.org/p/topazs-flagship-upscale-models-in",
+    "date": "2025-11-27",
+    "category": "model-release"
+  },
+  {
+    "title": "FLUX.2 Day-0 Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/flux2-state-of-the-art-visual-intelligence",
+    "date": "2025-11-27",
+    "category": "model-release"
+  },
+  {
+    "title": "Comfy Cloud: New Features and Pricing",
+    "url": "https://blog.comfy.org/p/comfy-cloud-new-features-and-pricing",
+    "date": "2026-01-23",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "HunyuanVideo 1.5 Native Support",
+    "url": "https://blog.comfy.org/p/hunyuanvideo-15-native-support",
+    "date": "2025-11-25",
+    "category": "model-release"
+  },
+  {
+    "title": "Meet Nano Banana Pro in ComfyUI",
+    "url": "https://blog.comfy.org/p/meet-nano-banana-pro-in-comfyui",
+    "date": "2025-11-21",
+    "category": "model-release"
+  },
+  {
+    "title": "Comfy Challenge 9: CloudCrafted",
+    "url": "https://blog.comfy.org/p/comfy-challenge-9-cloudcrafted",
+    "date": "2025-11-05",
+    "category": "community"
+  },
+  {
+    "title": "Comfy Cloud Is Now in Public Beta",
+    "url": "https://blog.comfy.org/p/comfy-cloud-is-now-in-public-beta",
+    "date": "2025-11-20",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Comfy Challenge 8: Spooky Renders",
+    "url": "https://blog.comfy.org/p/comfy-challenge-8-spooky-renders",
+    "date": "2025-10-29",
+    "category": "community"
+  },
+  {
+    "title": "LTX 2 Now Available in ComfyUI",
+    "url": "https://blog.comfy.org/p/ltx-2-now-available-in-comfyui",
+    "date": "2025-10-28",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI 0.3.66 Updates",
+    "url": "https://blog.comfy.org/p/comfyui-0366-updates",
+    "date": "2025-10-21",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Introducing ImagenWorld",
+    "url": "https://blog.comfy.org/p/introducing-imagenworld",
+    "date": "2025-10-17",
+    "category": "model-release"
+  },
+  {
+    "title": "Veo 3.1 Is Now Available in ComfyUI",
+    "url": "https://blog.comfy.org/p/veo-31-is-now-available-in-comfyui",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI on NVIDIA DGX Spark",
+    "url": "https://blog.comfy.org/p/comfyui-on-nvidia-dgx-spark",
+    "date": "2025-10-13",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Sora 2 API Nodes Now in ComfyUI",
+    "url": "https://blog.comfy.org/p/sora-2-api-nodes-now-in-comfyui",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI 0.3.63 Subgraph Publishing",
+    "url": "https://blog.comfy.org/p/comfyui-0363-subgraph-publishing",
+    "date": "2025-10-06",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Seedance Pro: Frame Control Unlocked",
+    "url": "https://blog.comfy.org/p/frame-control-unlocked-seedance-pro",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Comfy Challenge 6: Heartbeat",
+    "url": "https://blog.comfy.org/p/comfy-challenge-6-heartbeat",
+    "date": "2025-10-01",
+    "category": "community"
+  },
+  {
+    "title": "HUMO and Chroma1 Radiance Support",
+    "url": "https://blog.comfy.org/p/humo-and-chroma1-radiance-support",
+    "date": "2025-09-26",
+    "category": "model-release"
+  },
+  {
+    "title": "Comfy Challenge X: Wan",
+    "url": "https://blog.comfy.org/p/comfy-challenge-x-wan",
+    "date": "2025-09-25",
+    "category": "community"
+  },
+  {
+    "title": "Wan 2.5 Preview API Nodes in ComfyUI",
+    "url": "https://blog.comfy.org/p/wan-25-preview-api-nodes-in-comfyui",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Wan 2.2 Animate and Qwen Image Edit",
+    "url": "https://blog.comfy.org/p/wan22-animate-and-qwen-image-edit-2509",
+    "date": "2025-09-23",
+    "category": "model-release"
+  },
+  {
+    "title": "Pose Alchemy: Comfy Challenge 4 Montage",
+    "url": "https://blog.comfy.org/p/pose-alchemy-comfy-challenge-4-montage",
+    "date": "2025-09-18",
+    "category": "community"
+  },
+  {
+    "title": "Comfy Raises $17M Funding",
+    "url": "https://blog.comfy.org/p/comfy-raises-17m-funding",
+    "date": "2025-09-16",
+    "category": "other"
+  },
+  {
+    "title": "Comfy Cloud",
+    "url": "https://blog.comfy.org/p/comfy-cloud",
+    "date": "2025-09-15",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Seedream 4.0 Now Available in ComfyUI",
+    "url": "https://blog.comfy.org/p/seedream-40-now-available-in-comfyui",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Stable Audio 2.5 Is Now in ComfyUI",
+    "url": "https://blog.comfy.org/p/stable-audio-25-is-now-in-comfyui",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Latent Reforge: Comfy Challenge 3",
+    "url": "https://blog.comfy.org/p/latent-reforge-comfy-challenge-3",
+    "date": "2025-09-09",
+    "category": "community"
+  },
+  {
+    "title": "USO Available in ComfyUI",
+    "url": "https://blog.comfy.org/p/uso-available-in-comfyui",
+    "date": "2025-11-27",
+    "category": "model-release"
+  },
+  {
+    "title": "Falling: The Comfy Challenge 2 Montage",
+    "url": "https://blog.comfy.org/p/falling-the-comfy-challenge-2-montage",
+    "date": "2025-09-04",
+    "category": "community"
+  },
+  {
+    "title": "Wan 2.2 S2V in ComfyUI: Audio-Driven Video",
+    "url": "https://blog.comfy.org/p/wan22-s2v-in-comfyui-audio-driven",
+    "date": "2025-08-29",
+    "category": "model-release"
+  },
+  {
+    "title": "The Comfy Challenge 2: Falling",
+    "url": "https://blog.comfy.org/p/the-comfy-challenge-2-falling",
+    "date": "2025-08-28",
+    "category": "community"
+  },
+  {
+    "title": "Nano Banana via ComfyUI API Nodes",
+    "url": "https://blog.comfy.org/p/nano-banana-via-comfyui-api-nodes",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Day 1 Support of Qwen Image & InstantX",
+    "url": "https://blog.comfy.org/p/day-1-support-of-qwen-image-instantx",
+    "date": "2025-08-26",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI Now Supports Qwen Image ControlNet",
+    "url": "https://blog.comfy.org/p/comfyui-now-supports-qwen-image-controlnet",
+    "date": "2025-08-25",
+    "category": "model-release"
+  },
+  {
+    "title": "Unlimited Parallel API Nodes",
+    "url": "https://blog.comfy.org/p/unlimited-parallel-api-nodes-and",
+    "date": "2025-10-29",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ComfyUI 0.3.51: Frontend Updates",
+    "url": "https://blog.comfy.org/p/comfyui-035-frontend-updates",
+    "date": "2025-08-21",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Qwen Image Edit ComfyUI Support",
+    "url": "https://blog.comfy.org/p/qwen-image-edit-comfyui-support",
+    "date": "2025-08-20",
+    "category": "model-release"
+  },
+  {
+    "title": "The Comfy Challenge: Week 1",
+    "url": "https://blog.comfy.org/p/the-comfy-challenge-week-1",
+    "date": "2025-08-20",
+    "category": "community"
+  },
+  {
+    "title": "ComfyUI Wan 2.2 Fun InP Support",
+    "url": "https://blog.comfy.org/p/comfyui-wan22-fun-inp-support",
+    "date": "2025-08-13",
+    "category": "model-release"
+  },
+  {
+    "title": "Subgraph Official Release",
+    "url": "https://blog.comfy.org/p/subgraph-official-release",
+    "date": "2025-08-07",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Qwen Image in ComfyUI: New Era of Image Understanding",
+    "url": "https://blog.comfy.org/p/qwen-image-in-comfyui-new-era-of",
+    "date": "2025-08-05",
+    "category": "model-release"
+  },
+  {
+    "title": "Wan 2.2 FLF2V ComfyUI Native Support",
+    "url": "https://blog.comfy.org/p/wan22-flf2v-comfyui-native-support",
+    "date": "2025-08-02",
+    "category": "model-release"
+  },
+  {
+    "title": "Flux.1 KREA Dev Lands on ComfyUI",
+    "url": "https://blog.comfy.org/p/flux1-krea-dev-lands-on-comfyui-on",
+    "date": "2025-07-31",
+    "category": "model-release"
+  },
+  {
+    "title": "Wan 2.2 Memory Optimization",
+    "url": "https://blog.comfy.org/p/wan22-memory-optimization",
+    "date": "2025-07-30",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Wan 2.2 Day-0 Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/wan22-day-0-support-in-comfyui",
+    "date": "2025-07-28",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI HiDream E1.1 Native Support",
+    "url": "https://blog.comfy.org/p/comfyui-hidream-e11-native-support",
+    "date": "2025-07-21",
+    "category": "model-release"
+  },
+  {
+    "title": "Marey Realism v1.5 in ComfyUI",
+    "url": "https://blog.comfy.org/p/marey-realism-v15-in-comfyui-built",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Intel OpenVINO Joins Forces with ComfyUI",
+    "url": "https://blog.comfy.org/p/intel-openvino-joins-forces-with",
+    "date": "2025-07-01",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "OmniGen2 Native Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/omnigen2-native-support-in-comfyui",
+    "date": "2025-06-30",
+    "category": "model-release"
+  },
+  {
+    "title": "Flux.1 Kontext Dev Day-0 Support",
+    "url": "https://blog.comfy.org/p/flux1-kontext-dev-day-0-support",
+    "date": "2025-06-26",
+    "category": "model-release"
+  },
+  {
+    "title": "Cosmos Predict2 Now Supported in ComfyUI",
+    "url": "https://blog.comfy.org/p/cosmos-predict2-now-supported-in",
+    "date": "2025-06-17",
+    "category": "model-release"
+  },
+  {
+    "title": "Subgraph Update: Easier Testing",
+    "url": "https://blog.comfy.org/p/subgraph-update-easier-testing",
+    "date": "2025-06-13",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Dependency Resolution and Custom Nodes",
+    "url": "https://blog.comfy.org/p/dependency-resolution-and-custom",
+    "date": "2025-06-08",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Subgraphs Are Coming to ComfyUI",
+    "url": "https://blog.comfy.org/p/subgraphs-are-coming-to-comfyui",
+    "date": "2025-06-05",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Introducing the Node Help Menu",
+    "url": "https://blog.comfy.org/p/introducing-the-node-help-menu",
+    "date": "2025-06-04",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Flux.1 Kontext API Node in Day-1 Workflow",
+    "url": "https://blog.comfy.org/p/flux1-kontext-api-node-in-day-1-workflow",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "Introducing the Comfy Bounty Program",
+    "url": "https://blog.comfy.org/p/introducing-the-comfy-bounty-program",
+    "date": "2025-05-28",
+    "category": "community"
+  },
+  {
+    "title": "ComfyUI API Nodes Wave 2 Is Live",
+    "url": "https://blog.comfy.org/p/comfyui-api-nodes-wave-2-is-live",
+    "date": "2025-10-29",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Wan 2.1 VACE Native Support and ACE",
+    "url": "https://blog.comfy.org/p/wan21-vace-native-support-and-ace",
+    "date": "2025-05-17",
+    "category": "model-release"
+  },
+  {
+    "title": "API Nodes: Login via ComfyUI API Key",
+    "url": "https://blog.comfy.org/p/api-nodes-login-via-comfyui-api-key",
+    "date": "2025-10-29",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Stable Diffusion: Moment of Audio",
+    "url": "https://blog.comfy.org/p/stable-diffusion-moment-of-audio",
+    "date": "2025-05-08",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI Native API Nodes",
+    "url": "https://blog.comfy.org/p/comfyui-native-api-nodes",
+    "date": "2025-10-29",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ComfyUI Now Supports GPT Image 1",
+    "url": "https://blog.comfy.org/p/comfyui-now-supports-gpt-image-1",
+    "date": "2025-10-29",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI Wan 2.1 FLF2V and Wan 2.1 Fun",
+    "url": "https://blog.comfy.org/p/comfyui-wan21-flf2v-and-wan21-fun",
+    "date": "2025-04-20",
+    "category": "model-release"
+  },
+  {
+    "title": "HiDream I1 Native Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/hidream-i1-native-support-in-comfyui",
+    "date": "2025-04-17",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI Manager Joins Comfy Org",
+    "url": "https://blog.comfy.org/p/comfyui-manager-joins-comfy-org",
+    "date": "2025-03-29",
+    "category": "other"
+  },
+  {
+    "title": "Hunyuan3D 2.0 and MultiView Native Support",
+    "url": "https://blog.comfy.org/p/hunyuan3d-20-and-muitiview-native",
+    "date": "2025-03-22",
+    "category": "model-release"
+  },
+  {
+    "title": "Updates for Wan 2.1 and Hunyuan Image",
+    "url": "https://blog.comfy.org/p/updates-for-wan-21-and-hunyuan-image",
+    "date": "2025-03-10",
+    "category": "model-release"
+  },
+  {
+    "title": "Hunyuan Image2Video Day-1 Support",
+    "url": "https://blog.comfy.org/p/hunyuan-image2video-day-1-support",
+    "date": "2025-03-06",
+    "category": "model-release"
+  },
+  {
+    "title": "LTX Video 0.9.5 Day-1 Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/ltx-video-095-day-1-support-in-comfyui",
+    "date": "2025-03-06",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI Frontend 1.10 Update",
+    "url": "https://blog.comfy.org/p/comfyui-frontend-110-update-powerful",
+    "date": "2025-03-05",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Wan 2.1 Video Model Native Support",
+    "url": "https://blog.comfy.org/p/wan21-video-model-native-support",
+    "date": "2025-02-27",
+    "category": "model-release"
+  },
+  {
+    "title": "Lumina Image 2.0 Native Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/lumina-image-20-native-support-in",
+    "date": "2025-03-07",
+    "category": "model-release"
+  },
+  {
+    "title": "Easy Installation in Desktop",
+    "url": "https://blog.comfy.org/p/easy-installation-in-desktop",
+    "date": "2025-02-02",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "How to Get ComfyUI Running on Your Machine",
+    "url": "https://blog.comfy.org/p/how-to-get-comfyui-running-on-your",
+    "date": "2025-01-30",
+    "category": "tutorial"
+  },
+  {
+    "title": "Introducing ComfyUI RFC Process",
+    "url": "https://blog.comfy.org/p/introducing-comfyui-rfc-process-shaping",
+    "date": "2025-01-18",
+    "category": "other"
+  },
+  {
+    "title": "ComfyUI Now Supports NVIDIA Cosmos",
+    "url": "https://blog.comfy.org/p/comfyui-now-supports-nvidia-cosmos",
+    "date": "2025-01-17",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI Turns 2: A Journey and Call for Talent",
+    "url": "https://blog.comfy.org/p/comfyui-turns-2-a-journey-and-call",
+    "date": "2025-01-16",
+    "category": "community"
+  },
+  {
+    "title": "Join the ComfyUI Community Logo Creation",
+    "url": "https://blog.comfy.org/p/join-the-comfyui-community-logo-creation",
+    "date": "2025-01-08",
+    "category": "community"
+  },
+  {
+    "title": "Launching ComfyUI Registry",
+    "url": "https://blog.comfy.org/p/launching-comfyui-registry",
+    "date": "2025-01-03",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ComfyUI 2025 Jan Security Update",
+    "url": "https://blog.comfy.org/p/comfyui-2025-jan-security-update",
+    "date": "2025-01-04",
+    "category": "other"
+  },
+  {
+    "title": "Join the First ComfyUI User Survey",
+    "url": "https://blog.comfy.org/p/join-the-first-comfyui-user-survey",
+    "date": "2025-01-03",
+    "category": "community"
+  },
+  {
+    "title": "Running Hunyuan with 8GB VRAM",
+    "url": "https://blog.comfy.org/p/running-hunyuan-with-8gb-vram-and",
+    "date": "2024-12-28",
+    "category": "tutorial"
+  },
+  {
+    "title": "HunyuanVideo Native Support in ComfyUI",
+    "url": "https://blog.comfy.org/p/hunyuanvideo-native-support-in-comfyui",
+    "date": "2024-12-20",
+    "category": "model-release"
+  },
+  {
+    "title": "Native Localization Support (i18n)",
+    "url": "https://blog.comfy.org/p/native-localization-support-i18n",
+    "date": "2024-12-16",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Masking and Scheduling LoRA and Model Weights",
+    "url": "https://blog.comfy.org/p/masking-and-scheduling-lora-and-model-weights",
+    "date": "2024-12-18",
+    "category": "tutorial"
+  },
+  {
+    "title": "ComfyUI Statement on the Ultralytics Crypto Miner Situation",
+    "url": "https://blog.comfy.org/p/comfyui-statement-on-the-ultralytics-crypto-miner-situation",
+    "date": "2024-12-17",
+    "category": "other"
+  },
+  {
+    "title": "Open Sourcing V1 Desktop",
+    "url": "https://blog.comfy.org/p/open-sourcing-v1-desktop",
+    "date": "2025-01-02",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "SD 3.5 Large ControlNet",
+    "url": "https://blog.comfy.org/p/sd3-5-large-controlnet",
+    "date": "2024-12-17",
+    "category": "model-release"
+  },
+  {
+    "title": "LTXV Day-1 ComfyUI Support",
+    "url": "https://blog.comfy.org/p/ltxv-day-1-comfyui",
+    "date": "2024-12-17",
+    "category": "model-release"
+  },
+  {
+    "title": "Day-1 Support for Flux Tools in ComfyUI",
+    "url": "https://blog.comfy.org/p/day-1-support-for-flux-tools-in-comfyui",
+    "date": "2024-12-17",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI v0.3.0 Release",
+    "url": "https://blog.comfy.org/p/comfyui-v0-3-0-release",
+    "date": "2024-12-17",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "Mochi 1",
+    "url": "https://blog.comfy.org/p/mochi-1",
+    "date": "2024-12-17",
+    "category": "model-release"
+  },
+  {
+    "title": "SD 3.5 Medium",
+    "url": "https://blog.comfy.org/p/sd-35-medium",
+    "date": "2024-12-17",
+    "category": "model-release"
+  },
+  {
+    "title": "Making New UI the Default Option",
+    "url": "https://blog.comfy.org/p/making-new-ui-the-default-option-on-2024-11-15",
+    "date": "2024-12-17",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "SD 3.5 ComfyUI Support",
+    "url": "https://blog.comfy.org/p/sd3-5-comfyui",
+    "date": "2024-12-17",
+    "category": "model-release"
+  },
+  {
+    "title": "ComfyUI V1 Release",
+    "url": "https://blog.comfy.org/p/comfyui-v1-release",
+    "date": "2025-01-02",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ComfyUI v0.2.0 Release",
+    "url": "https://blog.comfy.org/p/comfyui-v0-2-0-release",
+    "date": "2024-12-17",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "ComfyUI v0.1.x Release",
+    "url": "https://blog.comfy.org/p/comfyui-v0-1-x-release-devil-in-the-details-2",
+    "date": "2024-12-17",
+    "category": "feature-announcement"
+  },
+  {
+    "title": "August 2024: Flux Support, New Frontend, For Loops",
+    "url": "https://blog.comfy.org/p/august-2024-flux-support-new-frontend-for-loops-and-more",
+    "date": "2024-12-16",
+    "category": "feature-announcement"
+  }
+]

--- a/site/knowledge/blog/_model-index.json
+++ b/site/knowledge/blog/_model-index.json
@@ -1,0 +1,32 @@
+{
+  "wan": [
+    "wan21-video-model-native-support.md",
+    "wan21-vace-native-support.md",
+    "wan22-day-0-support.md",
+    "wan26-reference-to-video.md",
+    "upscaling-handbook.md"
+  ],
+  "flux": ["flux2-day-0-support.md", "flux2-klein-4b.md"],
+  "hunyuan": [
+    "hunyuanvideo-native-support.md",
+    "hunyuanvideo-15-native-support.md",
+    "hunyuan3d-20-native-support.md"
+  ],
+  "ltx-video": ["ltx-video-095-support.md", "ltx-2-open-source-audio-video.md"],
+  "qwen": ["qwen-image-edit-2511.md"],
+  "sdxl": [],
+  "z-image": ["z-image-day-0-support.md"],
+  "ace-step": ["ace-step-15.md"],
+  "grok": ["grok-imagine.md"],
+  "vidu": ["vidu-q2.md"],
+  "seedance": ["seedance-15-pro.md"],
+  "fibo": ["fibo-edit.md"],
+  "kling": ["kling-26-motion-control.md"],
+  "meshy": ["meshy-6.md"],
+  "nano-banana": ["upscaling-handbook.md"],
+  "seedvr2": ["upscaling-handbook.md"],
+  "topaz": ["upscaling-handbook.md"],
+  "hitpaw": ["upscaling-handbook.md"],
+  "magnific": ["upscaling-handbook.md"],
+  "flashvsr": ["upscaling-handbook.md"]
+}

--- a/site/knowledge/blog/ace-step-15.md
+++ b/site/knowledge/blog/ace-step-15.md
@@ -1,0 +1,27 @@
+# ACE-Step 1.5 is Now Available in ComfyUI
+
+**Date**: 2026-02-04
+**Source**: https://blog.comfy.org/p/ace-step-15-is-now-available-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- Open-source music generation model with commercial-grade quality
+- Generates full songs in under 10 seconds on consumer hardware
+- Hybrid LM + DiT architecture: Language Model plans song structure, DiT handles audio synthesis
+- Full 4-minute song in ~1 second on RTX 5090, under 10 seconds on RTX 3090
+- 50+ language support with strong support for English, Chinese, Japanese, Korean, Spanish, German, French, Portuguese, Italian, Russian
+- Chain-of-Thought planning for coherent long-form compositions
+- Distribution Matching Distillation from Z-Image's DMD2
+- Intrinsic Reinforcement Learning eliminates biases from external reward models
+- Musical coherence score: 4.72
+
+## Benchmarks
+
+- RTX 5090: ~1 second for full 4-minute song
+- RTX 3090: under 10 seconds for full song
+- Musical coherence: 4.72
+
+## Related Templates
+
+- audio_ace_step_1_5_checkpoint

--- a/site/knowledge/blog/amd-rocm-support.md
+++ b/site/knowledge/blog/amd-rocm-support.md
@@ -1,0 +1,10 @@
+# Official AMD ROCm Support Arrives
+
+**Date**: 2026-01-06
+**Source**: https://blog.comfy.org/p/official-amd-rocm-support-arrives
+**Category**: feature-announcement
+
+## Key Facts
+
+- Official AMD ROCm support for ComfyUI
+- Enables running ComfyUI on AMD GPUs natively

--- a/site/knowledge/blog/fibo-edit.md
+++ b/site/knowledge/blog/fibo-edit.md
@@ -1,0 +1,16 @@
+# Introducing FIBO Edit: Precision Image Editing
+
+**Date**: 2026-01-21
+**Source**: https://blog.comfy.org/p/introducing-bria-fibo-edit-precision-image
+**Category**: model-release
+
+## Key Facts
+
+- Bria's JSON-native editing model
+- Trained on 100% licensed data, safe for commercial use
+- Open weights released
+- Precision image editing capabilities
+
+## Related Templates
+
+- image_fibo_edit

--- a/site/knowledge/blog/flux2-day-0-support.md
+++ b/site/knowledge/blog/flux2-day-0-support.md
@@ -1,0 +1,24 @@
+# FLUX.2 Day-0 Support in ComfyUI
+
+**Date**: 2025-11-27
+**Source**: https://blog.comfy.org/p/flux2-state-of-the-art-visual-intelligence
+**Category**: model-release
+
+## Key Facts
+
+- FLUX.2 is a next-generation image model from Black Forest Labs
+- Delivers up to 4MP photorealistic output
+- Far better lighting, skin, fabric, and hand detail compared to FLUX.1
+- Reliable multi-reference consistency with up to 10 reference images
+- Improved editing precision and better visual understanding
+- Professional-class text rendering
+- Available as FLUX.2 Dev (open-source BF16 and FP8 versions) and FLUX.2 Pro (API)
+- FP8 version developed in partnership with NVIDIA reduces VRAM by 40%
+- 24GB+ VRAM strongly recommended for high-res local use
+- FP8 workflow uses ~70GB RAM and ~5GB VRAM on RTX 3060 12GB
+- Suitable for e-commerce, marketing campaigns, environment mockups, social content
+
+## Related Templates
+
+- image_flux2
+- image_flux2_fp8

--- a/site/knowledge/blog/flux2-klein-4b.md
+++ b/site/knowledge/blog/flux2-klein-4b.md
@@ -1,0 +1,28 @@
+# FLUX.2 [klein] 4B & 9B
+
+**Date**: 2026-01-16
+**Source**: https://blog.comfy.org/p/flux2-klein-4b-fast-local-image-editing
+**Category**: model-release
+
+## Key Facts
+
+- Fastest image models in the Flux family, unifying image generation and editing
+- Designed for interactive workflows, immediate previews, and latency-critical applications
+- End-to-end inference around one second on distilled variants
+- Available in Base (undistilled) and Distilled (4-step) variants at both 4B and 9B parameters
+- Both sizes support text-to-image and image editing including single/multi-reference
+
+## Benchmarks
+
+- 9B distilled: 4 steps, ~2s on 5090, 19.6GB VRAM
+- 9B base: 50 steps, ~35s on 5090, 21.7GB VRAM
+- 4B distilled: 4 steps, ~1.2s on 5090, 8.4GB VRAM
+- 4B base: 50 steps, ~17s on 5090, 9.2GB VRAM
+
+## Related Templates
+
+- image_flux2_klein_text_to_image
+- image_flux2_klein_image_edit_4b_base
+- image_flux2_klein_image_edit_4b_distilled
+- image_flux2_klein_image_edit_9b_base
+- image_flux2_klein_image_edit_9b_distilled

--- a/site/knowledge/blog/grok-imagine.md
+++ b/site/knowledge/blog/grok-imagine.md
@@ -1,0 +1,14 @@
+# Grok Imagine Now Available in ComfyUI
+
+**Date**: 2026-01-29
+**Source**: https://blog.comfy.org/p/grok-imagine-now-available-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- Cinematic and moody image and video generation from xAI
+- Available through ComfyUI API nodes
+
+## Related Templates
+
+- api_grok_imagine

--- a/site/knowledge/blog/hunyuan3d-20-native-support.md
+++ b/site/knowledge/blog/hunyuan3d-20-native-support.md
@@ -1,0 +1,19 @@
+# Hunyuan3D 2.0 and MultiView Native Support
+
+**Date**: 2025-03-22
+**Source**: https://blog.comfy.org/p/hunyuan3d-20-and-muitiview-native
+**Category**: model-release
+
+## Key Facts
+
+- Open-source 3D generation model from Tencent
+- Generates high-fidelity 3D models with high-resolution texture maps from text or images
+- Hunyuan3D-2mv (multi-view) model has only 1.1B parameters
+- Turbo and fast models available for inference acceleration
+- Runs on Mac
+- Supports PBR material generation for near-realistic lighting effects
+- Three workflow types: multi-view, multi-view turbo, and single-image
+
+## Related Templates
+
+- 3d_hunyuan3d_2

--- a/site/knowledge/blog/hunyuanvideo-15-native-support.md
+++ b/site/knowledge/blog/hunyuanvideo-15-native-support.md
@@ -1,0 +1,20 @@
+# HunyuanVideo 1.5 Native Support
+
+**Date**: 2025-11-25
+**Source**: https://blog.comfy.org/p/hunyuanvideo-15-native-support
+**Category**: model-release
+
+## Key Facts
+
+- Lightweight 8.3B parameter model (down from 13B in original HunyuanVideo)
+- Runs on consumer GPUs with 24GB VRAM
+- Supports text-to-video and image-to-video
+- Native 720p output, upscalable to 1080p
+- Supports diverse styles: realistic, anime, 3D
+- In-video text rendering for Chinese and English
+- Strong instruction following for camera movements, physics, and emotional expressions
+
+## Related Templates
+
+- video_hunyuan_video_1.5_720p_t2v
+- video_hunyuan_video_1.5_720p_i2v

--- a/site/knowledge/blog/hunyuanvideo-native-support.md
+++ b/site/knowledge/blog/hunyuanvideo-native-support.md
@@ -1,0 +1,18 @@
+# HunyuanVideo Native Support in ComfyUI
+
+**Date**: 2024-12-20
+**Source**: https://blog.comfy.org/p/hunyuanvideo-native-support-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- HunyuanVideo is a 13-billion-parameter open-source video foundation model from Tencent
+- "Dual-stream to Single-stream" Transformer architecture fuses text and visuals
+- MLLM text encoder outperforms CLIP and T5 for instruction following and complex reasoning
+- Custom 3D VAE compresses videos into compact latent space preserving resolution and frame rate
+- Prompt Rewrite model with Normal Mode (improves intent) and Master Mode (optimizes composition/lighting)
+- Can generate both videos and still images (setting video length to 1)
+
+## Related Templates
+
+- video_hunyuan_video_t2v

--- a/site/knowledge/blog/kling-26-motion-control.md
+++ b/site/knowledge/blog/kling-26-motion-control.md
@@ -1,0 +1,15 @@
+# Kling 2.6 Motion Control in ComfyUI
+
+**Date**: 2026-01-13
+**Source**: https://blog.comfy.org/p/kling-26-motion-control
+**Category**: model-release
+
+## Key Facts
+
+- Precise control over character actions and expressions
+- Video reference motion control
+- Available through API nodes in ComfyUI
+
+## Related Templates
+
+- api_kling_26

--- a/site/knowledge/blog/ltx-2-open-source-audio-video.md
+++ b/site/knowledge/blog/ltx-2-open-source-audio-video.md
@@ -1,0 +1,28 @@
+# LTX-2: Open Source Audio-Video AI
+
+**Date**: 2026-01-08
+**Source**: https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai
+**Category**: model-release
+
+## Key Facts
+
+- Open-source audio-video foundation model from Lightricks
+- Synchronously generates motion, dialogue, background noise, and music in a single pass
+- Supports Canny, Depth, and Pose video-to-video control
+- Keyframe-driven generation
+- Native upscaling and prompt enhancement
+- Runs efficiently on consumer-grade hardware
+- NVFP4 and NVFP8 checkpoints available in partnership with NVIDIA
+- Up to 3x faster with 60% less VRAM using NVFP4
+
+## Benchmarks
+
+- NVFP4: Up to 3x faster, 60% less VRAM vs standard
+
+## Related Templates
+
+- video_ltx2_t2v
+- video_ltx2_i2v
+- video_ltx2_canny_to_video
+- video_ltx2_depth_to_video
+- video_ltx2_pose_to_video

--- a/site/knowledge/blog/ltx-video-095-support.md
+++ b/site/knowledge/blog/ltx-video-095-support.md
@@ -1,0 +1,19 @@
+# LTX-Video 0.9.5 Day-1 Support in ComfyUI
+
+**Date**: 2025-03-06
+**Source**: https://blog.comfy.org/p/ltx-video-095-day-1-support-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- Major update to the LTXV series from Lightricks
+- Introduces OpenRail-M license allowing commercial use of generated videos
+- Key frame conditioning: control start/end frames and add multiple key frames
+- Higher resolution videos with support for longer sequences
+- Fewer visual artifacts and better prompt understanding
+- Multi-frame control for flexible video generation
+
+## Related Templates
+
+- video_ltxv_t2v
+- video_ltxv_i2v

--- a/site/knowledge/blog/meshy-6.md
+++ b/site/knowledge/blog/meshy-6.md
@@ -1,0 +1,15 @@
+# Meshy 6 Now Available in ComfyUI
+
+**Date**: 2026-01-21
+**Source**: https://blog.comfy.org/p/meshy-6-now-available-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- High-quality 3D model generation
+- Production-ready 3D assets with enhanced geometry and mesh quality
+- Available through API nodes
+
+## Related Templates
+
+- api_meshy_6

--- a/site/knowledge/blog/nvidia-optimizations.md
+++ b/site/knowledge/blog/nvidia-optimizations.md
@@ -1,0 +1,11 @@
+# New ComfyUI Optimizations for NVIDIA
+
+**Date**: 2026-01-09
+**Source**: https://blog.comfy.org/p/new-comfyui-optimizations-for-nvidia
+**Category**: feature-announcement
+
+## Key Facts
+
+- Performance optimizations specific to NVIDIA GPUs
+- Includes NVFP4 quantization support
+- Improved inference speed for supported models

--- a/site/knowledge/blog/qwen-image-edit-2511.md
+++ b/site/knowledge/blog/qwen-image-edit-2511.md
@@ -1,0 +1,22 @@
+# Qwen Image Edit 2511 & Qwen Image Layered
+
+**Date**: 2025-12-25
+**Source**: https://blog.comfy.org/p/qwen-image-edit-2511-and-qwen-image
+**Category**: model-release
+
+## Key Facts
+
+- Qwen-Image-Edit-2511 is an enhanced version of Qwen-Image-Edit-2509
+- Better character consistency, especially in multi-person group photos
+- Instruction-driven image editing with natural language
+- Strong localized control: object replacement, style changes, background swaps
+- Built-in LoRA support without extra tuning
+- Qwen-Image-Layered decomposes images into multiple RGBA layers
+- Supports variable-layer decomposition (3, 4, or 8 layers)
+- Recursive decomposition for infinite layering
+- FP8 mixed model weight available
+
+## Related Templates
+
+- image_qwen_image_edit_2511
+- image_qwen_image_layered

--- a/site/knowledge/blog/seedance-15-pro.md
+++ b/site/knowledge/blog/seedance-15-pro.md
@@ -1,0 +1,15 @@
+# Seedance 1.5 Pro Now Available in ComfyUI
+
+**Date**: 2026-01-21
+**Source**: https://blog.comfy.org/p/seedance-1-5-pro-now-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- Professional audio-visual co-generation model
+- Generates synchronized video, dialogue, music, and sound effects together
+- Available through API nodes in ComfyUI
+
+## Related Templates
+
+- api_seedance_15_pro

--- a/site/knowledge/blog/upscaling-handbook.md
+++ b/site/knowledge/blog/upscaling-handbook.md
@@ -1,0 +1,27 @@
+# The Complete AI Upscaling Handbook: All in ComfyUI
+
+**Date**: 2026-02-06
+**Source**: https://blog.comfy.org/p/upscaling-in-comfyui
+**Category**: feature-announcement
+
+## Key Facts
+
+- Comprehensive guide covering 10 use cases and 20 workflows across all modern AI upscaling models
+- Two categories: conservative upscale (preserve original) vs creative upscale (reimagine details)
+- Conservative models: Magnific Precise, SeedVR2, FlashVSR, Topaz Fast, HitPaw
+- Creative models: Wan 2.2, Magnific Creative, Topaz Astra Creative, HitPaw
+- Magnific Skin Enhancer is best for portraits
+- SeedVR2 or Nano Banana Pro recommended for product photography
+- Do not rely on upscaling to fix common AI artifacts
+
+## Benchmarks
+
+- Image upscale 1K→4K times: Nano Banana Pro ~80s, Topaz ~100s, Magnific Creative ~50s, Magnific Skin Enhancer ~60s, Magnific Precise ~40s, HitPaw ~60s, WaveSpeed SeedVR2 ~40s
+- Video upscale 10s 720p: FlashVSR 1080p ~41s, FlashVSR 4K ~52s, SeedVR2 1080p on 5090 ~312s, Topaz 1080p ~374s, Topaz 4K ~560s, HitPaw 2K ~80s, HitPaw 4K ~175s
+
+## Related Templates
+
+- image_upscale_seedvr2
+- video_upscale_flashvsr
+- video_upscale_topaz
+- video_upscale_hitpaw

--- a/site/knowledge/blog/vidu-q2.md
+++ b/site/knowledge/blog/vidu-q2.md
@@ -1,0 +1,16 @@
+# Vidu Q2 Now Live in ComfyUI
+
+**Date**: 2026-01-22
+**Source**: https://blog.comfy.org/p/vidu-q2-now-live-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- Ultra-consistent characters with up to 7 reference subjects
+- 3x faster generation compared to previous version
+- Consistency, motion, and camera control capabilities
+- Available through API nodes
+
+## Related Templates
+
+- api_vidu_q2

--- a/site/knowledge/blog/wan21-vace-native-support.md
+++ b/site/knowledge/blog/wan21-vace-native-support.md
@@ -1,0 +1,20 @@
+# Wan 2.1 VACE Native Support
+
+**Date**: 2025-05-17
+**Source**: https://blog.comfy.org/p/wan21-vace-native-support-and-ace
+**Category**: model-release
+
+## Key Facts
+
+- Wan2.1-VACE is an open-source unified video editing model from Alibaba Tongyi team
+- Integrates multi-task capabilities in a single model
+- Supports high-resolution processing and flexible multi-modal input
+- All-in-one editing capabilities: Move-Anything, Swap-Anything, Reference-Anything, Expand-Anything, Animate-Anything
+- Supports text-to-video, image-to-video, and video-to-video workflows
+- Additional functions include motion brush, inpainting, outpainting, and adding elements
+
+## Related Templates
+
+- video_wan_vace_t2v
+- video_wan_vace_i2v
+- video_wan_vace_v2v

--- a/site/knowledge/blog/wan21-video-model-native-support.md
+++ b/site/knowledge/blog/wan21-video-model-native-support.md
@@ -1,0 +1,31 @@
+# Wan 2.1 Video Model Native Support
+
+**Date**: 2025-02-27
+**Source**: https://blog.comfy.org/p/wan21-video-model-native-support
+**Category**: model-release
+
+## Key Facts
+
+- Wan 2.1 is a series of 4 video generation models from Alibaba's Wan-AI team
+- Text-to-video 14B: Supports both 480P and 720P
+- Image-to-video 14B 720P: Supports 720P
+- Image-to-video 14B 480P: Supports 480P
+- Text-to-video 1.3B: Supports 480P
+- T2V-1.3B model requires only 8.19 GB VRAM, compatible with consumer-grade GPUs
+- Can generate a 5-second 480P video on an RTX 4090 in about 4 minutes (without quantization)
+- First video model capable of generating both Chinese and English text in video
+- Wan-VAE can encode/decode 1080P videos of any length while preserving temporal info
+- Supports text-to-video, image-to-video, video editing, text-to-image, and video-to-audio
+- Confirmed working on RTX 2060 with 6GB VRAM (T2V 1.3B)
+
+## Benchmarks
+
+- T2V-1.3B VRAM: 8.19 GB minimum
+- T2V-14B VRAM: 24GB+ recommended
+- 5-second 480P generation on RTX 4090: ~4 minutes
+
+## Related Templates
+
+- video_wan_t2v
+- video_wan_i2v_720p
+- video_wan_i2v_480p

--- a/site/knowledge/blog/wan22-day-0-support.md
+++ b/site/knowledge/blog/wan22-day-0-support.md
@@ -1,0 +1,24 @@
+# Wan 2.2 Day-0 Support in ComfyUI
+
+**Date**: 2025-07-28
+**Source**: https://blog.comfy.org/p/wan22-day-0-support-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- Wan 2.2 uses MoE (Mixture of Experts) architecture with high-noise and low-noise expert models
+- High-noise experts handle overall layout, low-noise experts refine details
+- Fully open-sourced under Apache 2.0 license, enabling commercial use
+- Cinematic aesthetic control with professional camera language
+- Supports lighting, color, and composition control
+- Smoothly reproduces complex motions with enhanced controllability
+- Precise semantic adherence for multi-object scenes
+- 5B version features high-compression VAE and optimized VRAM usage compared to 2.1
+- Available models: Wan2.2-TI2V-5B, Wan2.2-I2V-A14B, Wan2.2-T2V-A14B
+- FP16 and FP8 precision options available for 14B models
+
+## Related Templates
+
+- video_wan2_2_5B_ti2v
+- video_wan2_2_14B_t2v
+- video_wan2_2_14B_i2v

--- a/site/knowledge/blog/wan26-reference-to-video.md
+++ b/site/knowledge/blog/wan26-reference-to-video.md
@@ -1,0 +1,17 @@
+# WAN 2.6 Reference-to-Video
+
+**Date**: 2026-01-16
+**Source**: https://blog.comfy.org/p/wan26-reference-to-video
+**Category**: model-release
+
+## Key Facts
+
+- Generates new cinematic videos by learning motion, camera behavior, and visual style from reference clips
+- Supports up to two reference clips as input
+- 720p and 1080p output in portrait or landscape orientations
+- Prompt-based control over actions and scenes
+- Learns and reproduces motion patterns, framing, and overall style from references
+
+## Related Templates
+
+- api_wan_r2v

--- a/site/knowledge/blog/z-image-day-0-support.md
+++ b/site/knowledge/blog/z-image-day-0-support.md
@@ -1,0 +1,19 @@
+# Z-Image Day-0 Support in ComfyUI
+
+**Date**: 2026-01-28
+**Source**: https://blog.comfy.org/p/z-image-day-0-support-in-comfyui
+**Category**: model-release
+
+## Key Facts
+
+- Non-distilled foundation model for the Z-Image family
+- Enhanced creative control and potential for community fine-tuning
+- Requires 30-50 steps with cfg 3-5 for optimal quality
+- Broader range of artistic styles with exceptional photorealistic quality
+- Highly responsive to negative prompts for precise control
+- Higher generation diversity for more creative results
+- Foundation for the distilled Z-Image-Turbo variant
+
+## Related Templates
+
+- image_z_image

--- a/site/knowledge/models/flux.md
+++ b/site/knowledge/models/flux.md
@@ -43,3 +43,9 @@ Flux is a family of state-of-the-art text-to-image models developed by Black For
 - Concept art and illustrations
 - Product visualization
 - Character design
+
+## Blog References
+
+- [FLUX.2 Day-0 Support in ComfyUI](../blog/flux2-day-0-support.md) — FLUX.2 with 4MP output, multi-reference consistency, professional text rendering
+- [FLUX.2 [klein] 4B & 9B](../blog/flux2-klein-4b.md) — Fastest Flux models, sub-second inference, unified generation and editing
+- [The Complete AI Upscaling Handbook](../blog/upscaling-handbook.md) — Benchmarks for upscaling workflows

--- a/site/knowledge/models/hunyuan.md
+++ b/site/knowledge/models/hunyuan.md
@@ -47,3 +47,9 @@ Hunyuan-DiT is Tencent's open-source text-to-image diffusion transformer with na
 - **sampler**: DDPM, UniPC samplers supported
 - **resolution**: 1024x1024, 768x1280, 1280x768
 - **negative_prompt**: Recommended for quality control
+
+## Blog References
+
+- [HunyuanVideo Native Support](../blog/hunyuanvideo-native-support.md) — 13B parameter video model, dual-stream transformer, MLLM text encoder
+- [HunyuanVideo 1.5 Native Support](../blog/hunyuanvideo-15-native-support.md) — Lightweight 8.3B model, 720p output, runs on 24GB consumer GPUs
+- [Hunyuan3D 2.0 and MultiView Native Support](../blog/hunyuan3d-20-native-support.md) — 3D model generation with PBR materials, 1.1B parameter multi-view model

--- a/site/knowledge/models/ltx-video.md
+++ b/site/knowledge/models/ltx-video.md
@@ -47,3 +47,8 @@ LTX-Video is Lightricks' open-source video generation model optimized for fast, 
 - **cfg_scale**: Guidance strength (3-5 typical)
 - **width/height**: Output dimensions (768x512 native)
 - **seed**: For reproducible generation
+
+## Blog References
+
+- [LTX-Video 0.9.5 Day-1 Support](../blog/ltx-video-095-support.md) — Commercial license (OpenRail-M), multi-frame control, improved quality
+- [LTX-2: Open Source Audio-Video AI](../blog/ltx-2-open-source-audio-video.md) — Synchronized audio-video generation, NVFP4 for 3x speed / 60% less VRAM

--- a/site/knowledge/models/qwen.md
+++ b/site/knowledge/models/qwen.md
@@ -36,3 +36,7 @@ Qwen-Image (also known as Qwen-VL) is a vision-language model series from Alibab
 - Image-to-image transformation
 - Content-aware modifications
 - Style transfer and artistic effects
+
+## Blog References
+
+- [Qwen Image Edit 2511 & Qwen Image Layered](../blog/qwen-image-edit-2511.md) — Better character consistency, RGBA layer decomposition, built-in LoRA support

--- a/site/knowledge/models/wan.md
+++ b/site/knowledge/models/wan.md
@@ -45,3 +45,11 @@ Wan 2.1 is a video generation model from Alibaba capable of both image-to-video 
 - **steps**: Inference steps (20-50 recommended)
 - **cfg_scale**: Guidance scale for prompt adherence (3-7 typical)
 - **motion_bucket_id**: Controls amount of motion in I2V
+
+## Blog References
+
+- [Wan 2.1 Video Model Native Support](../blog/wan21-video-model-native-support.md) — Initial release with 4 model variants, 8.19GB VRAM minimum
+- [Wan 2.1 VACE Native Support](../blog/wan21-vace-native-support.md) — Unified video editing: Move/Swap/Reference/Expand/Animate Anything
+- [Wan 2.2 Day-0 Support](../blog/wan22-day-0-support.md) — MoE architecture, Apache 2.0 license, cinematic controls
+- [WAN 2.6 Reference-to-Video](../blog/wan26-reference-to-video.md) — Generate videos from reference clips at up to 1080p
+- [The Complete AI Upscaling Handbook](../blog/upscaling-handbook.md) — Wan 2.2 used for creative video upscaling


### PR DESCRIPTION
## Summary

Workstream 6: Blog Content Integration — extracts key information from blog.comfy.org for model releases and features to ground AI-generated descriptions in factual, authoritative content.

### Changes

**Task 6.1 — Blog post index** (`site/knowledge/blog/_index.json`)
- Scraped 110+ blog posts with URLs, titles, and dates

**Task 6.2 — Categorize posts**
- Tagged each post: `model-release`, `feature-announcement`, `tutorial`, `community`, `other`

**Task 6.3 — Key fact extraction** (23 markdown files in `site/knowledge/blog/`)
- Extracted facts, benchmarks, and related templates from high-priority posts
- Covers: Wan 2.1/2.2/2.6, FLUX.2/Klein, HunyuanVideo/1.5/3D, LTX-Video/LTX-2, Qwen Image Edit 2511, ACE-Step 1.5, Z-Image, upscaling handbook, and more

**Task 6.4 — Link blog posts to models/templates**
- Added `## Blog References` to 5 existing model docs: flux, wan, hunyuan, ltx-video, qwen
- Created `_model-index.json` reverse index mapping 16+ models to their blog posts

### Files changed
- `site/knowledge/blog/` — 25 new files (index, model-index, 23 fact extractions)
- `site/knowledge/models/*.md` — 5 files updated with blog references
- `WORKSTREAM.md` — All tasks marked complete