### PR TITLE
feat: add GA4 tracking via gtag.js to Astro site

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -34,6 +34,7 @@ jobs:
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       PUBLIC_POSTHOG_KEY: phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO
+      PUBLIC_GA_MEASUREMENT_ID: ${{ secrets.PUBLIC_GA_MEASUREMENT_ID }}
       SKIP_AI_GENERATION: ${{ inputs.skip_ai && 'true' || '' }}
       FORCE_AI_REGENERATE: ${{ inputs.force_regenerate && 'true' || '' }}
       AI_TEMPLATE_FILTER: ${{ inputs.template_filter }}

--- a/site/.env.example
+++ b/site/.env.example
@@ -9,6 +9,9 @@
 # Set in Vercel for production. If unset, PostHog is disabled.
 # PUBLIC_POSTHOG_KEY=phc_...
 
+# Google Analytics 4 measurement ID. If unset, GA4 is disabled.
+# PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
 # === AI Content Generation ===
 # OpenAI API key for AI content generation
 OPENAI_API_KEY=sk-...

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -6,6 +6,8 @@ import '../styles/global.css';
 import { LANGUAGES, type Locale } from '../i18n/config';
 import { getLocaleFromPath } from '../i18n/utils';
 
+const GA_ID = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
+
 interface Props {
   title: string;
   description: string;
@@ -49,6 +51,18 @@ const bodyClasses = isDark
 <!doctype html>
 <html lang={locale} dir={htmlDir} class="scroll-smooth">
   <head>
+    {GA_ID && (
+      <>
+        <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
+        <script is:inline define:vars={{ GA_ID }}>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          window.gtag = gtag;
+          gtag('js', new Date());
+          gtag('config', GA_ID);
+        </script>
+      </>
+    )}
     <SEOHead
       title={title}
       description={description}

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -23,7 +23,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://raw.githubusercontent.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://t.comfy.org; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://raw.githubusercontent.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com https://t.comfy.org https://www.google-analytics.com https://www.googletagmanager.com; frame-ancestors 'none'"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
## Summary

Add Google Analytics 4 (GA4) tracking to the Astro site via gtag.js, enabling conversion funnel visibility alongside existing Vercel Analytics.

## Changes

- **GA4 gtag.js in BaseLayout**: Conditionally loads the gtag.js script in `<head>` when `PUBLIC_GA_MEASUREMENT_ID` is set. Exposes `window.gtag` globally, which the existing `experiments.ts` already uses for experiment exposure tracking.
- **GitHub Actions**: Adds `PUBLIC_GA_MEASUREMENT_ID` secret to `deploy-site.yml` build env.
- **CSP update**: Allows `googletagmanager.com` (script-src) and `google-analytics.com` + `googletagmanager.com` (connect-src) in `vercel.json`.
- **Env documentation**: Adds `PUBLIC_GA_MEASUREMENT_ID` to `.env.example`.

## Manual Step Required

Add `PUBLIC_GA_MEASUREMENT_ID` as a GitHub Actions secret with the GA4 measurement ID value.

## Review Focus

- The GA4 script is **only rendered when the env var is set** — no impact on dev or if the secret is missing.
- Uses the same data stream/measurement ID across all `*.comfy.org` subdomains (GA4 best practice for subdomain tracking).
- `window.gtag` is already referenced by `site/src/lib/experiments.ts` for experiment exposure events — this PR makes that integration functional.

<!-- Pipeline-Ticket: 2e0e191f-6dfc-4401-a37f-60ea80f9542f -->
