### PR TITLE
feat(prompts): add PAS copywriting framework to AI content generation

### DIFF
--- a/site/knowledge/prompts/breakthrough.md
+++ b/site/knowledge/prompts/breakthrough.md
@@ -26,13 +26,15 @@ Highlight what's new and exciting about this workflow, capture early adopter int
 
 Each paragraph should be 2-3 sentences max, separated by `\n\n`. Use the full model/workflow name once in the first sentence, then refer to it as "this workflow" or "it". Do not repeat the name more than twice total.
 
-**Paragraph 1 (What it does + output)**: Start with "[Model name] introduces/enables [new capability]" in the first sentence. Include release timeframe if known.
+Follow the **PAS framework** from the system prompt (adapted for breakthroughs):
+
+**Paragraph 1 — Problem**: Start with "[Model name] introduces/enables [new capability]" in the first sentence. Name what was previously impossible or impractical. Include release timeframe if known.
 
 - Example: "Wan 2.1 brings video generation to ComfyUI, released in early 2025. It creates 480p videos from a single input image."
 
-**Paragraph 2 (How/why it works)**: What specifically improved — be concrete about the advancement rather than using vague superlatives.
+**Paragraph 2 — Agitate**: What specifically was limited before — cloud-only, research-grade hardware, poor quality, missing features. Be concrete about the gap this model closes.
 
-**Paragraph 3 (Who should use it)**: Why this matters for specific users. Ground the value in practical benefits, not hype.
+**Paragraph 3 — Solution**: Why this matters for specific users now. Ground the value in practical benefits, not hype.
 
 **Temporal framing phrases**:
 

--- a/site/knowledge/prompts/comparison.md
+++ b/site/knowledge/prompts/comparison.md
@@ -26,13 +26,15 @@ Help users understand why they should choose this workflow over alternatives, wh
 
 Each paragraph should be 2-3 sentences max, separated by `\n\n`. Use the full model/workflow name once in the first sentence, then refer to it as "this workflow" or "it". Do not repeat the name more than twice total.
 
-**Paragraph 1 (What it does + output)**: Start with "[Model name] solves/addresses [problem]" in the first sentence. State the problem and what this workflow produces.
+Follow the **PAS framework** from the system prompt (adapted for comparison):
+
+**Paragraph 1 — Problem**: Start with "[Model name] solves/addresses [problem]" in the first sentence. Name the task and the decision the user faces between approaches.
 
 - Example: "Flux inpainting handles object removal and background replacement in ComfyUI. It works on any uploaded image with painted mask regions."
 
-**Paragraph 2 (How it compares)**: How it stacks up against alternatives. Be specific, balanced, and include at least one honest tradeoff.
+**Paragraph 2 — Agitate**: How existing alternatives fall short — speed, cost, quality, complexity. Be specific, balanced, and include at least one honest tradeoff for this workflow too.
 
-**Paragraph 3 (Who should use it)**: When this is the right choice and when it might not be. Help users self-select.
+**Paragraph 3 — Solution**: When this is the right choice and when it might not be. Help users self-select with concrete criteria.
 
 **Comparison phrases to use**:
 

--- a/site/knowledge/prompts/showcase.md
+++ b/site/knowledge/prompts/showcase.md
@@ -26,13 +26,15 @@ Inspire users with what's possible, emphasize output quality, create desire to t
 
 Each paragraph should be 2-3 sentences max, separated by `\n\n`. Use the full model/workflow name once in the first sentence, then refer to it as "this workflow" or "it". Do not repeat the name more than twice total.
 
-**Paragraph 1 (What it does + output)**: Start with "[Model name] creates/generates [output type]" in the first sentence. Be specific about the output format and quality.
+Follow the **PAS framework** from the system prompt:
+
+**Paragraph 1 — Problem**: Start with "[Model name] creates/generates [output type]" in the first sentence. Name the creative task and the gap it fills.
 
 - Example: "Flux upscaling produces 4K images from low-resolution sources in ComfyUI. You can upscale photos, illustrations, and AI-generated art with preserved detail."
 
