### PR TITLE
fix(ci): reduce preview cron to 45min to avoid 429 rate limits

### DIFF
--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -2,7 +2,7 @@ name: Preview Cron
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/45 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -2,7 +2,10 @@ name: Preview Cron
 
 on:
   schedule:
-    - cron: '*/45 * * * *'
+    - cron: '0 0,3,6,9,12,15,18,21 * * *'
+    - cron: '45 0,3,6,9,12,15,18,21 * * *'
+    - cron: '30 1,4,7,10,13,16,19,22 * * *'
+    - cron: '15 2,5,8,11,14,17,20,23 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Changes preview cron schedule from every 15 minutes to every 45 minutes
- The 15-minute interval caused Vercel 429 rate limit errors on preview deployments due to the volume of matrix deploys (main prod + main test + labeled PRs)
- Production cron is unaffected — only preview environment hit the rate limit

Ref: https://github.com/Comfy-Org/workflow_templates/actions/runs/24222145508/job/70715913115

## Test plan
- [ ] Verify cron triggers every 45 minutes after merge
- [ ] Confirm no more 429 errors in preview cron runs