### PR TITLE
[CI] Add preview cron workflow for periodic rebuilds for test environments

### DIFF
--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -1,0 +1,108 @@
+name: Preview Cron
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.targets.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build rebuild targets
+        id: targets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          targets='[]'
+
+          # Always include main
+          targets=$(echo "$targets" | jq -c '. + [{"ref": "main", "is_main": true, "pr": 0}]')
+
+          # Find open PRs with the "preview-cron" label
+          prs=$(gh pr list --label "preview-cron" --state open --json number,headRefName)
+          for row in $(echo "$prs" | jq -c '.[]'); do
+            ref=$(echo "$row" | jq -r '.headRefName')
+            num=$(echo "$row" | jq -r '.number')
+            targets=$(echo "$targets" | jq -c \
+              --arg ref "$ref" --argjson num "$num" \
+              '. + [{"ref": $ref, "is_main": false, "pr": $num}]')
+          done
+
+          echo "matrix={\"include\":$targets}" >> "$GITHUB_OUTPUT"
+          echo "### Rebuild targets" >> "$GITHUB_STEP_SUMMARY"
+          echo "$targets" | jq '.' >> "$GITHUB_STEP_SUMMARY"
+
+  rebuild:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    concurrency:
+      group: preview-cron-${{ matrix.ref }}
+      cancel-in-progress: true
+    env:
+      SKIP_AI_GENERATION: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.ref }}
+
+      - name: Setup
+        uses: ./.github/actions/site-setup
+
+      - name: Restore content cache
+        uses: actions/cache@v4
+        with:
+          path: site/.content-cache
+          key: content-cache-cron-${{ matrix.ref }}-${{ hashFiles('templates/**', 'site/src/**') }}
+          restore-keys: |
+            content-cache-cron-${{ matrix.ref }}-
+
+      - name: Sync templates
+        run: pnpm run sync:en-only
+        working-directory: site
+
+      - name: Build Astro site
+        run: pnpm run build
+        working-directory: site
+        env:
+          PUBLIC_HUB_API_URL: ${{ secrets.HUB_API_URL_PREVIEW }}
+          PUBLIC_COMFY_CLOUD_URL: ${{ secrets.COMFY_CLOUD_URL_PREVIEW }}
+
+      - name: Deploy to Vercel
+        id: deploy
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: site
+          vercel-args: '--prebuilt'
+
+      - name: Alias main preview
+        if: matrix.is_main && vars.VERCEL_PREVIEW_ALIAS
+        run: |
+          npx vercel alias ${{ steps.deploy.outputs.preview-url }} ${{ vars.VERCEL_PREVIEW_ALIAS }} \
+            --token=${{ secrets.VERCEL_TOKEN }} \
+            --scope=${{ secrets.VERCEL_ORG_ID }}
+
+      - name: Comment preview URL on PR
+        if: matrix.pr > 0
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ matrix.pr }}
+          header: preview-cron
+          message: |
+            🔄 **Preview cron rebuilt:** ${{ steps.deploy.outputs.preview-url }}
+            _Last rebuild: ${{ github.event.head_commit.timestamp || 'manual trigger' }}_


### PR DESCRIPTION
## Motivation
We need dedicated test environment for content creator (in-house) and have requirements content should be updated without manual trigger
## Summary
- Add `preview-cron.yml` workflow that runs every 15 minutes
- **Main branch**: always rebuilds and deploys to a fixed Vercel alias (`VERCEL_PREVIEW_ALIAS` repo variable)
- **Labeled PRs**: open PRs with `preview-cron` label are automatically rebuilt and preview URL is commented on the PR

## Required setup
- **GitHub repo variable**: `VERCEL_PREVIEW_ALIAS` — fixed domain for the main preview (e.g. `preview-hub.comfy.org`)
- **GitHub label**: create `preview-cron` label on the repo
- Existing secrets (`HUB_API_URL_PREVIEW`, `COMFY_CLOUD_URL_PREVIEW`, `VERCEL_TOKEN`, etc.) are reused