### PR TITLE
fix: make workflow cards clickable on creators page

### DIFF
--- a/site/src/pages/workflows/creators.astro
+++ b/site/src/pages/workflows/creators.astro
@@ -147,18 +147,20 @@ const canonicalUrl = absoluteUrl('/workflows/creators/');
                 {/* Workflow cards */}
                 <div class="flex-1 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 xl:grid-cols-5 gap-4 min-w-0">
                   {tmplList.slice(0, 5).map((tmpl) => (
-                    <HubWorkflowCard
-                      name={tmpl.data.name}
-                      title={tmpl.data.title || tmpl.data.name}
-                      tags={tmpl.data.tags}
-                      logos={tmpl.data.logos}
-                      thumbnails={tmpl.data.thumbnails}
-                      username={tmpl.data.username}
-                      creatorDisplayName={profile.displayName}
-                      creatorAvatarUrl={profile.avatarUrl}
-                      locale={locale}
-                      hideAuthor
-                    />
+                    <a href={localizeUrl(`/workflows/${tmpl.data.name}/`, locale)} class="block" data-astro-prefetch>
+                      <HubWorkflowCard
+                        name={tmpl.data.name}
+                        title={tmpl.data.title || tmpl.data.name}
+                        tags={tmpl.data.tags}
+                        logos={tmpl.data.logos}
+                        thumbnails={tmpl.data.thumbnails}
+                        username={tmpl.data.username}
+                        creatorDisplayName={profile.displayName}
+                        creatorAvatarUrl={profile.avatarUrl}
+                        locale={locale}
+                        hideAuthor
+                      />
+                    </a>
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
HubWorkflowCard is rendered without client:load on the creators page, so Vue click handlers never hydrate. Wrap each card in an <a> tag to provide native navigation to the workflow detail page.