### PR TITLE
fix(site): make tag pills horizontally scrollable

### DIFF
--- a/site/src/components/hub/HubWorkflowCard.vue
+++ b/site/src/components/hub/HubWorkflowCard.vue
@@ -445,7 +445,7 @@ function handleCardClick() {
     </div>
 
     <!-- Tag pills -->
-    <div class="flex items-center gap-1.5 pt-4 overflow-hidden">
+    <div data-testid="tag-pills" class="flex items-center gap-1.5 pt-4 overflow-x-auto scrollbar-hide">
       <a
         v-for="tag in displayTags"
         :key="tag"
@@ -453,7 +453,7 @@ function handleCardClick() {
         class="tag-link"
         @click.stop
       >
-        <Badge variant="hub-pill" class="hover:bg-white/15 transition-colors truncate max-w-28">
+        <Badge variant="hub-pill" class="hover:bg-white/15 transition-colors shrink-0 whitespace-nowrap">
           {{ tagDisplayName(tag).toLowerCase().replace(/\s+/g, '-') }}
         </Badge>
       </a>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -150,6 +150,15 @@
     contain-intrinsic-size: auto 340px;
   }
 
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
   .scrollbar-thin {
     scrollbar-width: thin;
     scrollbar-color: var(--hub-bg-secondary) transparent;

--- a/site/tests/e2e.spec.ts
+++ b/site/tests/e2e.spec.ts
@@ -216,6 +216,41 @@ test.describe('Search Filter "+X more" Expansion', () => {
   });
 });
 
+test.describe('Tag Pills Scrollability', () => {
+  test('tag container allows horizontal scroll instead of clipping', async ({ page }) => {
+    await page.goto('/workflows/');
+    const firstCard = templateCardLink(page);
+    await expect(firstCard).toBeAttached({ timeout: 10000 });
+
+    // Find a tag container inside a card
+    const tagContainer = page.locator('[data-testid="tag-pills"]').first();
+    await expect(tagContainer).toBeAttached({ timeout: 5000 });
+
+    const overflowX = await tagContainer.evaluate(
+      (el) => getComputedStyle(el).overflowX
+    );
+    expect(overflowX).toBe('auto');
+  });
+
+  test('tag badges do not shrink below their content width', async ({ page }) => {
+    await page.goto('/workflows/');
+    const firstCard = templateCardLink(page);
+    await expect(firstCard).toBeAttached({ timeout: 10000 });
+
+    const tagContainer = page.locator('[data-testid="tag-pills"]').first();
+    await expect(tagContainer).toBeAttached({ timeout: 5000 });
+
+    const badges = tagContainer.locator('a');
+    const count = await badges.count();
+    if (count > 0) {
+      const flexShrink = await badges.first().locator('span').evaluate(
+        (el) => getComputedStyle(el).flexShrink
+      );
+      expect(flexShrink).toBe('0');
+    }
+  });
+});
+
 test.describe('Error Handling', () => {
   test('404 page renders correctly', async ({ page }) => {
     const response = await page.goto('/this-page-does-not-exist-xyz123');

--- a/site/tests/e2e.spec.ts
+++ b/site/tests/e2e.spec.ts
@@ -217,37 +217,47 @@ test.describe('Search Filter "+X more" Expansion', () => {
 });
 
 test.describe('Tag Pills Scrollability', () => {
-  test('tag container allows horizontal scroll instead of clipping', async ({ page }) => {
+  test('overflowed tag can be scrolled into view and clicked', async ({ page }) => {
+    // Use a narrow viewport to increase the chance of tag overflow
+    await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/workflows/');
     const firstCard = templateCardLink(page);
     await expect(firstCard).toBeAttached({ timeout: 10000 });
 
-    // Find a tag container inside a card
-    const tagContainer = page.locator('[data-testid="tag-pills"]').first();
-    await expect(tagContainer).toBeAttached({ timeout: 5000 });
+    // Find a tag container that actually overflows
+    const tagContainers = page.locator('[data-testid="tag-pills"]');
+    const containerCount = await tagContainers.count();
 
-    const overflowX = await tagContainer.evaluate(
-      (el) => getComputedStyle(el).overflowX
-    );
-    expect(overflowX).toBe('auto');
-  });
-
-  test('tag badges do not shrink below their content width', async ({ page }) => {
-    await page.goto('/workflows/');
-    const firstCard = templateCardLink(page);
-    await expect(firstCard).toBeAttached({ timeout: 10000 });
-
-    const tagContainer = page.locator('[data-testid="tag-pills"]').first();
-    await expect(tagContainer).toBeAttached({ timeout: 5000 });
-
-    const badges = tagContainer.locator('a');
-    const count = await badges.count();
-    if (count > 0) {
-      const flexShrink = await badges.first().locator('span').evaluate(
-        (el) => getComputedStyle(el).flexShrink
+    let overflowingContainer = null;
+    for (let i = 0; i < containerCount; i++) {
+      const container = tagContainers.nth(i);
+      const overflows = await container.evaluate(
+        (el) => el.scrollWidth > el.clientWidth
       );
-      expect(flexShrink).toBe('0');
+      if (overflows) {
+        overflowingContainer = container;
+        break;
+      }
     }
+
+    // Skip if no container overflows at this viewport width
+    test.skip(!overflowingContainer, 'No tag container overflows at 375px width');
+
+    // Get the last tag link — it should be partially or fully clipped
+    const lastTag = overflowingContainer!.locator('a').last();
+    await expect(lastTag).toBeAttached();
+
+    // Scroll the tag into view and click it
+    await lastTag.evaluate((el) =>
+      el.scrollIntoView({ behavior: 'instant', block: 'nearest', inline: 'nearest' })
+    );
+    await Promise.all([
+      page.waitForNavigation(),
+      lastTag.click(),
+    ]);
+
+    // Assert navigation went to the tag filter page
+    expect(page.url()).toMatch(/\/workflows\/tag\/.+\//);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix tag pills on workflow cards being clipped by `overflow-hidden` on narrow screens
- Change to `overflow-x-auto` with hidden scrollbar so users can swipe/scroll to see all tags
- Apply `shrink-0 whitespace-nowrap` to tag badges to prevent shrinking and text truncation
- Add E2E tests verifying tag container overflow property and flex-shrink behavior

## Test plan
- [x] On mobile, swipe horizontally on cards with 3+ tags
- [x] On desktop, scroll tags with trackpad/mouse wheel
- [x] Verify scrollbar is not visible
- [x] E2E tests pass: `pnpm run test:e2e`

## demo

https://github.com/user-attachments/assets/44ca79a4-ed97-475e-8aaa-adcb63f17cdb



Slack ref: https://comfy-organization.slack.com/archives/C0AEPRS8N74/p1773076747344099

notion ref: https://www.notion.so/comfy-org/Bug-Filter-tags-cut-off-on-workflow-cards-31e6d73d3650815e9a09eeffee7bd1b5?source=copy_link 