### PR TITLE
fix: run template sync before build in deploy workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -51,6 +51,10 @@ jobs:
           restore-keys: |
             content-cache-
 
+      - name: Sync templates
+        run: pnpm run sync
+        working-directory: site
+
       - name: Build Astro site
         run: pnpm run build
         working-directory: site


### PR DESCRIPTION
## Problem

The deploy workflow (`deploy-site.yml`) runs `pnpm run build` (Astro build) but does **not** run the `sync` step first. The `sync` step (`pnpm run sync`) copies thumbnails from `templates/` to `site/public/templates/thumbnails/` and syncs template metadata into the site.

Without it, recently added templates have broken thumbnail images on the deployed site — currently ~14 templates added since the last manual sync (including Kling v3 and others) are affected.

## Fix

Added a "Sync templates" step (`pnpm run sync`) before the "Build Astro site" step in the deploy workflow, using the same `working-directory: site`.

This ensures thumbnails and template metadata are always up-to-date before the Astro build runs.