### PR TITLE
fix(seo): use www.comfy.org domain and add lastmod fallbacks

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -27,12 +27,15 @@ if (fs.existsSync(templatesDir)) {
   }
 }
 
+// Build timestamp used as lastmod fallback for pages without a specific date
+const buildDate = new Date().toISOString();
+
 // Supported locales (matches src/i18n/config.ts)
 const locales = ['en', 'zh', 'zh-TW', 'ja', 'ko', 'es', 'fr', 'ru', 'tr', 'ar', 'pt-BR'];
 
 // https://astro.build/config
 export default defineConfig({
-  site: (process.env.PUBLIC_SITE_ORIGIN || 'https://comfy.org').replace(/\/$/, ''),
+  site: (process.env.PUBLIC_SITE_ORIGIN || 'https://www.comfy.org').replace(/\/$/, ''),
   prefetch: {
     prefetchAll: false,
     defaultStrategy: 'hover',
@@ -49,7 +52,7 @@ export default defineConfig({
       // Use custom filename to avoid collision with Framer's /sitemap.xml
       filenameBase: 'sitemap-workflows',
       // Include Framer's marketing sitemap in the index
-      customSitemaps: ['https://comfy.org/sitemap.xml'],
+      customSitemaps: ['https://www.comfy.org/sitemap.xml'],
       serialize(item) {
         const url = new URL(item.url);
         const pathname = url.pathname;
@@ -61,9 +64,7 @@ export default defineConfig({
         if (templateMatch) {
           const slug = templateMatch[2];
           const date = templateDates.get(slug);
-          if (date) {
-            item.lastmod = new Date(date).toISOString();
-          }
+          item.lastmod = date ? new Date(date).toISOString() : buildDate;
           // @ts-expect-error - sitemap types are stricter than actual API
           item.changefreq = 'monthly';
           item.priority = 0.8;
@@ -72,6 +73,7 @@ export default defineConfig({
 
         // Homepage
         if (pathname === '/' || pathname === '') {
+          item.lastmod = buildDate;
           // @ts-expect-error - sitemap types are stricter than actual API
           item.changefreq = 'daily';
           item.priority = 1.0;
@@ -80,6 +82,7 @@ export default defineConfig({
 
         // Workflows index (including localized versions)
         if (pathname.match(/^(?:\/[a-z]{2}(?:-[A-Z]{2})?)?\/workflows\/?$/)) {
+          item.lastmod = buildDate;
           // @ts-expect-error - sitemap types are stricter than actual API
           item.changefreq = 'daily';
           item.priority = 0.9;

--- a/site/src/config/site.ts
+++ b/site/src/config/site.ts
@@ -1,4 +1,4 @@
-const DEFAULT_ORIGIN = 'https://comfy.org';
+const DEFAULT_ORIGIN = 'https://www.comfy.org';
 
 function normalizeOrigin(raw?: string): string {
   const v = raw?.trim();


### PR DESCRIPTION
## Summary

Fixes two SEO issues affecting sitemap correctness and crawl efficiency.

### Fix Site Origin — Wrong Domain in All Sitemap URLs

All sitemap URLs, canonical tags, and structured data used `https://comfy.org` instead of the canonical `https://www.comfy.org`. Google treats these as separate properties, so the mismatch could prevent indexing.

**Changes:**
- `site/astro.config.mjs`: Updated fallback origin from `https://comfy.org` → `https://www.comfy.org`
- `site/astro.config.mjs`: Updated `customSitemaps` reference to `https://www.comfy.org/sitemap.xml`
- `site/src/config/site.ts`: Updated `DEFAULT_ORIGIN` to `https://www.comfy.org`

Local dev still works via the `PUBLIC_SITE_ORIGIN` env var override.

### Add `lastmod` Fallback for Index and Homepage Entries

Homepage, workflows index pages, and template detail pages without a `date` field had no `<lastmod>` in the sitemap. Google uses `lastmod` to prioritize crawl scheduling.

**Changes:**
- Added a `buildDate` timestamp constant
- Set `lastmod = buildDate` on homepage and workflows index entries
- Template detail pages now fall back to `buildDate` when no `date` field exists

## Verification

After deploy, confirm:
1. `curl https://www.comfy.org/sitemap-workflows-0.xml` — all URLs use `https://www.comfy.org/` and have `<lastmod>`
2. View source on a workflow page — `<link rel="canonical">` uses `https://www.comfy.org/`
