### PR TITLE
fix(site): restore gtag arguments object to fix GA4 tracking

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -56,7 +56,7 @@ const bodyClasses = isDark
         <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
         <script is:inline define:vars={{ GA_ID }}>
           window.dataLayer = window.dataLayer || [];
-          function gtag(...args){dataLayer.push(args);}
+          function gtag(){dataLayer.push(arguments);}
           window.gtag = gtag;
           gtag('js', new Date());
           gtag('config', GA_ID);


### PR DESCRIPTION
## Problem

GA4 active user counts for `/workflows` pages dropped ~95% (from ~4K to ~200/day) starting March 18.

## Root Cause

PR #705 (`e4bbe5e6`) changed the gtag function signature in `BaseLayout.astro`:

```diff
- function gtag(){dataLayer.push(arguments);}
+ function gtag(...args){dataLayer.push(args);}
```

Google's `gtag.js` library performs internal type checking and **requires the native `Arguments` object**, not a regular Array. When it receives an Array (from spread `...args`), it silently drops events — no console errors, no warnings. This is a [known gotcha](https://www.mykolaaleksandrov.dev/posts/2025/11/react-google-analytics-implementation/).

## Fix

One-line revert to the standard Google snippet:

```js
function gtag(){dataLayer.push(arguments);}
```

## Verification

After deploy, GA4 Realtime report should show active users on `/workflows` pages again within minutes.