### PR TITLE
feat(knowledge): add custom node docs and registry descriptions

### DIFF
--- a/site/knowledge/custom-nodes/comfyui-animatediff-evolved.md
+++ b/site/knowledge/custom-nodes/comfyui-animatediff-evolved.md
@@ -1,0 +1,17 @@
+# ComfyUI-AnimateDiff-Evolved
+
+**Author**: Kosinkadink
+**URL**: https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved
+**Registry**: https://registry.comfy.org/nodes/comfyui-animatediff-evolved
+**Downloads**: 389,746
+**Stars**: 3,375
+**Templates using this**: 1
+
+## Description
+
+Improved AnimateDiff integration for ComfyUI. Provides nodes for generating short animations and videos using AnimateDiff motion modules with Stable Diffusion models. Supports various motion models, context scheduling, and advanced animation controls.
+
+## Key Nodes
+
+- `AnimateDiffLoader`: Loads an AnimateDiff motion model and injects it into the Stable Diffusion pipeline for animated output.
+- `AnimateDiffModuleLoader`: Loads and configures AnimateDiff motion modules with additional parameters for controlling animation behavior.

--- a/site/knowledge/custom-nodes/comfyui-audioschedule.md
+++ b/site/knowledge/custom-nodes/comfyui-audioschedule.md
@@ -1,0 +1,20 @@
+# ComfyUI-AudioScheduler
+
+**Author**: a1lazydog
+**URL**: https://github.com/a1lazydog/ComfyUI-AudioScheduler
+**Downloads**: Unknown
+**Stars**: Unknown
+**Templates using this**: 16
+
+## Description
+
+Audio processing nodes for controlling animations and audio-reactive workflows in ComfyUI. Supports loading MP3 and WAV files and extracting audio data such as amplitude and FFT frequency information for use in scheduling animation parameters.
+
+> **Note**: The original repository is no longer available. The information below is based on known node functionality from existing workflow templates.
+
+## Key Nodes
+
+- `SaveAudioMP3`: Saves audio output as an MP3 file.
+- `LoadAudio`: Loads an audio file (MP3 or WAV) into the workflow.
+- `AudioToAudioData`: Converts raw audio into structured audio data for analysis.
+- `AudioToFFTs`: Extracts FFT (Fast Fourier Transform) frequency data from audio, enabling audio-reactive animation control.

--- a/site/knowledge/custom-nodes/comfyui-cfgnorm.md
+++ b/site/knowledge/custom-nodes/comfyui-cfgnorm.md
@@ -1,0 +1,17 @@
+# ComfyUI-CFGNorm
+
+**Author**: Clybius
+**URL**: https://github.com/Clybius/ComfyUI-CFGNorm
+**Downloads**: Unknown
+**Stars**: Unknown
+**Templates using this**: 1
+
+## Description
+
+Implements CFG (Classifier-Free Guidance) normalization for ComfyUI. Provides a node that normalizes the CFG scale during the sampling process, which can help reduce artifacts and improve image quality at high CFG values.
+
+> **Note**: The original repository is no longer available. The information below is based on known node functionality from existing workflow templates.
+
+## Key Nodes
+
+- `CFGNorm`: Applies normalization to the classifier-free guidance signal during sampling, helping to prevent oversaturation and artifacts that can occur at high CFG scale values.

--- a/site/knowledge/custom-nodes/comfyui-controlnet-aux.md
+++ b/site/knowledge/custom-nodes/comfyui-controlnet-aux.md
@@ -1,0 +1,20 @@
+# comfyui_controlnet_aux
+
+**Author**: Fannovel16
+**URL**: https://github.com/Fannovel16/comfyui_controlnet_aux
+**Registry**: https://registry.comfy.org/nodes/comfyui_controlnet_aux
+**Downloads**: 1,691,696
+**Stars**: 3,764
+**Templates using this**: 4
+
+## Description
+
+Plug-and-play ComfyUI node sets for making ControlNet hint images. Provides preprocessor nodes that generate various types of control images (edges, depth maps, poses, line art) from input images for use with ControlNet models.
+
+## Key Nodes
+
+- `DWPreprocessor`: Generates DensePose/DWPose estimations for human pose detection, used as ControlNet input.
+- `LineArtPreprocessor`: Extracts line art from an image for use with line art ControlNet models.
+- `CannyEdgePreprocessor`: Applies Canny edge detection to produce edge maps for ControlNet conditioning.
+- `DepthAnythingPreprocessor`: Generates monocular depth maps using the Depth Anything model.
+- `OpenPosePreprocessor`: Detects human body, hand, and face keypoints for pose-guided generation.

