### PR TITLE
feat(analytics): track author on template events

### DIFF
--- a/site/src/components/PostHogAnalytics.astro
+++ b/site/src/components/PostHogAnalytics.astro
@@ -20,8 +20,9 @@
   if (detailPage) {
     const name = detailPage.getAttribute('data-template') || '';
     const mediaType = detailPage.getAttribute('data-media-type') || '';
+    const author = detailPage.getAttribute('data-author') || undefined;
     if (name) {
-      trackTemplateViewed(name, mediaType);
+      trackTemplateViewed(name, mediaType, author);
     }
   }
 
@@ -34,8 +35,9 @@
     if (runBtn) {
       const templateName = runBtn.getAttribute('data-template') || '';
       const location = runBtn.getAttribute('data-location') || 'unknown';
+      const author = runBtn.getAttribute('data-author') || undefined;
       if (templateName) {
-        trackRunButtonClicked(templateName, location);
+        trackRunButtonClicked(templateName, location, author);
       } else {
         trackSignupCtaClicked(location);
       }
@@ -46,7 +48,8 @@
     const downloadBtn = target.closest('.download-json-btn');
     if (downloadBtn) {
       const templateName = downloadBtn.getAttribute('data-template') || '';
-      if (templateName) trackDownloadButtonClicked(templateName);
+      const author = downloadBtn.getAttribute('data-author') || undefined;
+      if (templateName) trackDownloadButtonClicked(templateName, author);
       return;
     }
 
@@ -54,7 +57,8 @@
     const shareBtn = target.closest('#share-workflow-btn');
     if (shareBtn) {
       const templateName = shareBtn.getAttribute('data-template') || '';
-      if (templateName) trackShareButtonClicked(templateName);
+      const author = shareBtn.getAttribute('data-author') || undefined;
+      if (templateName) trackShareButtonClicked(templateName, author);
     }
   });
 </script>

--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -82,6 +82,7 @@ function formatRelativeDate(dateStr: string): string {
   class="template-detail-page bg-page min-h-screen text-content scroll-smooth"
   data-template={data.name}
   data-media-type={data.mediaType}
+  data-author={data.username || ''}
 >
   <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pt-4 lg:pt-16 pb-32">
     <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 justify-between w-full">
@@ -207,6 +208,7 @@ function formatRelativeDate(dateStr: string): string {
               rel="noopener noreferrer"
               class="run-cloud-btn flex items-center justify-center h-10 bg-brand rounded-full text-sm font-bold text-page hover:opacity-90 transition-opacity"
               data-template={data.name}
+              data-author={data.username || ''}
               data-location="hero"
             >
               {t('cta.tryCloud', locale)}
@@ -216,6 +218,7 @@ function formatRelativeDate(dateStr: string): string {
               download
               class="download-json-btn flex items-center justify-center h-10 border border-divider rounded-full text-sm text-content hover:border-white/60 transition-colors"
               data-template={data.name}
+              data-author={data.username || ''}
             >
               {t('cta.downloadJson', locale)}
             </a>

--- a/site/src/lib/posthog.ts
+++ b/site/src/lib/posthog.ts
@@ -39,32 +39,44 @@ export function capture(eventName: string, properties?: EventProperties): void {
 export function trackRunButtonClicked(
   templateName: string,
   location: string,
+  author?: string,
 ): void {
   capture('hub:run_button_clicked', {
     template_name: templateName,
     location,
+    author,
   });
 }
 
-export function trackDownloadButtonClicked(templateName: string): void {
+export function trackDownloadButtonClicked(
+  templateName: string,
+  author?: string,
+): void {
   capture('hub:download_button_clicked', {
     template_name: templateName,
+    author,
   });
 }
 
-export function trackShareButtonClicked(templateName: string): void {
+export function trackShareButtonClicked(
+  templateName: string,
+  author?: string,
+): void {
   capture('hub:share_button_clicked', {
     template_name: templateName,
+    author,
   });
 }
 
 export function trackTemplateViewed(
   templateName: string,
   mediaType: string,
+  author?: string,
 ): void {
   capture('hub:template_viewed', {
     template_name: templateName,
     media_type: mediaType,
+    author,
   });
 }
 


### PR DESCRIPTION
Add author property to template_viewed, run_button_clicked, download_button_clicked, and share_button_clicked PostHog events via data-author attributes.