### PR TITLE
feat: A/B test content templates + fix Vercel thumbnail deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -62,4 +62,4 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: site
-          vercel-args: '--prod'
+          vercel-args: '--prebuilt --prod'


### PR DESCRIPTION
## Changes

### A/B Content Template Distribution
Replaces the keyword-based `selectContentTemplate` (which skewed 70% tutorial, 18% breakthrough) with a **stratified hash-based assignment** that distributes all 4 content templates evenly across popularity tiers:

- tutorial: 25.9%
- showcase: 24.9%
- comparison: 24.6%
- breakthrough: 24.6%

**How it works:**
1. Sort all templates by usage into 4 popularity quartiles
2. Within each quartile, assign content types via round-robin (sorted by deterministic name hash)
3. Each template always gets the same type (stable for caching)

This ensures proper A/B sampling — every content template type gets templates from all popularity levels, so we can fairly compare their effectiveness.

Bumps `CACHE_VERSION` to `2` to force regeneration with the new assignments.

### Fix Vercel Thumbnail Deploy
Changes `vercel-args` from `--prod` to `--prebuilt --prod` in the deploy workflow. Previously, the Vercel action would re-build on Vercel's servers where `../templates/` doesn't exist, so thumbnails were never copied. Now it deploys the CI-built `.vercel/output/` directly, which has thumbnails properly synced.