--- a/site/knowledge/custom-nodes/comfyui-custom-scripts.md
+++ b/site/knowledge/custom-nodes/comfyui-custom-scripts.md
@@ -1,0 +1,17 @@
+# ComfyUI-Custom-Scripts
+
+**Author**: pythongosssss
+**URL**: https://github.com/pythongosssss/ComfyUI-Custom-Scripts
+**Registry**: https://registry.comfy.org/nodes/comfyui-custom-scripts
+**Downloads**: 1,781,557
+**Stars**: 2,936
+**Templates using this**: 8
+
+## Description
+
+Enhancements and experiments for ComfyUI, mostly focusing on UI features. Includes utility nodes for string manipulation and text processing that are commonly used in workflow templates for parsing and transforming text outputs.
+
+## Key Nodes
+
+- `RegexReplace`: Performs regex-based find-and-replace on text strings. Commonly used to clean or transform prompt text and model outputs.
+- `RegexExtract`: Extracts matching substrings from text using regular expressions.

--- a/site/knowledge/custom-nodes/comfyui-depthanythingv2.md
+++ b/site/knowledge/custom-nodes/comfyui-depthanythingv2.md
@@ -1,0 +1,17 @@
+# ComfyUI-DepthAnythingV2
+
+**Author**: Kijai
+**URL**: https://github.com/kijai/ComfyUI-DepthAnythingV2
+**Registry**: https://registry.comfy.org/nodes/comfyui-depthanythingv2
+**Downloads**: 249,182
+**Stars**: 391
+**Templates using this**: 1
+
+## Description
+
+ComfyUI nodes to use Depth Anything V2 for monocular depth estimation. Models auto-download from HuggingFace. Depth Anything V2 provides high-quality depth maps from single images, useful for ControlNet conditioning, 3D effects, and scene understanding.
+
+## Key Nodes
+
+- `DepthAnything_V2`: Generates a depth map from an input image using the Depth Anything V2 model.
+- `DownloadAndLoadDepthAnythingV2Model`: Downloads (if needed) and loads a Depth Anything V2 model checkpoint for use in the workflow.

--- a/site/knowledge/custom-nodes/comfyui-essentials.md
+++ b/site/knowledge/custom-nodes/comfyui-essentials.md
@@ -1,0 +1,20 @@
+# ComfyUI_essentials
+
+**Author**: Matteo (cubiq)
+**URL**: https://github.com/cubiq/ComfyUI_essentials
+**Registry**: https://registry.comfy.org/nodes/comfyui_essentials
+**Downloads**: 1,874,070
+**Stars**: 1,043
+**Templates using this**: 24
+
+## Description
+
+Essential nodes that are weirdly missing from ComfyUI core. With few exceptions they are new features and not commodities. Provides utility nodes for image manipulation, math operations, and batch processing that fill common gaps in the default node set.
+
+## Key Nodes
+
+- `GetImageSize+`: Returns the width and height of an input image, useful for conditional logic and dynamic resizing.
+- `BatchImagesNode`: Batches multiple images together into a single tensor for parallel processing.
+- `ResizeAndPadImage`: Resizes an image to target dimensions while padding to maintain aspect ratio.
+- `SimpleMath+`: Evaluates simple mathematical expressions, useful for dynamic parameter calculation within workflows.
+- `ImageBatchMulti`: Combines multiple image inputs into a batch with flexible input count.

