### PR TITLE
seo: improve metadata, alt text, structured data, and i18n page titles

### DIFF
--- a/site/src/components/ThumbnailDisplay.astro
+++ b/site/src/components/ThumbnailDisplay.astro
@@ -123,7 +123,7 @@ const isVideo = primaryThumb?.endsWith('.mp4') || primaryThumb?.endsWith('.mov')
     <div class={`compare-slider relative overflow-hidden ${className}`} data-compare-slider>
       <img
         src={`/workflows/thumbnails/${primaryThumb}`}
-        alt={`${title} - After`}
+        alt={`ComfyUI workflow preview: ${title} - After`}
         loading={loading}
         fetchpriority={fetchpriority}
         width="640"
@@ -139,7 +139,7 @@ const isVideo = primaryThumb?.endsWith('.mp4') || primaryThumb?.endsWith('.mov')
       >
         <img
           src={`/workflows/thumbnails/${secondaryThumb}`}
-          alt={`${title} - Before`}
+          alt={`ComfyUI workflow: ${title} - Before`}
           loading={loading}
           width="640"
           height="360"
@@ -177,7 +177,7 @@ const isVideo = primaryThumb?.endsWith('.mp4') || primaryThumb?.endsWith('.mov')
     <div class={`hover-dissolve group relative overflow-hidden ${className}`}>
       <img
         src={`/workflows/thumbnails/${primaryThumb}`}
-        alt={`${title} - State 1`}
+        alt={`ComfyUI workflow template: ${title} - Preview 1`}
         loading={loading}
         fetchpriority={fetchpriority}
         width="640"
@@ -189,7 +189,7 @@ const isVideo = primaryThumb?.endsWith('.mp4') || primaryThumb?.endsWith('.mov')
       />
       <img
         src={`/workflows/thumbnails/${secondaryThumb}`}
-        alt={`${title} - State 2`}
+        alt={`ComfyUI workflow template: ${title} - Preview 2`}
         loading={loading}
         width="640"
         height="360"
@@ -203,7 +203,7 @@ const isVideo = primaryThumb?.endsWith('.mp4') || primaryThumb?.endsWith('.mov')
     <div class={`animated-thumb group relative overflow-hidden ${className}`}>
       <img
         src={`/workflows/thumbnails/${primaryThumb}`}
-        alt={title}
+        alt={`ComfyUI workflow template: ${title}`}
         loading={loading}
         fetchpriority={fetchpriority}
         width="640"
@@ -218,7 +218,7 @@ const isVideo = primaryThumb?.endsWith('.mp4') || primaryThumb?.endsWith('.mov')
     <div class={`zoom-hover group relative overflow-hidden ${className}`}>
       <img
         src={`/workflows/thumbnails/${primaryThumb}`}
-        alt={title}
+        alt={`ComfyUI workflow template: ${title}`}
         loading={loading}
         fetchpriority={fetchpriority}
         width="640"
@@ -233,7 +233,7 @@ const isVideo = primaryThumb?.endsWith('.mp4') || primaryThumb?.endsWith('.mov')
     <div class={`default-thumb group relative overflow-hidden ${className}`}>
       <img
         src={`/workflows/thumbnails/${primaryThumb}`}
-        alt={title}
+        alt={`ComfyUI workflow template: ${title}`}
         loading={loading}
         fetchpriority={fetchpriority}
         width="640"

