### PR TITLE
fix(analytics): update PostHog API host to t.comfy.org

### DIFF
--- a/site/src/lib/posthog.ts
+++ b/site/src/lib/posthog.ts
@@ -8,7 +8,7 @@ export function initPostHog(): void {
   if (typeof window === 'undefined' || initialized || !POSTHOG_KEY) return;
 
   posthog.init(POSTHOG_KEY, {
-    api_host: 'https://ph.comfy.org',
+    api_host: 'https://t.comfy.org',
     ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
     capture_pageview: true,

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -14,7 +14,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://raw.githubusercontent.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://ph.comfy.org; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://raw.githubusercontent.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://t.comfy.org; frame-ancestors 'none'"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
Update PostHog API host from ph.comfy.org to t.comfy.org in both the PostHog init config and the Vercel CSP connect-src header.