### PR TITLE
fix: pass status filter in search index build for preview deploys

### DIFF
--- a/site/scripts/lib/search/build-index.ts
+++ b/site/scripts/lib/search/build-index.ts
@@ -49,9 +49,18 @@ async function fetchIndexEntries(): Promise<IndexEntry[] | null> {
   const apiUrl = (process.env.PUBLIC_HUB_API_URL || '').replace(/\/$/, '');
   if (!apiUrl) return null;
   try {
-    const res = await fetch(`${apiUrl}/api/hub/workflows/index`);
+    // Match hub-api.ts listWorkflowIndex(): preview builds request all statuses
+    // so the search index includes pending/rejected/deprecated workflows too.
+    // Production builds (PUBLIC_APPROVED_ONLY=true) request only approved.
+    const approvedOnly = process.env.PUBLIC_APPROVED_ONLY === 'true';
+    const statuses = approvedOnly
+      ? 'approved'
+      : 'pending,approved,rejected,deprecated';
+    const res = await fetch(`${apiUrl}/api/hub/workflows/index?status=${statuses}`);
     if (!res.ok) return null;
-    return (await res.json()) as IndexEntry[];
+    const entries = (await res.json()) as IndexEntry[];
+    // Return null on empty array so the caller falls back to content collection
+    return entries.length > 0 ? entries : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- `build-index.ts` was calling `/api/hub/workflows/index` **without `?status=`**, while `hub-api.ts` `listWorkflowIndex()` passes explicit status filters
- On the test API (preview builds), the default response without status filter returns no workflows → empty `search-index.json` (0 documents) → text search completely broken on preview
- Production was unaffected because the prod API returns approved workflows by default
- Also fixed: empty array `[]` from API was treated as truthy, skipping the content collection fallback

## Changes
1. Pass `?status=` query parameter matching `hub-api.ts` logic (`PUBLIC_APPROVED_ONLY` env var)
2. Fall back to content collection when API returns empty array

## Test plan
- [ ] Deploy preview and verify `search-index.json` has documents (not 245 bytes)
- [ ] Type a search query (e.g. "Grok") in the SearchPopover and confirm results appear
- [ ] Verify production build still produces correct search index

🤖 Generated with [Claude Code](https://claude.com/claude-code)