--- a/site/src/components/hub/HubWorkflowCard.vue
+++ b/site/src/components/hub/HubWorkflowCard.vue
@@ -225,7 +225,7 @@ function handleCardClick() {
       >
         <img
           :src="primaryUrl || ''"
-          :alt="`${title} - After`"
+          :alt="`ComfyUI workflow preview: ${title} - After`"
           loading="lazy"
           decoding="async"
           draggable="false"
@@ -237,7 +237,7 @@ function handleCardClick() {
         >
           <img
             :src="secondaryUrl || ''"
-            :alt="`${title} - Before`"
+            :alt="`ComfyUI workflow preview: ${title} - Before`"
             loading="lazy"
             decoding="async"
             draggable="false"
@@ -273,7 +273,7 @@ function handleCardClick() {
       >
         <img
           :src="primaryUrl || ''"
-          :alt="`${title} - 1`"
+          :alt="`ComfyUI workflow: ${title} - Preview 1`"
           loading="lazy"
           decoding="async"
           draggable="false"
@@ -281,7 +281,7 @@ function handleCardClick() {
         />
         <img
           :src="secondaryUrl || ''"
-          :alt="`${title} - 2`"
+          :alt="`ComfyUI workflow: ${title} - Preview 2`"
           loading="lazy"
           decoding="async"
           draggable="false"
@@ -332,7 +332,7 @@ function handleCardClick() {
       <img
         v-else-if="primaryUrl && isAnimatedWebp"
         :src="primaryUrl"
-        :alt="title"
+        :alt="`ComfyUI workflow template: ${title}`"
         loading="lazy"
         decoding="async"
         draggable="false"
@@ -342,7 +342,7 @@ function handleCardClick() {
       <img
         v-else-if="primaryUrl && showZoomHover"
         :src="primaryUrl"
-        :alt="title"
+        :alt="`ComfyUI workflow template: ${title}`"
         loading="lazy"
         decoding="async"
         draggable="false"
@@ -352,7 +352,7 @@ function handleCardClick() {
       <img
         v-else-if="primaryUrl"
         :src="primaryUrl"
-        :alt="title"
+        :alt="`ComfyUI workflow template: ${title}`"
         loading="lazy"
         decoding="async"
         draggable="false"

--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -141,7 +141,7 @@
                 href="/workflows/"
                 class="text-white/90 text-sm hover:text-white transition-colors"
               >
-                Template
+                Workflows
               </a>
             </li>
           </ul>

--- a/site/src/i18n/ui.ts
+++ b/site/src/i18n/ui.ts
@@ -4,7 +4,7 @@ import type { Locale } from './config';
 export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   en: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': "Discover the World's Top Creators and Workflows",
+    'hub.subtitle': "Discover the World's Top Creators and ComfyUI Workflows",
     'hub.filters': 'FILTERS',
     'hub.models': 'MODELS',
     'hub.showMore': 'Show more...',
@@ -23,7 +23,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
       'This is a simplified visualization. The actual workflow may contain additional nodes and connections.',
     'labels.nodeUses': 'Uses',
     'meta.title': 'ComfyUI Workflows',
-    'meta.description': 'Browse free, ready-to-use ComfyUI workflows',
+    'meta.description': 'Free Official ComfyUI workflow templates for AI image generation, video creation, and audio synthesis. Discover cutting-edge AI generation technology',
     'template.count': 'templates',
     'template.updated': 'Updated daily',
     'template.runs': 'runs',
@@ -60,14 +60,14 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   zh: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': '发现全球顶级创作者',
+    'hub.subtitle': '发现全球顶级创作者和 ComfyUI 工作流',
     'hub.filters': '筛选',
     'hub.models': '模型',
     'hub.showMore': '查看更多...',
     'hub.topCreators': '顶级创作者',
     'hub.submitCreation': '提交作品',
     'hub.search': '搜索...',
-    'nav.templates': '工作流',
+    'nav.templates': 'ComfyUI 工作流',
     'nav.back': '返回工作流列表',
     'nav.backShort': '返回',
     'labels.createdBy': '创建者',
@@ -78,7 +78,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
     'labels.workflowPreviewNote': '这是简化的可视化。实际工作流可能包含更多节点和连接。',
     'labels.nodeUses': '使用',
     'meta.title': 'ComfyUI 工作流',
-    'meta.description': '浏览免费、开箱即用的 ComfyUI 工作流',
+    'meta.description': 'ComfyUI 官方工作流模板，支持 AI 图像生成、视频创作和音频合成。专业的 Stable Diffusion、Flux、SDXL 工作流。',
     'template.count': '个模板',
     'template.updated': '每日更新',
     'template.runs': '次运行',
@@ -115,7 +115,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   'zh-TW': {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': '探索全球頂級創作者',
+    'hub.subtitle': '探索全球頂級創作者和 ComfyUI 工作流',
     'hub.filters': '篩選',
     'hub.models': '模型',
     'hub.showMore': '查看更多...',
@@ -170,7 +170,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   ja: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': '世界のトップクリエイターを発見',
+    'hub.subtitle': '世界のトップクリエイターと ComfyUI ワークフローを発見',
     'hub.filters': 'フィルター',
     'hub.models': 'モデル',
     'hub.showMore': 'もっと見る...',
@@ -226,7 +226,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   ko: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': '세계 최고의 크리에이터를 만나보세요',
+    'hub.subtitle': '세계 최고의 크리에이터와 ComfyUI 워크플로우를 만나보세요',
     'hub.filters': '필터',
     'hub.models': '모델',
     'hub.showMore': '더 보기...',
@@ -282,7 +282,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   es: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': 'Descubre a los Mejores Creadores del Mundo',
+    'hub.subtitle': 'Descubre a los Mejores Creadores del Mundo y ComfyUI Workflows',
     'hub.filters': 'FILTROS',
     'hub.models': 'MODELOS',
     'hub.showMore': 'Ver más...',
@@ -338,7 +338,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   fr: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': 'Découvrez les Meilleurs Créateurs du Monde',
+    'hub.subtitle': 'Découvrez les Meilleurs Créateurs du Monde et ComfyUI Workflows',
     'hub.filters': 'FILTRES',
     'hub.models': 'MODÈLES',
     'hub.showMore': 'Voir plus...',
@@ -394,7 +394,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   ru: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': 'Откройте для себя лучших создателей мира',
+    'hub.subtitle': 'Откройте для себя лучших создателей мира и ComfyUI Workflows',
     'hub.filters': 'ФИЛЬТРЫ',
     'hub.models': 'МОДЕЛИ',
     'hub.showMore': 'Показать ещё...',
@@ -450,7 +450,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   tr: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': 'Dünyanın En İyi Yaratıcılarını Keşfedin',
+    'hub.subtitle': 'Dünyanın En İyi Yaratıcılarını ve ComfyUI Workflows Keşfedin',
     'hub.filters': 'FİLTRELER',
     'hub.models': 'MODELLER',
     'hub.showMore': 'Daha fazla...',
@@ -506,7 +506,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   ar: {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': 'اكتشف أفضل المبدعين في العالم',
+    'hub.subtitle': 'اكتشف أفضل المبدعين في العالم و ComfyUI Workflows',
     'hub.filters': 'التصفية',
     'hub.models': 'النماذج',
     'hub.showMore': 'عرض المزيد...',
@@ -562,7 +562,7 @@ export const UI_STRINGS: Record<Locale, Record<string, string>> = {
   },
   'pt-BR': {
     'hub.title': 'ComfyHub',
-    'hub.subtitle': 'Descubra os Melhores Criadores do Mundo',
+    'hub.subtitle': 'Descubra os Melhores Criadores do Mundo e ComfyUI Workflows',
     'hub.filters': 'FILTROS',
     'hub.models': 'MODELOS',
     'hub.showMore': 'Ver mais...',

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -157,7 +157,7 @@ if (isCreatorProfile && rawUsername) {
   const { data } = template;
   templateData = data as TemplateData;
 
-  pageTitle = `${data.title || data.name} - ComfyUI`;
+  pageTitle = `${data.title || data.name} - Official ComfyUI Workflow Template`;
   pageDescription = data.metaDescription || data.description;
   canonicalUrl = absoluteUrl('/' + locale + '/workflows/' + data.name + '/');
   hreflangBasePath = `/workflows/${data.name}/`;
@@ -175,10 +175,16 @@ if (isCreatorProfile && rawUsername) {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
     headline: data.title || data.name,
-    description: data.description,
+    description: data.metaDescription || data.description,
     image: primaryThumbnail ? absoluteUrl('/workflows/thumbnails/' + primaryThumbnail) : undefined,
     datePublished: data.date,
     inLanguage: locale,
+    keywords: ['ComfyUI workflow', 'ComfyUI template', data.title || data.name, ...(data.tags || []), ...(data.models || [])].join(', '),
+    about: {
+      '@type': 'Thing',
+      name: 'ComfyUI Workflows',
+      description: 'Node-based AI workflow system',
+    },
   };
 
   faqStructuredData = data.faqItems?.length

--- a/site/src/pages/[locale]/workflows/index.astro
+++ b/site/src/pages/[locale]/workflows/index.astro
@@ -33,6 +33,25 @@ const allTemplates = sortByUsage(templates);
 
 const canonicalUrl = absoluteUrl('/' + locale + '/workflows/');
 
+// WebSite structured data for SEO
+const websiteStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: t('meta.title', typedLocale),
+  url: canonicalUrl,
+  description: t('meta.description', typedLocale),
+  inLanguage: locale,
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${canonicalUrl}?q={search_term_string}`,
+    },
+    'query-input': 'required name=search_term_string',
+  },
+};
+
+// CollectionPage structured data
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
@@ -40,6 +59,26 @@ const structuredData = {
   description: t('meta.description', typedLocale),
   url: canonicalUrl,
   inLanguage: locale,
+  numberOfItems: allTemplates.length,
+};
+
+// ItemList structured data for top workflows
+const itemListStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: t('meta.title', typedLocale),
+  description: t('meta.description', typedLocale),
+  numberOfItems: Math.min(allTemplates.length, 20),
+  itemListElement: allTemplates.slice(0, 20).map((tmpl, idx) => ({
+    '@type': 'ListItem',
+    position: idx + 1,
+    item: {
+      '@type': 'SoftwareApplication',
+      name: tmpl.data.title || tmpl.data.name,
+      url: absoluteUrl(`/${locale}/workflows/${tmpl.data.name}/`),
+      applicationCategory: 'MultimediaApplication',
+    },
+  })),
 };
 
 // Serialize template data for the Vue island (plain objects only)
@@ -67,7 +106,7 @@ const mediaTypes = ['image', 'video', 'audio', '3d'];
 ---
 
 <BaseLayout
-  title={`${t('meta.title', typedLocale)} - ComfyUI`}
+  title={typedLocale === 'zh' ? 'ComfyUI 工作流 - 免费官方 AI 图像、视频、3D 和音频生成模板' : typedLocale === 'zh-TW' ? 'ComfyUI 工作流 - 免費官方 AI 圖像、視頻、3D 和音頻生成模板' : typedLocale === 'ja' ? 'ComfyUI ワークフロー - 無料公式 AI 画像・動画・3D・音声生成テンプレート' : typedLocale === 'ko' ? 'ComfyUI 워크플로우 - 무료 공식 AI 이미지, 비디오, 3D 및 오디오 생성 템플릿' : typedLocale === 'es' ? 'ComfyUI Workflows - Plantillas Oficiales Gratuitas de Generación de Imágenes, Video, 3D y Audio con IA' : typedLocale === 'fr' ? 'ComfyUI Workflows - Modèles Officiels Gratuits de Génération d\'Images, Vidéo, 3D et Audio par IA' : typedLocale === 'ru' ? 'ComfyUI Workflows - Бесплатные официальные шаблоны генерации изображений, видео, 3D и аудио с помощью ИИ' : typedLocale === 'tr' ? 'ComfyUI Workflows - Ücretsiz Resmi AI Görüntü, Video, 3D ve Ses Oluşturma Şablonları' : typedLocale === 'ar' ? 'ComfyUI Workflows - قوالب رسمية مجانية لتوليد الصور والفيديو والصوت بالذكاء الاصطناعي' : typedLocale === 'pt-BR' ? 'ComfyUI Workflows - Templates Oficiais Gratuitos de Geração de Imagens, Vídeo, 3D e Áudio com IA' : `ComfyUI Workflows - Free Official AI Image, Video, 3D & Audio Generation Templates`}
   description={t('meta.description', typedLocale)}
   canonicalUrl={canonicalUrl}
   ogImage="/workflows/og-default.png"
@@ -85,6 +124,10 @@ const mediaTypes = ['image', 'video', 'audio', '3d'];
     <!-- Interactive browse (Vue island) -->
     <HubBrowse client:load templates={serialized} locale={typedLocale} mediaTypes={mediaTypes} />
   </div>
+
+  <!-- Additional structured data for SEO -->
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(websiteStructuredData)} />
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(itemListStructuredData)} />
 
   <!-- Custom Footer -->
   <Fragment slot="footer">

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -22,7 +22,7 @@ const { template } = Astro.props;
 const locale = DEFAULT_LOCALE;
 const { data } = template;
 
-const title = `${data.title || data.name} - ComfyUI Workflow`;
+const title = `${data.title || data.name} - Official ComfyUI Workflow Template`;
 const hreflangBasePath = `/workflows/${data.name}/`;
 const canonicalUrl = absoluteUrl(hreflangBasePath);
 
@@ -38,10 +38,16 @@ const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'TechArticle',
   headline: data.title || data.name,
-  description: data.description,
+  description: data.metaDescription || data.description,
   image: primaryThumbnail ? absoluteUrl('/workflows/thumbnails/' + primaryThumbnail) : undefined,
   datePublished: data.date,
   inLanguage: 'en',
+  keywords: ['ComfyUI workflow', 'ComfyUI template', data.title || data.name, ...(data.tags || []), ...(data.models || [])].join(', '),
+  about: {
+    '@type': 'Thing',
+    name: 'ComfyUI Workflows',
+    description: 'Node-based AI workflow system',
+  },
 };
 
 const faqStructuredData = data.faqItems?.length
@@ -69,15 +75,17 @@ const breadcrumbStructuredData = {
 const softwareAppStructuredData = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
-  name: data.title || data.name,
+  name: `${data.title || data.name} - ComfyUI Workflow`,
   applicationCategory: 'MultimediaApplication',
   operatingSystem: 'Windows, macOS, Linux',
   description: data.metaDescription || data.description,
+  keywords: ['ComfyUI', 'workflow template', 'AI generation', ...(data.tags || [])].join(', '),
   offers: {
     '@type': 'Offer',
     price: '0',
     priceCurrency: 'USD',
   },
+  featureList: data.tags?.join(', ') || '',
 };
 ---
 

--- a/site/src/pages/workflows/index.astro
+++ b/site/src/pages/workflows/index.astro
@@ -19,12 +19,51 @@ const allTemplates = templates
 
 const canonicalUrl = absoluteUrl(localizeUrl('/workflows/', locale));
 
+// WebSite structured data for SEO
+const websiteStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'ComfyUI Workflows',
+  alternateName: 'ComfyHub',
+  url: canonicalUrl,
+  description: t('meta.description', locale),
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${canonicalUrl}?q={search_term_string}`,
+    },
+    'query-input': 'required name=search_term_string',
+  },
+};
+
+// CollectionPage structured data
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
   name: t('meta.title', locale),
   description: t('meta.description', locale),
   url: canonicalUrl,
+  numberOfItems: allTemplates.length,
+};
+
+// ItemList structured data for top workflows
+const itemListStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'ComfyUI Workflow Templates',
+  description: 'Collection of free ComfyUI workflow templates',
+  numberOfItems: Math.min(allTemplates.length, 20),
+  itemListElement: allTemplates.slice(0, 20).map((tmpl, idx) => ({
+    '@type': 'ListItem',
+    position: idx + 1,
+    item: {
+      '@type': 'SoftwareApplication',
+      name: tmpl.data.title || tmpl.data.name,
+      url: absoluteUrl(`/workflows/${tmpl.data.name}/`),
+      applicationCategory: 'MultimediaApplication',
+    },
+  })),
 };
 
 // Serialize template data for the Vue island (plain objects only)
@@ -52,7 +91,7 @@ const mediaTypes = ['image', 'video', 'audio', '3d'];
 ---
 
 <BaseLayout
-  title={`${t('meta.title', locale)} - Free AI Generation Workflows`}
+  title="ComfyUI Workflows - Free Official AI Image, Video, 3D & Audio Generation Templates"
   description={t('meta.description', locale)}
   canonicalUrl={canonicalUrl}
   ogImage="/workflows/og-default.png"
@@ -68,6 +107,10 @@ const mediaTypes = ['image', 'video', 'audio', '3d'];
     <!-- Interactive browse (Vue island) -->
     <HubBrowse client:load templates={serialized} locale={locale} mediaTypes={mediaTypes} />
   </div>
+
+  <!-- Additional structured data for SEO -->
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(websiteStructuredData)} />
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(itemListStructuredData)} />
 
   <!-- Custom Footer -->
   <Fragment slot="footer">


### PR DESCRIPTION
## Summary

- **Image alt text**: Added descriptive "ComfyUI workflow" prefix to all thumbnail alt attributes across all display variants
- **UI copy keyword optimization**: Updated hub subtitle, nav label, and meta.description across all 11 locales to include "ComfyUI Workflows" keyword
- **Localized page titles**: Workflow index page previously only had localized titles for 4 languages (zh/zh-TW/ja/ko), falling back to English for the rest. This PR completes all 11 languages (added es/fr/ru/tr/ar/pt-BR)
- **Footer link text**: Renamed footer "Template" link to "Workflows"
- **Structured data enhancements** (Schema.org):
  - Added `WebSite` + `SearchAction` to index pages (enables Google Sitelinks search box)
  - Added `ItemList` with top 20 templates to index pages (enables Rich Results)
  - Added `numberOfItems` to `CollectionPage`
  - Added `keywords` and `about` fields to `TechArticle` on template detail pages
  - Added `keywords` and `featureList` to `SoftwareApplication`
  - Prefer AI-generated `metaDescription` over plain `description` in structured data

## Files Changed

| File | Change |
|---|---|
| `ThumbnailDisplay.astro` | Improve alt text for all thumbnail variants |
| `HubWorkflowCard.vue` | Improve alt text for card images |
| `i18n/ui.ts` | Update hub subtitle, nav label, meta.description for all 11 locales |
| `workflows/index.astro` (en) | Add WebSite + ItemList structured data, improve title |
| `[locale]/workflows/index.astro` | Same as above, complete localized titles for all 11 languages |
| `workflows/[slug].astro` (en) | Enhance TechArticle + SoftwareApplication structured data |
| `[locale]/workflows/[slug].astro` | Same as above, localized versions |
| `SiteFooter.astro` | Rename footer link text from "Template" to "Workflows" |

## Test Plan

- [ ] Run `pnpm run dev` and verify localized `<title>` renders correctly for each language
- [ ] Validate structured data format using Google Rich Results Test
- [ ] Confirm JSON-LD scripts are correctly injected in `<head>`