--- a/site/knowledge/custom-nodes/comfyui-florence2.md
+++ b/site/knowledge/custom-nodes/comfyui-florence2.md
@@ -1,0 +1,16 @@
+# ComfyUI-Florence2
+
+**Author**: Kijai
+**URL**: https://github.com/kijai/ComfyUI-Florence2
+**Registry**: https://registry.comfy.org/nodes/comfyui-florence2
+**Downloads**: 1,103,756
+**Stars**: 1,592
+**Templates using this**: 1
+
+## Description
+
+Nodes to use Florence2 VLM (Vision-Language Model) for image vision tasks including object detection, captioning, segmentation, and OCR. Florence2 is a versatile model that can perform multiple vision tasks through natural language prompts.
+
+## Key Nodes
+
+- `Florence2`: Runs the Florence2 vision-language model on an input image with a text prompt to perform tasks such as image captioning, object detection, region-based captioning, segmentation, and optical character recognition.

--- a/site/knowledge/custom-nodes/comfyui-frame-interpolation.md
+++ b/site/knowledge/custom-nodes/comfyui-frame-interpolation.md
@@ -1,0 +1,16 @@
+# ComfyUI-Frame-Interpolation
+
+**Author**: Fannovel16
+**URL**: https://github.com/Fannovel16/ComfyUI-Frame-Interpolation
+**Registry**: https://registry.comfy.org/nodes/comfyui-frame-interpolation
+**Downloads**: 1,181,197
+**Stars**: 952
+**Templates using this**: 1
+
+## Description
+
+A custom node suite for Video Frame Interpolation in ComfyUI. Supports multiple frame interpolation algorithms including FILM, RIFE, and others for generating intermediate frames between existing video frames, enabling smooth slow-motion effects and frame rate upscaling.
+
+## Key Nodes
+
+- `FILM VFI`: Performs video frame interpolation using Google's FILM (Frame Interpolation for Large Motion) model. Generates high-quality intermediate frames between two input frames, handling large motion and occlusion effectively.

--- a/site/knowledge/custom-nodes/comfyui-impact-pack.md
+++ b/site/knowledge/custom-nodes/comfyui-impact-pack.md
@@ -1,0 +1,19 @@
+# ComfyUI Impact Pack
+
+**Author**: Dr.Lt.Data
+**URL**: https://github.com/ltdrdata/ComfyUI-Impact-Pack
+**Registry**: https://registry.comfy.org/nodes/comfyui-impact-pack
+**Downloads**: 2,055,471
+**Stars**: 2,950
+**Templates using this**: 1
+
+## Description
+
+This node pack offers various detector nodes and detailer nodes that allow you to configure a workflow that automatically enhances facial details. It also provides an iterative upscaler and segment-based processing for targeted inpainting and enhancement.
+
+## Key Nodes
+
+- `FaceDetailer`: Automatically detects faces in an image and re-generates them at higher detail, improving facial quality in full-scene generations.
+- `DetailerForEach`: Runs a detailing pass on each detected segment individually, useful for enhancing multiple faces or objects in a single image.
+- `SAMLoader`: Loads a Segment Anything Model (SAM) for use with detection-based workflows.
+- `SAMDetectorCombined`: Combines SAM segmentation with a detection model to produce precise masks for detected regions.

--- a/site/knowledge/custom-nodes/comfyui-instantid.md
+++ b/site/knowledge/custom-nodes/comfyui-instantid.md
@@ -1,0 +1,17 @@
+# ComfyUI_InstantID
+
+**Author**: Matteo (cubiq)
+**URL**: https://github.com/cubiq/ComfyUI_InstantID
+**Registry**: https://registry.comfy.org/nodes/comfyui_instantid
+**Downloads**: 259,261
+**Stars**: 1,794
+**Templates using this**: 1
+
+## Description
+
+Native InstantID support for ComfyUI. InstantID enables zero-shot identity-preserving generation — given a single reference face image, it can generate new images that maintain the identity of the person without any fine-tuning.
+
+## Key Nodes
+
+- `InstantIDFaceAnalysis`: Analyzes a reference face image and extracts facial embeddings for identity preservation during generation.
+- `ApplyInstantID`: Applies the extracted identity embeddings to condition the generation pipeline, ensuring the output preserves the facial identity from the reference image.

