### PR TITLE
fix: preserve synced fields in humanEdited override path

### DIFF
--- a/site/scripts/generate-ai.ts
+++ b/site/scripts/generate-ai.ts
@@ -1185,9 +1185,10 @@ async function main() {
         console.log(`⏭️  [SKIP] ${template.name} - human edited`);
       } else {
         console.log(`⏭️  [SKIP] ${template.name} - human edited`);
+        const existing = await loadExistingSynced(outPath);
         await writeFile(
           outPath,
-          JSON.stringify({ ...template, ...override, humanEdited: true }, null, 2)
+          JSON.stringify({ ...existing, ...template, ...override, humanEdited: true }, null, 2)
         );
       }
       stats.skipped++;


### PR DESCRIPTION
## Problem

PR #571 added `loadExistingSynced` to preserve synced fields (like `thumbnails`) when `generate-ai.ts` overwrites template JSON files. However, it missed one code path — the `humanEdited` override branch.

Without this fix, any human-edited template would lose synced fields (`thumbnails`, `estimatedTime`, `requiredNodes`, `workflowModels`, etc.) because it wrote `{ ...template, ...override }` instead of `{ ...existing, ...template, ...override }`.

## Fix

Add `...existing` spread to the humanEdited write path, consistent with the other 4 write paths fixed in PR #571.

## Risk

Low — no human overrides exist yet (`overrides/templates/` only has `.gitkeep`), so this is a preventive fix.