### PR TITLE
feat(analytics): enable cross-domain cookies and always-on person profiles

### DIFF
--- a/site/src/lib/posthog.ts
+++ b/site/src/lib/posthog.ts
@@ -10,7 +10,8 @@ export function initPostHog(): void {
   posthog.init(POSTHOG_KEY, {
     api_host: 'https://ph.comfy.org',
     ui_host: 'https://us.posthog.com',
-    person_profiles: 'identified_only',
+    person_profiles: 'always',
+    cross_subdomain_cookie: true,
     capture_pageview: true,
     capture_pageleave: true,
     autocapture: false,


### PR DESCRIPTION
Enable cross-subdomain cookie sharing and switch person_profiles from identified_only to always for better user tracking across comfy.org subdomains.