### PR TITLE
ci: add PUBLIC_HUB_API_URL to deploy-site workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -47,6 +47,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       PUBLIC_POSTHOG_KEY: phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO
       PUBLIC_GA_MEASUREMENT_ID: ${{ secrets.PUBLIC_GA_MEASUREMENT_ID }}
+      PUBLIC_HUB_API_URL: ${{ secrets.HUB_API_URL }}
       SKIP_AI_GENERATION: ${{ inputs.skip_ai && 'true' || '' }}
       FORCE_AI_REGENERATE: ${{ inputs.force_regenerate && 'true' || '' }}
       AI_TEMPLATE_FILTER: ${{ inputs.template_filter }}


### PR DESCRIPTION
## Summary
- Production deploy workflow (`deploy-site.yml`) was missing `PUBLIC_HUB_API_URL` env var
- Astro build fell back to hardcoded default instead of using the correct URL from `secrets.HUB_API_URL`
- `preview-site.yml` already had this — `deploy-site.yml` was simply missed

## Test plan
- [x] Verify `HUB_API_URL` secret exists in repo settings
- [ ] Trigger a manual deploy and confirm the hub API URL is resolved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)