### PR TITLE
ci: fix hub API URL for production deploy

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -47,6 +47,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       PUBLIC_POSTHOG_KEY: phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO
       PUBLIC_GA_MEASUREMENT_ID: ${{ secrets.PUBLIC_GA_MEASUREMENT_ID }}
+      PUBLIC_HUB_API_URL: ${{ secrets.HUB_API_URL }}
       SKIP_AI_GENERATION: ${{ inputs.skip_ai && 'true' || '' }}
       FORCE_AI_REGENERATE: ${{ inputs.force_regenerate && 'true' || '' }}
       AI_TEMPLATE_FILTER: ${{ inputs.template_filter }}

--- a/site/src/lib/hub-api.ts
+++ b/site/src/lib/hub-api.ts
@@ -8,7 +8,7 @@
  */
 
 const HUB_API_BASE =
-  (import.meta.env.PUBLIC_HUB_API_URL || 'https://api.comfy.org').replace(/\/$/, '');
+  (import.meta.env.PUBLIC_HUB_API_URL || 'https://cloud.comfy.org').replace(/\/$/, '');
 
 // ---------------------------------------------------------------------------
 // Types — mirrors backend OpenAPI schemas


### PR DESCRIPTION
## Summary
- Add `PUBLIC_HUB_API_URL` env var to `deploy-site.yml` (was already in `preview-site.yml`)
- Correct fallback default in `hub-api.ts` from `api.comfy.org` to `cloud.comfy.org`

## Test plan
- [x] Verify `HUB_API_URL` secret exists in repo settings
- [x] Trigger a manual deploy and confirm the hub API URL resolves correctly