### PR TITLE
Fix publish workflow: abort if subpackage upload fails

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,44 +216,66 @@ jobs:
           for pkg in $PACKAGES; do
             if [ "$pkg" != "meta" ]; then
               echo "📦 Building package: $pkg"
-              
+
               if ! python -m build --outdir dist packages/$pkg; then
                 echo "❌ Failed to build package $pkg"
                 exit 1
               fi
-              
+
               echo "🚀 Publishing $pkg to PyPI..."
-              if ! twine upload dist/*$pkg* 2>/dev/null; then
-                echo "⚠️ Upload failed for $pkg (may already exist), continuing..."
-              else
-                echo "✅ Successfully published $pkg"
+              # --skip-existing returns exit code 0 if version already on PyPI (idempotent)
+              # Real upload failures (auth, network, etc.) will still exit non-zero and abort the workflow
+              if ! twine upload --skip-existing dist/*$pkg*; then
+                echo "❌ Failed to upload $pkg - aborting to prevent broken meta package"
+                exit 1
               fi
-              
+              echo "✅ Successfully published $pkg"
+
               rm -f dist/*$pkg*
             fi
           done
-          
+
+          # Before publishing meta, verify all pinned subpackage dependencies are on PyPI
+          echo -e "\n--- Pre-publish dependency check for meta package ---"
+          META_DEPS=$(grep -E 'comfyui-workflow-templates-[a-z-]+==\S+' pyproject.toml | grep -oE 'comfyui-workflow-templates-[a-z-]+==[0-9.]+')
+          ALL_DEPS_OK=true
+          for dep in $META_DEPS; do
+            pkg_name=$(echo "$dep" | cut -d= -f1)
+            pkg_ver=$(echo "$dep" | cut -d= -f3)
+            pypi_check=$(curl -s --max-time 10 "https://pypi.org/pypi/$pkg_name/$pkg_ver/json" -o /dev/null -w "%{http_code}")
+            if [ "$pypi_check" = "200" ]; then
+              echo "✓ $pkg_name==$pkg_ver is available on PyPI"
+            else
+              echo "❌ $pkg_name==$pkg_ver is NOT on PyPI (HTTP $pypi_check) - cannot publish meta"
+              ALL_DEPS_OK=false
+            fi
+          done
+          if [ "$ALL_DEPS_OK" = "false" ]; then
+            echo "❌ One or more meta dependencies are missing from PyPI. Aborting."
+            exit 1
+          fi
+
           # Then build and publish meta package
           echo -e "\n--- Building Meta Package ---"
           for pkg in $PACKAGES; do
             if [ "$pkg" = "meta" ]; then
               echo "📦 Building root meta package"
-              
+
               if ! python -m build --outdir dist .; then
                 echo "❌ Failed to build meta package"
                 exit 1
               fi
-              
+
               echo "🚀 Publishing meta package to PyPI..."
-              if ! twine upload dist/comfyui_workflow_templates-*; then
+              if ! twine upload --skip-existing dist/comfyui_workflow_templates-*; then
                 echo "❌ Failed to upload meta package"
                 exit 1
               fi
-              
+
               echo "✅ Successfully published meta package"
             fi
           done
-          
+
           echo -e "\n🎉 All packages published successfully!"
         env:
           TWINE_USERNAME: __token__

--- a/packages/media_other/pyproject.toml
+++ b/packages/media_other/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-other"
-version = "0.3.136"
+version = "0.3.137"
 description = "Media bundle containing audio/3D/misc workflow assets"
 readme = {text = "Media bundle containing audio, 3D, and other workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.9.16"
+version = "0.9.17"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -22,19 +22,19 @@ dependencies = [
     "comfyui-workflow-templates-media-api==0.3.61",
     "comfyui-workflow-templates-media-video==0.3.58",
     "comfyui-workflow-templates-media-image==0.3.100",
-    "comfyui-workflow-templates-media-other==0.3.136",
+    "comfyui-workflow-templates-media-other==0.3.137",
 ]
 
 [project.optional-dependencies]
 api = ["comfyui-workflow-templates-media-api==0.3.61"]
 video = ["comfyui-workflow-templates-media-video==0.3.58"]
 image = ["comfyui-workflow-templates-media-image==0.3.100"]
-other = ["comfyui-workflow-templates-media-other==0.3.136"]
+other = ["comfyui-workflow-templates-media-other==0.3.137"]
 all = [
     "comfyui-workflow-templates-media-api==0.3.61",
     "comfyui-workflow-templates-media-video==0.3.58",
     "comfyui-workflow-templates-media-image==0.3.100",
-    "comfyui-workflow-templates-media-other==0.3.136",
+    "comfyui-workflow-templates-media-other==0.3.137",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

- **Root cause**: `twine upload` errors were silenced with `2>/dev/null` and treated as warnings — when `media-other` upload failed, the workflow kept going and published the meta package with a dependency on a version that never made it to PyPI
- **Fix**: Replace silent error suppression with `twine upload --skip-existing` (idempotent for already-published versions, but fails loudly on real errors)
- **Safety net**: Added a pre-publish dependency check — before building/publishing the meta package, the workflow now verifies every pinned subpackage version exists on PyPI via HTTP check; aborts if any are missing
- **Version bumps**: `media_other` 0.3.136 → 0.3.137 (republish the missing version), meta 0.9.16 → 0.9.17 (trigger new release)

## Test plan

- [ ] Merge triggers publish workflow
- [ ] `media_other==0.3.137` appears on PyPI before meta package is published
- [ ] `pip install comfyui-workflow-templates==0.9.17` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)