--- a/site/knowledge/custom-nodes/comfyui-ipadapter-plus.md
+++ b/site/knowledge/custom-nodes/comfyui-ipadapter-plus.md
@@ -1,0 +1,17 @@
+# ComfyUI_IPAdapter_plus
+
+**Author**: Matteo (cubiq)
+**URL**: https://github.com/cubiq/ComfyUI_IPAdapter_plus
+**Registry**: https://registry.comfy.org/nodes/comfyui_ipadapter_plus
+**Downloads**: 959,299
+**Stars**: 5,770
+**Templates using this**: 1
+
+## Description
+
+ComfyUI reference implementation for the IPAdapter models. The IPAdapter models are very powerful for image conditioning — the style and composition of a reference image can be easily transferred to the generation. Think of it as a 1-image LoRA.
+
+## Key Nodes
+
+- `IPAdapterUnifiedLoader`: Loads an IPAdapter model and its required CLIP vision encoder in a single node, simplifying setup.
+- `IPAdapterApply`: Applies the loaded IPAdapter model to condition generation based on a reference image, transferring style, composition, or subject features.

--- a/site/knowledge/custom-nodes/comfyui-latentupscaler.md
+++ b/site/knowledge/custom-nodes/comfyui-latentupscaler.md
@@ -1,0 +1,17 @@
+# ComfyUI-LatentUpscaler
+
+**Author**: city96
+**URL**: https://github.com/city96/ComfyUI-LatentUpscaler
+**Downloads**: Unknown
+**Stars**: Unknown
+**Templates using this**: 2
+
+## Description
+
+Provides latent-space upscaling models for ComfyUI. Instead of upscaling decoded images, this pack operates directly in latent space, offering faster upscaling with less VRAM usage compared to pixel-space methods.
+
+> **Note**: The original repository is no longer available. The information below is based on known node functionality from existing workflow templates.
+
+## Key Nodes
+
+- `LatentUpscaleModelLoader`: Loads a latent upscale model for use in the workflow pipeline.

--- a/site/knowledge/custom-nodes/comfyui-qwenvl-nodes.md
+++ b/site/knowledge/custom-nodes/comfyui-qwenvl-nodes.md
@@ -1,0 +1,17 @@
+# ComfyUI-QwenVL-Nodes
+
+**Author**: ZHO-ZHO-ZHO
+**URL**: https://github.com/ZHO-ZHO-ZHO/ComfyUI-QwenVL-Nodes
+**Downloads**: Unknown
+**Stars**: Unknown
+**Templates using this**: 1
+
+## Description
+
+Nodes for using QwenVL (Qwen Vision-Language) models within ComfyUI. Enables vision-language tasks such as image understanding, captioning, and text-guided image editing through the Qwen multimodal model family.
+
+> **Note**: The original repository is no longer available. The information below is based on known node functionality from existing workflow templates.
+
+## Key Nodes
+
+- `TextEncodeQwenImageEditPlus`: Encodes text prompts using the QwenVL model for image editing tasks, providing enhanced text understanding for vision-language guided editing workflows.

--- a/site/knowledge/custom-nodes/comfyui-reference-latent.md
+++ b/site/knowledge/custom-nodes/comfyui-reference-latent.md
@@ -1,0 +1,17 @@
+# ComfyUI-Reference-Latent
+
+**Author**: Clybius
+**URL**: https://github.com/Clybius/ComfyUI-Reference-Latent
+**Downloads**: Unknown
+**Stars**: Unknown
+**Templates using this**: 1
+
+## Description
+
+Provides reference latent conditioning for ComfyUI. Allows using a reference image's latent representation to guide the generation process, enabling style and structure transfer without dedicated IP-Adapter or ControlNet models.
+
+> **Note**: The original repository is no longer available. The information below is based on known node functionality from existing workflow templates.
+
+## Key Nodes
+
+- `ReferenceLatent`: Takes a reference image and injects its latent representation into the diffusion process to guide generation, transferring visual characteristics from the reference to the output.

--- a/site/knowledge/custom-nodes/comfyui-sampler-scheduler-transforms.md
+++ b/site/knowledge/custom-nodes/comfyui-sampler-scheduler-transforms.md
@@ -1,0 +1,17 @@
+# ComfyUI-sampler-scheduler-transforms
+
+**Author**: WASasquatch
+**URL**: https://github.com/WASasquatch/ComfyUI-sampler-scheduler-transforms
+**Downloads**: Unknown
+**Stars**: Unknown
+**Templates using this**: 1
+
+## Description
+
+Provides custom sampler and scheduler transform nodes for ComfyUI. Allows manual specification of sigma schedules and custom noise schedules for fine-grained control over the diffusion sampling process.
+
+> **Note**: The original repository is no longer available. The information below is based on known node functionality from existing workflow templates.
+
+## Key Nodes
+
+- `ManualSigmas`: Allows manual specification of the sigma (noise) schedule used during sampling, giving precise control over the denoising steps instead of relying on built-in scheduler presets.

