### PR TITLE
fix(analytics): add hub: prefix to PostHog events and centralize tracking

### DIFF
--- a/site/src/components/PostHogAnalytics.astro
+++ b/site/src/components/PostHogAnalytics.astro
@@ -1,23 +1,60 @@
 ---
 // PostHog analytics initialization — loaded on every page via BaseLayout.
-// Uses different project keys for staging vs production (detected by hostname).
+// All PostHog event tracking is centralised here via global event delegation.
 ---
 
 <script>
-  import { initPostHog, trackRunButtonClicked, trackSignupCtaClicked } from '../lib/posthog';
+  import {
+    initPostHog,
+    trackRunButtonClicked,
+    trackSignupCtaClicked,
+    trackDownloadButtonClicked,
+    trackShareButtonClicked,
+    trackTemplateViewed,
+  } from '../lib/posthog';
+
   initPostHog();
 
-  // Global delegation for run-cloud and signup CTA buttons across all pages
+  // Template detail page view
+  const detailPage = document.querySelector('.template-detail-page');
+  if (detailPage) {
+    const name = detailPage.getAttribute('data-template') || '';
+    const mediaType = detailPage.getAttribute('data-media-type') || '';
+    if (name) {
+      trackTemplateViewed(name, mediaType);
+    }
+  }
+
+  // Global click delegation
   document.addEventListener('click', (e) => {
-    const target = (e.target as HTMLElement).closest('.run-cloud-btn');
-    if (target) {
-      const templateName = target.getAttribute('data-template') || '';
-      const location = target.getAttribute('data-location') || 'unknown';
+    const target = e.target as HTMLElement;
+
+    // Run on Cloud button
+    const runBtn = target.closest('.run-cloud-btn');
+    if (runBtn) {
+      const templateName = runBtn.getAttribute('data-template') || '';
+      const location = runBtn.getAttribute('data-location') || 'unknown';
       if (templateName) {
         trackRunButtonClicked(templateName, location);
       } else {
         trackSignupCtaClicked(location);
       }
+      return;
+    }
+
+    // Download JSON button
+    const downloadBtn = target.closest('.download-json-btn');
+    if (downloadBtn) {
+      const templateName = downloadBtn.getAttribute('data-template') || '';
+      if (templateName) trackDownloadButtonClicked(templateName);
+      return;
+    }
+
+    // Share button
+    const shareBtn = target.closest('#share-workflow-btn');
+    if (shareBtn) {
+      const templateName = shareBtn.getAttribute('data-template') || '';
+      if (templateName) trackShareButtonClicked(templateName);
     }
   });
 </script>

--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -76,7 +76,7 @@ function formatRelativeDate(dateStr: string): string {
 }
 ---
 
-<article class="bg-page min-h-screen text-content scroll-smooth">
+<article class="template-detail-page bg-page min-h-screen text-content scroll-smooth" data-template={data.name} data-media-type={data.mediaType}>
   <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pt-4 lg:pt-16 pb-32">
     <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 justify-between w-full">
       {/* Back button */}
@@ -264,30 +264,20 @@ function formatRelativeDate(dateStr: string): string {
   </div>
 </article>
 
-<script is:inline define:vars={{ templateName: data.name, mediaType: data.mediaType }}>
-  // PostHog helper — safe to call before/after init
-  function phCapture(event, props) {
-    if (window.posthog) window.posthog.capture(event, props);
-  }
-
-  // Track template page view
-  phCapture('template_viewed', { template_name: templateName, media_type: mediaType });
-
-  // Run on Cloud button
+<script is:inline define:vars={{ templateName: data.name }}>
+  // Run on Cloud button — Vercel analytics
   document.querySelectorAll('.run-cloud-btn').forEach((link) => {
     link.addEventListener('click', () => {
       const loc = link.getAttribute('data-location') || 'hero';
-      phCapture('run_button_clicked', { template_name: templateName, location: loc });
       if (window.va) {
         window.va('event', { name: 'cta_click', template: templateName, location: loc });
       }
     });
   });
 
-  // Download JSON button
+  // Download JSON button — Vercel analytics
   document.querySelectorAll('.download-json-btn').forEach((link) => {
     link.addEventListener('click', () => {
-      phCapture('download_button_clicked', { template_name: templateName });
       if (window.va) {
         window.va('event', { name: 'download_json', template: templateName });
       }
@@ -298,7 +288,6 @@ function formatRelativeDate(dateStr: string): string {
   const shareBtn = document.getElementById('share-workflow-btn');
   if (shareBtn) {
     shareBtn.addEventListener('click', function () {
-      phCapture('share_button_clicked', { template_name: templateName });
       var url = window.location.href;
 
       function showCopied() {

--- a/site/src/lib/posthog.ts
+++ b/site/src/lib/posthog.ts
@@ -9,10 +9,12 @@ export function initPostHog(): void {
 
   posthog.init(POSTHOG_KEY, {
     api_host: 'https://ph.comfy.org',
+    ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
     capture_pageview: true,
     capture_pageleave: true,
     autocapture: false,
+    debug: import.meta.env.DEV,
   });
 
   initialized = true;
@@ -22,7 +24,7 @@ export function initPostHog(): void {
  * All tracked events follow the object_verb taxonomy:
  * - snake_case
  * - past tense verbs
- * - e.g. run_button_clicked, template_viewed
+ * - e.g. hub:run_button_clicked, hub:template_viewed
  */
 type EventProperties = Record<string, string | number | boolean | undefined>;
 
@@ -37,20 +39,20 @@ export function trackRunButtonClicked(
   templateName: string,
   location: string,
 ): void {
-  capture('run_button_clicked', {
+  capture('hub:run_button_clicked', {
     template_name: templateName,
     location,
   });
 }
 
 export function trackDownloadButtonClicked(templateName: string): void {
-  capture('download_button_clicked', {
+  capture('hub:download_button_clicked', {
     template_name: templateName,
   });
 }
 
 export function trackShareButtonClicked(templateName: string): void {
-  capture('share_button_clicked', {
+  capture('hub:share_button_clicked', {
     template_name: templateName,
   });
 }
@@ -59,14 +61,14 @@ export function trackTemplateViewed(
   templateName: string,
   mediaType: string,
 ): void {
-  capture('template_viewed', {
+  capture('hub:template_viewed', {
     template_name: templateName,
     media_type: mediaType,
   });
 }
 
 export function trackSearchPerformed(query: string): void {
-  capture('search_performed', {
+  capture('hub:search_performed', {
     query,
   });
 }
@@ -75,14 +77,14 @@ export function trackFilterApplied(
   filterType: string,
   filterValue: string,
 ): void {
-  capture('filter_applied', {
+  capture('hub:filter_applied', {
     filter_type: filterType,
     filter_value: filterValue,
   });
 }
 
 export function trackSignupCtaClicked(location: string): void {
-  capture('signup_cta_clicked', {
+  capture('hub:signup_cta_clicked', {
     location,
   });
 }


### PR DESCRIPTION
Add `hub:` prefix to all custom PostHog events and move tracking from inline `window.posthog` calls to module-based global event delegation in PostHogAnalytics.astro. Also adds `ui_host` and dev-only `debug` mode to PostHog config.