### PR TITLE
fix: add explicit max-age=0 to prevent browser caching stale HTML

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -9,7 +9,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "s-maxage=300, stale-while-revalidate=60"
+          "value": "public, max-age=0, must-revalidate, s-maxage=300, stale-while-revalidate=60"
         }
       ]
     },
@@ -18,7 +18,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "s-maxage=300, stale-while-revalidate=60"
+          "value": "public, max-age=0, must-revalidate, s-maxage=300, stale-while-revalidate=60"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Follow-up to #750
- Previous fix only set `s-maxage=300` for CDN caching but left `max-age` unspecified, allowing browsers to heuristically cache HTML pages
- Add `max-age=0, must-revalidate` so browsers always revalidate with the CDN
- Final header: `public, max-age=0, must-revalidate, s-maxage=300, stale-while-revalidate=60`
  - **Browser**: always revalidates with CDN (no stale HTML from local cache)
  - **CDN (Cloudflare + Vercel)**: 5-min edge cache with 1-min stale-while-revalidate

Credit to @christianbyrne for the suggestion.

## Test plan
- [ ] Verify `/workflows/` response includes `max-age=0, must-revalidate`
- [ ] Confirm browser DevTools shows no disk cache hits for HTML pages