### PR TITLE
fix: rank popular models by total usage instead of template count

### DIFF
--- a/site/src/components/hub/HubBrowse.vue
+++ b/site/src/components/hub/HubBrowse.vue
@@ -52,15 +52,15 @@ const topTags = computed(() => {
     .map(([name]) => name);
 });
 
-// Derive top models from template data
+// Derive top models from template data (ranked by total usage)
 const topModels = computed(() => {
-  const counts = new Map<string, number>();
+  const usageTotals = new Map<string, number>();
   for (const t of props.templates) {
     for (const m of t.models) {
-      counts.set(m, (counts.get(m) || 0) + 1);
+      usageTotals.set(m, (usageTotals.get(m) || 0) + (t.usage || 0));
     }
   }
-  return Array.from(counts.entries())
+  return Array.from(usageTotals.entries())
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5)
     .map(([name]) => name);


### PR DESCRIPTION
The "POPULAR MODELS" sidebar in `HubBrowse.vue` was ranking models by how many templates reference them (template count), which caused models like Stability (19 templates, 1,233 total usage) to appear in the top 5 while higher-usage models like Qwen-Image-Edit (6,467 usage) and LTX-2 (2,220 usage) were excluded.

This changes the ranking to use total `usage` across all templates for each model, which better reflects actual popularity.