### PR TITLE
fix(ci): remove secrets from if expressions in preview-cron

### DIFF
--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -93,25 +93,26 @@ jobs:
           working-directory: site
           vercel-args: '--prebuilt'
 
-      - name: Alias main preview (prod API)
-        if: matrix.is_main && matrix.api_env == 'production' && secrets.VERCEL_PREVIEW_ALIAS
+      - name: Alias main preview
+        if: matrix.is_main
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.preview-url }}
-          ALIAS: ${{ secrets.VERCEL_PREVIEW_ALIAS }}
+          PROD_ALIAS: ${{ secrets.VERCEL_PREVIEW_ALIAS }}
+          TEST_ALIAS: ${{ secrets.VERCEL_PREVIEW_TEST_ALIAS }}
+          API_ENV: ${{ matrix.api_env }}
           VERCEL_TOKEN_VAL: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
         run: |
-          npx vercel alias "$PREVIEW_URL" "$ALIAS" --token="$VERCEL_TOKEN_VAL" --scope="$VERCEL_SCOPE"
-
-      - name: Alias main preview (test API)
-        if: matrix.is_main && matrix.api_env == 'test' && secrets.VERCEL_PREVIEW_TEST_ALIAS
-        env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.preview-url }}
-          ALIAS: ${{ secrets.VERCEL_PREVIEW_TEST_ALIAS }}
-          VERCEL_TOKEN_VAL: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
-        run: |
-          npx vercel alias "$PREVIEW_URL" "$ALIAS" --token="$VERCEL_TOKEN_VAL" --scope="$VERCEL_SCOPE"
+          if [ "$API_ENV" = "production" ]; then
+            ALIAS="$PROD_ALIAS"
+          else
+            ALIAS="$TEST_ALIAS"
+          fi
+          if [ -n "$ALIAS" ]; then
+            npx vercel alias "$PREVIEW_URL" "$ALIAS" --token="$VERCEL_TOKEN_VAL" --scope="$VERCEL_SCOPE"
+          else
+            echo "Alias secret not set for $API_ENV, skipping"
+          fi
 
       - name: Comment preview URL on PR
         if: matrix.pr > 0


### PR DESCRIPTION
## Summary

- **Bug**: `secrets.*` in `if:` expressions causes GitHub Actions to reject the entire workflow file (`Unrecognized named-value: secrets`). This broke all scheduled preview-cron runs since PR #743 (March 27).
- **Fix**: Move secret-existence checks from `if:` conditions into shell scripts.
- **Refactor**: Merge two duplicate alias steps into one parametric step that selects the correct alias via `API_ENV`.

## Root Cause

```yaml
# ❌ GitHub Actions does not allow secrets in if expressions
if: matrix.is_main && matrix.api_env == 'production' && secrets.VERCEL_PREVIEW_ALIAS
```

```yaml
# ✅ Check in shell instead
if: matrix.is_main
run: |
  if [ "$API_ENV" = "production" ]; then ALIAS="$PROD_ALIAS"; else ALIAS="$TEST_ALIAS"; fi
  if [ -n "$ALIAS" ]; then npx vercel alias ...; fi
```

## Environment Matrix (unchanged)

| Scenario | ref | api_env | Alias domain |
|----------|-----|---------|--------------|
| Preview Prod | main | production | `VERCEL_PREVIEW_ALIAS` |
| Preview Test | main | test | `VERCEL_PREVIEW_TEST_ALIAS` |
| PR Preview | PR branch | test | (no alias, comments URL on PR) |

## Test Plan

- [ ] `workflow_dispatch` trigger succeeds (currently fails with parse error)
- [ ] Scheduled runs resume every 15 minutes
- [ ] Production API preview aliased to `VERCEL_PREVIEW_ALIAS`
- [ ] Test API preview aliased to `VERCEL_PREVIEW_TEST_ALIAS`
- [ ] PR previews still post comment with URL