### PR TITLE
Remove redundant template_viewed PostHog event

### DIFF
--- a/site/src/components/PostHogAnalytics.astro
+++ b/site/src/components/PostHogAnalytics.astro
@@ -10,20 +10,9 @@
     trackSignupCtaClicked,
     trackDownloadButtonClicked,
     trackShareButtonClicked,
-    trackTemplateViewed,
   } from '../lib/posthog';
 
   initPostHog();
-
-  // Template detail page view
-  const detailPage = document.querySelector('.template-detail-page');
-  if (detailPage) {
-    const name = detailPage.getAttribute('data-template') || '';
-    const mediaType = detailPage.getAttribute('data-media-type') || '';
-    if (name) {
-      trackTemplateViewed(name, mediaType);
-    }
-  }
 
   // Global click delegation
   document.addEventListener('click', (e) => {

--- a/site/src/lib/posthog.ts
+++ b/site/src/lib/posthog.ts
@@ -24,7 +24,7 @@ export function initPostHog(): void {
  * All tracked events follow the object_verb taxonomy:
  * - snake_case
  * - past tense verbs
- * - e.g. hub:run_button_clicked, hub:template_viewed
+ * - e.g. hub:run_button_clicked, hub:search_performed
  */
 type EventProperties = Record<string, string | number | boolean | undefined>;
 
@@ -54,16 +54,6 @@ export function trackDownloadButtonClicked(templateName: string): void {
 export function trackShareButtonClicked(templateName: string): void {
   capture('hub:share_button_clicked', {
     template_name: templateName,
-  });
-}
-
-export function trackTemplateViewed(
-  templateName: string,
-  mediaType: string,
-): void {
-  capture('hub:template_viewed', {
-    template_name: templateName,
-    media_type: mediaType,
   });
 }
 


### PR DESCRIPTION
PostHog auto-captures $pageview events for every page load, making the custom template_viewed event redundant. Removes the event call and its unused helper.