--- a/site/knowledge/custom-nodes/comfyui-segment-anything-2.md
+++ b/site/knowledge/custom-nodes/comfyui-segment-anything-2.md
@@ -1,0 +1,17 @@
+# ComfyUI-segment-anything-2
+
+**Author**: Kijai
+**URL**: https://github.com/kijai/ComfyUI-segment-anything-2
+**Registry**: https://registry.comfy.org/nodes/comfyui-segment-anything-2
+**Downloads**: 205,905
+**Stars**: 1,165
+**Templates using this**: 1
+
+## Description
+
+Nodes to use Meta's Segment Anything 2 (SAM2) for image or video segmentation. SAM2 extends the original SAM with video support, enabling consistent object segmentation across video frames with temporal awareness.
+
+## Key Nodes
+
+- `Sam2Segmentation`: Segments objects in an image or video frame using the SAM2 model, producing precise masks based on point prompts, box prompts, or automatic detection.
+- `DownloadAndLoadSAM2Model`: Downloads (if needed) and loads a SAM2 model checkpoint for use in the segmentation workflow.

--- a/site/knowledge/custom-nodes/comfyui-segment-anything.md
+++ b/site/knowledge/custom-nodes/comfyui-segment-anything.md
@@ -1,0 +1,14 @@
+# comfyui_segment_anything
+
+**Author**: storyicon
+**URL**: https://github.com/storyicon/comfyui_segment_anything
+**Stars**: 1,073
+**Templates using this**: 1
+
+## Description
+
+Based on GroundingDino and SAM (Segment Anything Model), this pack allows you to use semantic text strings to segment any element in an image. Combines open-vocabulary object detection with precise segmentation for powerful text-guided masking.
+
+## Key Nodes
+
+- `GroundingDinoSAMSegment`: Takes an image and a text prompt describing the object to segment. Uses GroundingDino for open-vocabulary detection and SAM for precise mask generation, producing segmentation masks for the described objects.

--- a/site/knowledge/custom-nodes/comfyui-ultimatesdupscale.md
+++ b/site/knowledge/custom-nodes/comfyui-ultimatesdupscale.md
@@ -1,0 +1,16 @@
+# ComfyUI_UltimateSDUpscale
+
+**Author**: ssit
+**URL**: https://github.com/ssitu/ComfyUI_UltimateSDUpscale
+**Registry**: https://registry.comfy.org/nodes/comfyui_ultimatesdupscale
+**Downloads**: 1,127,484
+**Stars**: 1,422
+**Templates using this**: 1
+
+## Description
+
+ComfyUI nodes for the Ultimate Stable Diffusion Upscale script by Coyote-A. Performs tiled upscaling using Stable Diffusion, allowing high-resolution image generation without running out of VRAM by processing the image in overlapping tiles.
+
+## Key Nodes
+
+- `UltimateSDUpscale`: Upscales an image using tiled Stable Diffusion denoising. Splits the image into tiles, processes each tile with img2img, and seamlessly blends them together for a coherent high-resolution result.

--- a/site/knowledge/custom-nodes/comfyui-videohelpersuite.md
+++ b/site/knowledge/custom-nodes/comfyui-videohelpersuite.md
@@ -1,0 +1,20 @@
+# ComfyUI-VideoHelperSuite
+
+**Author**: Kosinkadink
+**URL**: https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite
+**Registry**: https://registry.comfy.org/nodes/comfyui-videohelpersuite
+**Downloads**: 2,106,142
+**Stars**: 1,483
+**Templates using this**: 32
+
+## Description
+
+Nodes related to video workflows. Provides essential utilities for loading, combining, and inspecting video files within ComfyUI. This is the most widely used custom node pack in our workflow templates, powering the majority of video-based pipelines.
+
+## Key Nodes
+
+- `GetVideoComponents`: Extracts individual components (frames, audio, metadata) from a video file for downstream processing.
+- `VHS_LoadVideo`: Loads a video file into the workflow, outputting frames and audio for further manipulation.
+- `VHS_VideoCombine`: Combines processed frames and audio back into a video file, with options for format and codec.
+- `VHS_VideoInfo`: Retrieves metadata about a video file such as frame count, resolution, frame rate, and duration.
+- `VHS_BatchManager`: Manages batches of video frames for efficient processing in large video workflows.

