### PR TITLE
Fix preview cron: read VERCEL_PREVIEW_ALIAS from secrets

### DIFF
--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -91,9 +91,9 @@ jobs:
           vercel-args: '--prebuilt'
 
       - name: Alias main preview
-        if: matrix.is_main && vars.VERCEL_PREVIEW_ALIAS
+        if: matrix.is_main && secrets.VERCEL_PREVIEW_ALIAS
         run: |
-          npx vercel alias ${{ steps.deploy.outputs.preview-url }} ${{ vars.VERCEL_PREVIEW_ALIAS }} \
+          npx vercel alias ${{ steps.deploy.outputs.preview-url }} ${{ secrets.VERCEL_PREVIEW_ALIAS }} \
             --token=${{ secrets.VERCEL_TOKEN }} \
             --scope=${{ secrets.VERCEL_ORG_ID }}
 


### PR DESCRIPTION
## Summary
- `VERCEL_PREVIEW_ALIAS` was added as a GitHub secret, but the workflow referenced it as `vars.VERCEL_PREVIEW_ALIAS` (repo variable)
- Changed to `secrets.VERCEL_PREVIEW_ALIAS` so the alias step runs correctly