-**Paragraph 2 (How/why it works)**: What makes it effective — speed, quality, consistency. Include specific metrics when available (e.g., "4x upscale in under 30 seconds").
+**Paragraph 2 — Agitate**: Acknowledge the previous limitations — slow manual upscaling, cloud costs, quality loss with traditional methods. One sentence, then pivot to this workflow's advantage (speed, quality, consistency).
 
-**Paragraph 3 (Who should use it)**: Which users and workflows benefit most. Be concrete about use cases.
+**Paragraph 3 — Solution**: Which users and workflows benefit most. Be concrete about outputs and professional applications.
 
 **Descriptive language to use**:
 

--- a/site/knowledge/prompts/system.md
+++ b/site/knowledge/prompts/system.md
@@ -9,6 +9,16 @@ You are a technical content writer for ComfyUI, an AI image and video generation
 - Focus on outcomes and benefits (what can users CREATE)
 - Confident, not salesy
 
+# Copywriting Framework
+
+Use **Problem → Agitate → Solution (PAS)** to structure the `extendedDescription`:
+
+1. **Problem** (paragraph 1): Name the specific task or pain point the user has. What are they trying to do? What's hard about it today?
+2. **Agitate** (paragraph 2): Briefly acknowledge why existing approaches fall short — cloud costs, manual effort, quality limitations, hardware barriers. One sentence is enough; don't dwell.
+3. **Solution** (paragraph 3): Present this workflow as the concrete answer. What does the user get? Be specific about outputs, speed, and who benefits.
+
+This framework applies lightly — the tone should feel helpful, not manipulative. The "agitate" step is a single honest observation, not fear-mongering.
+
 # Writing Style
 
 - Keep paragraphs SHORT: 2-3 sentences max, separated by blank lines (\n\n)

--- a/site/knowledge/prompts/tutorial.md
+++ b/site/knowledge/prompts/tutorial.md
@@ -24,13 +24,15 @@ Help users understand exactly how to use this workflow, with clear instructions 
 
 Each paragraph should be 2-3 sentences max, separated by `\n\n`. Use the full model/workflow name once in the first sentence, then refer to it as "this workflow" or "it". Do not repeat the name more than twice total.
 
-**Paragraph 1 (What it does + output)**: Start with "[Model name] [task]" in the first sentence. State what the workflow produces and for whom.
+Follow the **PAS framework** from the system prompt:
+
+**Paragraph 1 — Problem**: Start with "[Model name] [task]" in the first sentence. Name the task and what makes it worth solving.
 
 - Example: "Flux inpainting enables precise object removal and background replacement in ComfyUI. Upload any image and paint over the area you want to change."
 
-**Paragraph 2 (How/why it works)**: Explain the key technical approach briefly. Include hardware requirements if notable.
+**Paragraph 2 — Agitate**: Briefly note why this was hard before — cloud costs, manual work, quality issues, hardware limits. One honest sentence, then pivot to how this workflow addresses it.
 
-**Paragraph 3 (Who should use it)**: Who benefits most and what they can achieve. Keep it concrete and specific.
+**Paragraph 3 — Solution**: What the user gets concretely — outputs, speed, who benefits. Keep it specific and actionable.
 
 ### howToUse (5-8 numbered steps)
 


### PR DESCRIPTION
Adds the **Problem → Agitate → Solution** copywriting framework to the AI content generation prompts.

### Changes

- **system.md**: New `# Copywriting Framework` section defining PAS structure for `extendedDescription` paragraphs
- **tutorial.md, showcase.md, comparison.md, breakthrough.md**: Updated paragraph guidance to follow PAS (Problem → Agitate → Solution) instead of generic What/How/Who labels

### How it works

Each `extendedDescription` now follows:
1. **Problem** — Name the task/pain point the user has
2. **Agitate** — One honest sentence about why existing approaches fall short
3. **Solution** — Present this workflow as the concrete answer with specific outputs

Applied lightly — tone stays helpful, not manipulative. The agitate step is a single observation, not fear-mongering.