--- a/site/src/lib/node-registry.ts
+++ b/site/src/lib/node-registry.ts
@@ -152,18 +152,22 @@ export const CUSTOM_NODE_REGISTRY: Record<string, CustomNodeInfo> = {
   GetImageSize: {
     package: 'ComfyUI_essentials',
     url: 'https://github.com/cubiq/ComfyUI_essentials',
+    description: 'Essential utility nodes missing from ComfyUI core',
   },
   ResizeAndPadImage: {
     package: 'ComfyUI_essentials',
     url: 'https://github.com/cubiq/ComfyUI_essentials',
+    description: 'Essential utility nodes missing from ComfyUI core',
   },
   ImageBatchMulti: {
     package: 'ComfyUI_essentials',
     url: 'https://github.com/cubiq/ComfyUI_essentials',
+    description: 'Essential utility nodes missing from ComfyUI core',
   },
   BatchImagesNode: {
     package: 'ComfyUI_essentials',
     url: 'https://github.com/cubiq/ComfyUI_essentials',
+    description: 'Essential utility nodes missing from ComfyUI core',
   },
 
   // Qwen Image nodes
@@ -177,54 +181,79 @@ export const CUSTOM_NODE_REGISTRY: Record<string, CustomNodeInfo> = {
   ReferenceLatent: {
     package: 'ComfyUI-Reference-Latent',
     url: 'https://github.com/Clybius/ComfyUI-Reference-Latent',
+    description: 'Reference latent conditioning for style transfer',
   },
 
   // CFG utilities
   CFGNorm: {
     package: 'ComfyUI-CFGNorm',
     url: 'https://github.com/Clybius/ComfyUI-CFGNorm',
+    description: 'CFG normalization for improved generation quality',
   },
 
   // Regex utilities
   RegexReplace: {
     package: 'ComfyUI-Custom-Scripts',
     url: 'https://github.com/pythongosssss/ComfyUI-Custom-Scripts',
+    description: 'UI enhancements and utility scripts for ComfyUI',
   },
   RegexExtract: {
     package: 'ComfyUI-Custom-Scripts',
     url: 'https://github.com/pythongosssss/ComfyUI-Custom-Scripts',
+    description: 'UI enhancements and utility scripts for ComfyUI',
   },
 
   // Video helpers
   GetVideoComponents: {
     package: 'ComfyUI-VideoHelperSuite',
     url: 'https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite',
+    description: 'Video loading, combining, and processing nodes',
   },
   VHS_BatchManager: {
     package: 'ComfyUI-VideoHelperSuite',
     url: 'https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite',
+    description: 'Video loading, combining, and processing nodes',
   },
   VHS_VIDEOINFO: {
     package: 'ComfyUI-VideoHelperSuite',
     url: 'https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite',
+    description: 'Video loading, combining, and processing nodes',
+  },
+  VHS_LoadVideo: {
+    package: 'ComfyUI-VideoHelperSuite',
+    url: 'https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite',
+    description: 'Video loading, combining, and processing nodes',
+  },
+  VHS_VideoCombine: {
+    package: 'ComfyUI-VideoHelperSuite',
+    url: 'https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite',
+    description: 'Video loading, combining, and processing nodes',
+  },
+  VHS_VideoInfo: {
+    package: 'ComfyUI-VideoHelperSuite',
+    url: 'https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite',
+    description: 'Video loading, combining, and processing nodes',
   },
 
   // Audio nodes
   SaveAudioMP3: {
     package: 'ComfyUI-AudioScheduler',
     url: 'https://github.com/a1lazydog/ComfyUI-AudioScheduler',
+    description: 'Audio processing and scheduling nodes for animation control',
   },
 
   // Manual sigmas
   ManualSigmas: {
     package: 'ComfyUI-sampler-scheduler-transforms',
     url: 'https://github.com/WASasquatch/ComfyUI-sampler-scheduler-transforms',
+    description: 'Custom sampler and scheduler transform utilities',
   },
 
   // Latent upscale
   LatentUpscaleModelLoader: {
     package: 'ComfyUI-LatentUpscaler',
     url: 'https://github.com/city96/ComfyUI-LatentUpscaler',
+    description: 'Neural network-based latent space upscaling',
   },
 
   // Ultimate SD Upscale
@@ -238,78 +267,135 @@ export const CUSTOM_NODE_REGISTRY: Record<string, CustomNodeInfo> = {
   SAMLoader: {
     package: 'ComfyUI-Impact-Pack',
     url: 'https://github.com/ltdrdata/ComfyUI-Impact-Pack',
+    description: 'Detector and detailer nodes for automatic facial enhancement and iterative upscaling',
   },
   SAMDetectorCombined: {
     package: 'ComfyUI-Impact-Pack',
     url: 'https://github.com/ltdrdata/ComfyUI-Impact-Pack',
+    description: 'Detector and detailer nodes for automatic facial enhancement and iterative upscaling',
   },
   FaceDetailer: {
     package: 'ComfyUI-Impact-Pack',
     url: 'https://github.com/ltdrdata/ComfyUI-Impact-Pack',
+    description: 'Detector and detailer nodes for automatic facial enhancement and iterative upscaling',
   },
   DetailerForEach: {
     package: 'ComfyUI-Impact-Pack',
     url: 'https://github.com/ltdrdata/ComfyUI-Impact-Pack',
+    description: 'Detector and detailer nodes for automatic facial enhancement and iterative upscaling',
   },
 
   // ControlNet Aux
   CannyEdgePreprocessor: {
     package: 'comfyui_controlnet_aux',
     url: 'https://github.com/Fannovel16/comfyui_controlnet_aux',
+    description: 'Plug-and-play preprocessors for generating ControlNet hint images',
   },
   DepthAnythingPreprocessor: {
     package: 'comfyui_controlnet_aux',
     url: 'https://github.com/Fannovel16/comfyui_controlnet_aux',
+    description: 'Plug-and-play preprocessors for generating ControlNet hint images',
   },
   OpenPosePreprocessor: {
     package: 'comfyui_controlnet_aux',
     url: 'https://github.com/Fannovel16/comfyui_controlnet_aux',
+    description: 'Plug-and-play preprocessors for generating ControlNet hint images',
   },
   LineArtPreprocessor: {
     package: 'comfyui_controlnet_aux',
     url: 'https://github.com/Fannovel16/comfyui_controlnet_aux',
+    description: 'Plug-and-play preprocessors for generating ControlNet hint images',
+  },
+  DWPreprocessor: {
+    package: 'comfyui_controlnet_aux',
+    url: 'https://github.com/Fannovel16/comfyui_controlnet_aux',
+    description: 'Plug-and-play preprocessors for generating ControlNet hint images',
+  },
+  PixelPerfectResolution: {
+    package: 'comfyui_controlnet_aux',
+    url: 'https://github.com/Fannovel16/comfyui_controlnet_aux',
+    description: 'Plug-and-play preprocessors for generating ControlNet hint images',
   },
 
   // IP-Adapter
   IPAdapterUnifiedLoader: {
     package: 'ComfyUI_IPAdapter_plus',
     url: 'https://github.com/cubiq/ComfyUI_IPAdapter_plus',
+    description: 'Image conditioning via IPAdapter models for style and composition transfer',
   },
   IPAdapterApply: {
     package: 'ComfyUI_IPAdapter_plus',
     url: 'https://github.com/cubiq/ComfyUI_IPAdapter_plus',
+    description: 'Image conditioning via IPAdapter models for style and composition transfer',
   },
 
   // AnimateDiff
   AnimateDiffLoader: {
     package: 'ComfyUI-AnimateDiff-Evolved',
     url: 'https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved',
+    description: 'AnimateDiff motion module integration for video generation',
   },
   AnimateDiffModuleLoader: {
     package: 'ComfyUI-AnimateDiff-Evolved',
     url: 'https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved',
+    description: 'AnimateDiff motion module integration for video generation',
   },
 
   // Florence2
   Florence2: {
     package: 'ComfyUI-Florence2',
     url: 'https://github.com/kijai/ComfyUI-Florence2',
+    description: 'Florence2 vision-language model for object detection, captioning, segmentation, and OCR',
   },
 
   // InstantID
   InstantIDFaceAnalysis: {
     package: 'ComfyUI_InstantID',
     url: 'https://github.com/cubiq/ComfyUI_InstantID',
+    description: 'Native InstantID face identity preservation for consistent character generation',
   },
   ApplyInstantID: {
     package: 'ComfyUI_InstantID',
     url: 'https://github.com/cubiq/ComfyUI_InstantID',
+    description: 'Native InstantID face identity preservation for consistent character generation',
   },
 
   // Segment Anything
   GroundingDinoSAMSegment: {
     package: 'comfyui_segment_anything',
     url: 'https://github.com/storyicon/comfyui_segment_anything',
+    description: 'Text-prompted image segmentation using GroundingDINO and SAM',
+  },
+
+  // Frame Interpolation
+  'FILM VFI': {
+    package: 'ComfyUI-Frame-Interpolation',
+    url: 'https://github.com/Fannovel16/ComfyUI-Frame-Interpolation',
+    description: 'Video frame interpolation for smooth slow-motion and frame rate conversion',
+  },
+
+  // Depth Anything V2
+  DepthAnything_V2: {
+    package: 'ComfyUI-DepthAnythingV2',
+    url: 'https://github.com/kijai/ComfyUI-DepthAnythingV2',
+    description: 'Depth Anything V2 monocular depth estimation',
+  },
+  DownloadAndLoadDepthAnythingV2Model: {
+    package: 'ComfyUI-DepthAnythingV2',
+    url: 'https://github.com/kijai/ComfyUI-DepthAnythingV2',
+    description: 'Depth Anything V2 monocular depth estimation',
+  },
+
+  // Segment Anything 2
+  Sam2Segmentation: {
+    package: 'ComfyUI-segment-anything-2',
+    url: 'https://github.com/kijai/ComfyUI-segment-anything-2',
+    description: 'SAM 2 segmentation for images and video with point and box prompts',
+  },
+  DownloadAndLoadSAM2Model: {
+    package: 'ComfyUI-segment-anything-2',
+    url: 'https://github.com/kijai/ComfyUI-segment-anything-2',
+    description: 'SAM 2 segmentation for images and video with point and box prompts',
   },
 };
 


### PR DESCRIPTION
## Summary

Adds knowledge base documentation for the top 20 custom node packages used across workflow templates, sourced from the Comfy Registry API and GitHub.

## Changes

### New: `site/knowledge/custom-nodes/` (20 files)
Each doc includes author, GitHub URL, registry link, download/star counts, template usage count, description, and key nodes listing.

**Top packages by template usage:**
| Package | Templates | Downloads |
|---------|-----------|-----------|
| ComfyUI-VideoHelperSuite | 32 | 2.1M |
| ComfyUI_essentials | 24 | 1.9M |
| ComfyUI-AudioScheduler | 16 | — |
| ComfyUI-Custom-Scripts | 8 | 1.8M |
| comfyui_controlnet_aux | 4 | 1.7M |

### Updated: `site/src/lib/node-registry.ts`
- Added `description` field to all existing registry entries that were missing it
- Added 9 new node entries for frequently-used nodes not previously registered:
  - `VHS_LoadVideo`, `VHS_VideoCombine`, `VHS_VideoInfo` (VideoHelperSuite)
  - `DWPreprocessor`, `PixelPerfectResolution` (controlnet_aux)
  - `FILM VFI` (Frame-Interpolation)
  - `DepthAnything_V2`, `DownloadAndLoadDepthAnythingV2Model` (DepthAnythingV2)
  - `Sam2Segmentation`, `DownloadAndLoadSAM2Model` (segment-anything-2)

## Data Sources
- Comfy Registry API (`https://api.comfy.org/nodes/{id}`) for package metadata
- WS0 inventory data for template usage counts
- GitHub READMEs for packages not on the registry

## Verification
- `pnpm run lint` passes with zero warnings