### PR TITLE
Fix search index duplicate ID crash and make prebuild failures fatal

### DIFF
--- a/.github/workflows/cron-rebuild-site.yml
+++ b/.github/workflows/cron-rebuild-site.yml
@@ -2,10 +2,10 @@ name: Cron Rebuild Site
 
 on:
   schedule:
-    # Every 30 minutes — rebuilds the site to pick up new UGC workflows
+    # Once per day at midnight UTC — rebuilds the site to pick up new UGC workflows
     # for search index, sitemap, filter pages, and pre-rendered detail pages.
     # Only approved workflows are included in the production build.
-    - cron: '*/30 * * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch: # Allow manual trigger
 
 concurrency:

--- a/.github/workflows/cron-rebuild-site.yml
+++ b/.github/workflows/cron-rebuild-site.yml
@@ -2,10 +2,10 @@ name: Cron Rebuild Site
 
 on:
   schedule:
-    # Every 15 minutes — rebuilds the site to pick up new UGC workflows
+    # Every 30 minutes — rebuilds the site to pick up new UGC workflows
     # for search index, sitemap, filter pages, and pre-rendered detail pages.
     # Only approved workflows are included in the production build.
-    - cron: '*/15 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch: # Allow manual trigger
 
 concurrency:

--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -2,10 +2,7 @@ name: Preview Cron
 
 on:
   schedule:
-    - cron: '0 0,3,6,9,12,15,18,21 * * *'
-    - cron: '45 0,3,6,9,12,15,18,21 * * *'
-    - cron: '30 1,4,7,10,13,16,19,22 * * *'
-    - cron: '15 2,5,8,11,14,17,20,23 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ The template site is deployed to four environments via GitHub Actions:
 main merge (version bump)
   └─ PyPI publish ─► deploy-site.yml ─► Production (approved only)
 
+Once per day (00:00 UTC)
+  └─ cron-rebuild-site.yml         ─► Production         (prod API, approved only)
+
 Every 15 minutes
-  ├─ cron-rebuild-site.yml         ─► Production         (prod API, approved only)
   └─ preview-cron.yml
        ├─ main (prod API)          ─► Preview Prod        (prod API, all workflows)
        └─ main (test API)          ─► Preview Test        (test API, all workflows)
@@ -50,7 +52,7 @@ PR opened/updated
 | Environment | Workflow | API | Status Filter | Vercel Flag | Alias Secret | Trigger |
 |-------------|----------|-----|---------------|-------------|--------------|---------|
 | **Production** | `deploy-site.yml` | Production | `approved` only | `--prod` | — | PyPI publish / manual |
-| **Production** | `cron-rebuild-site.yml` | Production | `approved` only | `--prod` | — | Every 15 min |
+| **Production** | `cron-rebuild-site.yml` | Production | `approved` only | `--prod` | — | Once per day (00:00 UTC) |
 | **Preview Prod** | `preview-cron.yml` (main, prod) | Production | None (all) | preview | `VERCEL_PREVIEW_ALIAS` | Every 15 min |
 | **Preview Test** | `preview-cron.yml` (main, test) | Test | None (all) | preview | `VERCEL_PREVIEW_TEST_ALIAS` | Every 15 min |
 | **PR Preview** | `preview-site.yml` | Configurable | None (all) | preview | — | PR changes |

--- a/README.md
+++ b/README.md
@@ -39,24 +39,24 @@ main merge (version bump)
 Once per day (00:00 UTC)
   └─ cron-rebuild-site.yml         ─► Production         (prod API, approved only)
 
-Every 15 minutes
+Once per day (00:00 UTC)
   └─ preview-cron.yml
        ├─ main (prod API)          ─► Preview Prod        (prod API, all workflows)
        └─ main (test API)          ─► Preview Test        (test API, all workflows)
 
 PR opened/updated
   ├─ preview-site.yml              ─► PR Preview (one-off)
-  └─ preview-cron.yml (label)      ─► PR Preview (15-min, requires "preview-cron" label)
+  └─ preview-cron.yml (label)      ─► PR Preview (daily, requires "preview-cron" label)
 ```
 
 | Environment | Workflow | API | Status Filter | Vercel Flag | Alias Secret | Trigger |
 |-------------|----------|-----|---------------|-------------|--------------|---------|
 | **Production** | `deploy-site.yml` | Production | `approved` only | `--prod` | — | PyPI publish / manual |
 | **Production** | `cron-rebuild-site.yml` | Production | `approved` only | `--prod` | — | Once per day (00:00 UTC) |
-| **Preview Prod** | `preview-cron.yml` (main, prod) | Production | None (all) | preview | `VERCEL_PREVIEW_ALIAS` | Every 15 min |
-| **Preview Test** | `preview-cron.yml` (main, test) | Test | None (all) | preview | `VERCEL_PREVIEW_TEST_ALIAS` | Every 15 min |
+| **Preview Prod** | `preview-cron.yml` (main, prod) | Production | None (all) | preview | `VERCEL_PREVIEW_ALIAS` | Once per day (00:00 UTC) |
+| **Preview Test** | `preview-cron.yml` (main, test) | Test | None (all) | preview | `VERCEL_PREVIEW_TEST_ALIAS` | Once per day (00:00 UTC) |
 | **PR Preview** | `preview-site.yml` | Configurable | None (all) | preview | — | PR changes |
-| **PR Preview** | `preview-cron.yml` (PR) | Test | None (all) | preview | — | Every 15 min |
+| **PR Preview** | `preview-cron.yml` (PR) | Test | None (all) | preview | — | Once per day (00:00 UTC) |
 
 **Status filtering** is controlled by the `PUBLIC_APPROVED_ONLY` environment variable at build time. When set to `'true'`, only workflows with `status: 'approved'` from the hub API index endpoint are included in the build. Preview environments omit this flag to show all workflows (pending, approved, rejected, deprecated) for internal review.
 

--- a/site/scripts/lib/search/build-index.ts
+++ b/site/scripts/lib/search/build-index.ts
@@ -47,6 +47,11 @@ const MEDIA_TYPE_LABELS: Record<string, string> = {
   '3d': '3D',
 };
 
+/**
+ * Fetch workflow index entries from the hub API.
+ * Returns `null` when no API URL is configured (local dev).
+ * Throws when the API is configured but returns an error or empty response.
+ */
 async function fetchIndexEntries(): Promise<IndexEntry[] | null> {
   const apiUrl = (process.env.PUBLIC_HUB_API_URL || '').replace(/\/$/, '');
   if (!apiUrl) return null;

--- a/site/scripts/lib/search/build-index.ts
+++ b/site/scripts/lib/search/build-index.ts
@@ -20,6 +20,8 @@ interface SearchDocument {
   username: string;
   creatorName: string;
   // Stored fields for display (not searched)
+  name: string;
+  slug: string;
   thumbnail: string;
   usage: number;
   tagsArray: string[];
@@ -106,10 +108,15 @@ export async function buildSearchIndex(): Promise<void> {
       const creatorName = displayNames.get(username) || username;
       const tags = data.tags || [];
       const models = data.models || [];
-      const name = data.name || data.shareId || '';
+      const shareId = data.shareId || '';
+      const name = data.name || shareId;
+      // Use shareId as the unique ID; name can be duplicated across users
+      const id = shareId || name;
+      // URL slug: "{name}-{shareId}" for hub entries, "{name}" for legacy
+      const slug = shareId ? `${name}-${shareId}` : name;
 
       documents.push({
-        id: name,
+        id,
         title: data.title || name,
         description: data.description || '',
         tags: tags.map(tagSearchText).join(' '),
@@ -118,6 +125,8 @@ export async function buildSearchIndex(): Promise<void> {
         mediaTypeLabel: MEDIA_TYPE_LABELS[data.mediaType || ''] || data.mediaType || 'image',
         username,
         creatorName,
+        name,
+        slug,
         thumbnail: data.thumbnailUrl || '',
         usage: 0,
         tagsArray: tags.map(tagDisplayName),
@@ -137,9 +146,14 @@ export async function buildSearchIndex(): Promise<void> {
       const models: string[] = data.models || [];
       const thumbnails: string[] = data.thumbnails || [];
 
+      const shareId = data.shareId || '';
+      const name = data.name || shareId;
+      const id = shareId || name;
+      const slug = shareId ? `${name}-${shareId}` : name;
+
       documents.push({
-        id: data.name,
-        title: data.title || data.name,
+        id,
+        title: data.title || name,
         description: data.description || '',
         tags: tags.map(tagSearchText).join(' '),
         models: models.join(' '),
@@ -147,6 +161,8 @@ export async function buildSearchIndex(): Promise<void> {
         mediaTypeLabel: MEDIA_TYPE_LABELS[data.mediaType] || data.mediaType,
         username,
         creatorName: username,
+        name,
+        slug,
         thumbnail: thumbnails[0] || '',
         usage: data.usage || 0,
         tagsArray: tags.map(tagDisplayName),
@@ -179,6 +195,8 @@ export async function buildSearchIndex(): Promise<void> {
       'title',
       'mediaType',
       'mediaTypeLabel',
+      'name',
+      'slug',
       'thumbnail',
       'username',
       'creatorName',

--- a/site/scripts/lib/search/build-index.ts
+++ b/site/scripts/lib/search/build-index.ts
@@ -50,22 +50,21 @@ const MEDIA_TYPE_LABELS: Record<string, string> = {
 async function fetchIndexEntries(): Promise<IndexEntry[] | null> {
   const apiUrl = (process.env.PUBLIC_HUB_API_URL || '').replace(/\/$/, '');
   if (!apiUrl) return null;
-  try {
-    // Match hub-api.ts listWorkflowIndex(): preview builds request all statuses
-    // so the search index includes pending/rejected/deprecated workflows too.
-    // Production builds (PUBLIC_APPROVED_ONLY=true) request only approved.
-    const approvedOnly = process.env.PUBLIC_APPROVED_ONLY === 'true';
-    const statuses = approvedOnly
-      ? 'approved'
-      : 'pending,approved,rejected,deprecated';
-    const res = await fetch(`${apiUrl}/api/hub/workflows/index?status=${statuses}`);
-    if (!res.ok) return null;
-    const entries = (await res.json()) as IndexEntry[];
-    // Return null on empty array so the caller falls back to content collection
-    return entries.length > 0 ? entries : null;
-  } catch {
-    return null;
+
+  const approvedOnly = process.env.PUBLIC_APPROVED_ONLY === 'true';
+  const statuses = approvedOnly
+    ? 'approved'
+    : 'pending,approved,rejected,deprecated';
+  const res = await fetch(`${apiUrl}/api/hub/workflows/index?status=${statuses}`);
+
+  if (!res.ok) {
+    throw new Error(`Hub API returned ${res.status}: ${res.statusText}`);
   }
+  const entries = (await res.json()) as IndexEntry[];
+  if (entries.length === 0) {
+    throw new Error('Hub API returned empty index');
+  }
+  return entries;
 }
 
 async function fetchProfileDisplayName(username: string): Promise<string> {
@@ -86,7 +85,7 @@ export async function buildSearchIndex(): Promise<void> {
 
   const documents: SearchDocument[] = [];
 
-  // Try hub API first, fall back to content collection files
+  // Hub API is the primary source; content collection is only for local/offline builds
   const hubEntries = await fetchIndexEntries();
   if (hubEntries) {
     logger.info(`Building search index from hub API (${hubEntries.length} entries)`);
@@ -133,9 +132,9 @@ export async function buildSearchIndex(): Promise<void> {
       });
     }
   } else {
-    // Fallback: read from synced content collection files
+    // No PUBLIC_HUB_API_URL — local/offline build, use content collection
     const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.json') && !f.includes('/'));
-    logger.info(`Building search index from content collection (${files.length} files)`);
+    logger.warn(`No hub API configured — building search index from content collection (${files.length} files)`);
 
     for (const file of files) {
       const filePath = path.join(CONTENT_DIR, file);

--- a/site/scripts/prebuild-parallel.ts
+++ b/site/scripts/prebuild-parallel.ts
@@ -83,9 +83,9 @@ async function main(): Promise<void> {
 
   const phase2Failed = phase2Results.filter((r) => !r.success);
   if (phase2Failed.length > 0) {
-    console.warn('\n⚠️  Phase 2: some tasks failed (non-fatal):');
+    console.error('\n❌ Phase 2 failed:');
     for (const f of phase2Failed) {
-      console.warn(`   - ${f.name}: ${f.error}`);
+      console.error(`   - ${f.name}: ${f.error}`);
     }
   }
 
@@ -107,6 +107,10 @@ async function main(): Promise<void> {
   const savedTime = sequentialEstimate - totalDuration;
   if (savedTime > 1000) {
     console.log(`   Saved ~${(savedTime / 1000).toFixed(1)}s vs sequential`);
+  }
+
+  if (phase2Failed.length > 0) {
+    process.exit(1);
   }
 }
 

--- a/site/src/components/hub/SearchPopover.vue
+++ b/site/src/components/hub/SearchPopover.vue
@@ -168,8 +168,8 @@ const badgeFilteredTemplates = computed(() => {
   return result;
 });
 
-// Set of allowed IDs for scoping MiniSearch when badges are active
-const badgeFilteredIds = computed(() => {
+// Set of allowed names for scoping MiniSearch when badges are active
+const badgeFilteredNames = computed(() => {
   if (!hasBadges.value) return null;
   return new Set(badgeFilteredTemplates.value.map((t) => t.name));
 });
@@ -194,7 +194,7 @@ watchDebounced(
     isSearching.value = true;
     try {
       searchResults.value = await searchIndex(trimmed, {
-        allowedIds: badgeFilteredIds.value ?? undefined,
+        allowedNames: badgeFilteredNames.value ?? undefined,
       });
       trackSearchPerformed(trimmed);
     } finally {
@@ -414,7 +414,7 @@ function activateItem(index: number) {
       if (creator) window.location.href = getCreatorUrl(creator.username);
     } else {
       const wf = displayedWorkflows.value[index - sugTotal - matchedCreators.value.length];
-      if (wf) window.location.href = getTemplateUrl(wf.slug || wf.id);
+      if (wf) window.location.href = getTemplateUrl(wf.slug);
     }
   } else {
     const popCount = popularWorkflows.value.length;
@@ -1073,7 +1073,7 @@ onUnmounted(() => {
                 <a
                   v-for="(hit, i) in displayedWorkflows"
                   :key="hit.id"
-                  :href="getTemplateUrl(hit.slug || hit.id)"
+                  :href="getTemplateUrl(hit.slug)"
                   :data-nav-index="activeWorkflowOffset + i"
                   class="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-lg hover:bg-white/5 transition-colors group"
                   :class="{ 'bg-white/10': activeIndex === activeWorkflowOffset + i }"

--- a/site/src/components/hub/SearchPopover.vue
+++ b/site/src/components/hub/SearchPopover.vue
@@ -414,7 +414,7 @@ function activateItem(index: number) {
       if (creator) window.location.href = getCreatorUrl(creator.username);
     } else {
       const wf = displayedWorkflows.value[index - sugTotal - matchedCreators.value.length];
-      if (wf) window.location.href = getTemplateUrl(wf.id);
+      if (wf) window.location.href = getTemplateUrl(wf.slug || wf.id);
     }
   } else {
     const popCount = popularWorkflows.value.length;
@@ -1073,7 +1073,7 @@ onUnmounted(() => {
                 <a
                   v-for="(hit, i) in displayedWorkflows"
                   :key="hit.id"
-                  :href="getTemplateUrl(hit.id)"
+                  :href="getTemplateUrl(hit.slug || hit.id)"
                   :data-nav-index="activeWorkflowOffset + i"
                   class="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-lg hover:bg-white/5 transition-colors group"
                   :class="{ 'bg-white/10': activeIndex === activeWorkflowOffset + i }"

--- a/site/src/components/hub/SearchPopover.vue
+++ b/site/src/components/hub/SearchPopover.vue
@@ -423,7 +423,7 @@ function activateItem(index: number) {
 
     if (index < popCount) {
       const wf = popularWorkflows.value[index];
-      if (wf) window.location.href = getTemplateUrl(wf.name);
+      if (wf) window.location.href = getTemplateUrl(`${wf.name}-${wf.shareId}`);
     } else if (index < popCount + creatorCount) {
       const creator = topCreators.value[index - popCount];
       if (creator) window.location.href = getCreatorUrl(creator.username);
@@ -725,7 +725,7 @@ onUnmounted(() => {
                 <a
                   v-for="(wf, i) in popularWorkflows"
                   :key="wf.name"
-                  :href="getTemplateUrl(wf.name)"
+                  :href="getTemplateUrl(`${wf.name}-${wf.shareId}`)"
                   :data-nav-index="i"
                   class="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-lg hover:bg-white/5 transition-colors group"
                   :class="{ 'bg-white/10': activeIndex === i }"

--- a/site/src/lib/hub-api.ts
+++ b/site/src/lib/hub-api.ts
@@ -460,6 +460,32 @@ export function extractShareId(urlSegment: string): string | null {
   return null;
 }
 
+/**
+ * Load serialized templates from hub API.
+ * In production/preview builds (PUBLIC_HUB_API_URL set), hub API failure throws
+ * to fail the build — no silent fallback to stale content collection data.
+ * In local builds (no PUBLIC_HUB_API_URL), falls back to content collection.
+ */
+export async function loadSerializedTemplates(
+  getCollection: () => Promise<{ id: string; data: Parameters<typeof serializeCollectionEntry>[0] }[]>
+): Promise<SerializedTemplate[]> {
+  const profiles = await getProfileCache();
+  try {
+    const entries = await listWorkflowIndex();
+    return entries.map((e) => serializeIndexEntry(e, profiles));
+  } catch (err) {
+    if (import.meta.env.PUBLIC_HUB_API_URL) {
+      throw new Error(`Hub API failed during build: ${err}`);
+    }
+    console.warn('No hub API configured, using content collection for local build');
+    const templates = await getCollection();
+    return templates
+      .filter((tmpl) => !tmpl.id.includes('/'))
+      .sort((a, b) => ((b.data as any).usage || 0) - ((a.data as any).usage || 0))
+      .map((tmpl) => serializeCollectionEntry(tmpl.data, profiles));
+  }
+}
+
 function mapThumbnailVariant(
   type?: string
 ): ThumbnailVariant | undefined {

--- a/site/src/lib/hub-api.ts
+++ b/site/src/lib/hub-api.ts
@@ -477,11 +477,11 @@ export async function loadSerializedTemplates(
     if (import.meta.env.PUBLIC_HUB_API_URL) {
       throw new Error(`Hub API failed during build: ${err}`);
     }
-    console.warn('No hub API configured, using content collection for local build');
+    console.warn('Hub API error, falling back to content collection:', err);
     const templates = await getCollection();
     return templates
       .filter((tmpl) => !tmpl.id.includes('/'))
-      .sort((a, b) => ((b.data as any).usage || 0) - ((a.data as any).usage || 0))
+      .sort((a, b) => (b.data.usage || 0) - (a.data.usage || 0))
       .map((tmpl) => serializeCollectionEntry(tmpl.data, profiles));
   }
 }

--- a/site/src/lib/search.ts
+++ b/site/src/lib/search.ts
@@ -6,6 +6,8 @@ import MiniSearch, { type SearchResult } from 'minisearch';
 
 export interface WorkflowHit {
   id: string;
+  name: string;
+  slug: string;
   title: string;
   mediaType: string;
   mediaTypeLabel: string;
@@ -58,6 +60,8 @@ async function loadIndex(): Promise<MiniSearch> {
       'title',
       'mediaType',
       'mediaTypeLabel',
+      'name',
+      'slug',
       'thumbnail',
       'username',
       'creatorName',
@@ -76,9 +80,12 @@ function ensureIndex(): Promise<MiniSearch> {
 }
 
 function mapResult(result: SearchResult): WorkflowHit {
+  const name = (result.name as string) || (result.id as string);
   return {
     id: result.id as string,
-    title: (result.title as string) || (result.id as string),
+    name,
+    slug: (result.slug as string) || name,
+    title: (result.title as string) || name,
     mediaType: (result.mediaType as string) || 'image',
     mediaTypeLabel: (result.mediaTypeLabel as string) || 'Image',
     thumbnail: (result.thumbnail as string) || '',
@@ -123,7 +130,7 @@ function deriveCreators(workflows: WorkflowHit[], query: string): CreatorHit[] {
 
 export async function search(
   query: string,
-  options?: { allowedIds?: Set<string> }
+  options?: { allowedNames?: Set<string> }
 ): Promise<SearchResults> {
   const trimmed = query.trim();
   if (!trimmed) {
@@ -131,18 +138,19 @@ export async function search(
   }
 
   const index = await ensureIndex();
-  let results = index.search(trimmed, {
+  const results = index.search(trimmed, {
     prefix: true,
     fuzzy: 0.2,
     tokenize,
   });
 
-  // Scope results to allowed IDs when badge filters are active
-  if (options?.allowedIds) {
-    results = results.filter((r) => options.allowedIds!.has(r.id as string));
+  let workflows = results.map(mapResult);
+
+  // Scope results to allowed names when badge filters are active
+  if (options?.allowedNames) {
+    workflows = workflows.filter((w) => options.allowedNames!.has(w.name));
   }
 
-  const workflows = results.map(mapResult);
   const creators = deriveCreators(workflows, trimmed);
 
   return { workflows, creators };

--- a/site/src/pages/[locale]/workflows/category/[type].astro
+++ b/site/src/pages/[locale]/workflows/category/[type].astro
@@ -18,7 +18,7 @@ import { localizeUrl } from '../../../../i18n/utils';
 import { SITE_ORIGIN, absoluteUrl } from '../../../../config/site';
 import { categoryPath } from '../../../../lib/routes';
 import { badgeVariants } from '../../../../components/ui/badge';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate, type MediaType } from '../../../../lib/hub-api';
+import { loadSerializedTemplates, type SerializedTemplate, type MediaType } from '../../../../lib/hub-api';
 
 const validTypes: MediaType[] = ['image', 'video', 'audio', '3d'];
 
@@ -48,24 +48,8 @@ const categoryName = t(categoryTranslationKeys[mediaType], typedLocale);
 const title = `${categoryName} Workflows - ${t('meta.title', typedLocale)}`;
 const description = t('meta.description', typedLocale);
 
-const profiles = await getProfileCache();
-
-// Try hub API first, fall back to content collection
-let templates: SerializedTemplate[];
-try {
-  const entries = await listWorkflowIndex();
-  templates = entries
-    .filter((e) => (e.mediaType || 'image') === mediaType)
-    .map((e) => serializeIndexEntry(e, profiles));
-} catch (err) {
-  console.error('Hub API failed, falling back to content collection:', err);
-  const allTemplates = await getCollection('templates');
-  templates = allTemplates
-    .filter((tmpl) => !tmpl.id.includes('/'))
-    .filter((tmpl) => tmpl.data.mediaType === mediaType)
-    .sort((a, b) => (b.data.usage || 0) - (a.data.usage || 0))
-    .map((tmpl) => serializeCollectionEntry(tmpl.data, profiles));
-}
+const allSerialized = await loadSerializedTemplates(() => getCollection('templates'));
+const templates = allSerialized.filter((t) => t.mediaType === mediaType);
 
 const basePath = categoryPath(mediaType);
 const canonicalUrl = absoluteUrl(localizeUrl(basePath, typedLocale));

--- a/site/src/pages/[locale]/workflows/category/[type].astro
+++ b/site/src/pages/[locale]/workflows/category/[type].astro
@@ -49,7 +49,7 @@ const title = `${categoryName} Workflows - ${t('meta.title', typedLocale)}`;
 const description = t('meta.description', typedLocale);
 
 const allSerialized = await loadSerializedTemplates(() => getCollection('templates'));
-const templates = allSerialized.filter((t) => t.mediaType === mediaType);
+const templates = allSerialized.filter((tmpl) => tmpl.mediaType === mediaType);
 
 const basePath = categoryPath(mediaType);
 const canonicalUrl = absoluteUrl(localizeUrl(basePath, typedLocale));

--- a/site/src/pages/[locale]/workflows/index.astro
+++ b/site/src/pages/[locale]/workflows/index.astro
@@ -15,9 +15,8 @@ import SiteFooter from '../../../components/hub/SiteFooter.astro';
 import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
 import { t } from '../../../i18n/ui';
 import { absoluteUrl } from '../../../config/site';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate } from '../../../lib/hub-api';
+import { loadSerializedTemplates } from '../../../lib/hub-api';
 
-const profiles = await getProfileCache();
 const { locale } = Astro.params;
 
 // Validate locale
@@ -27,19 +26,7 @@ if (!locale || !LOCALES.includes(locale as Locale) || locale === DEFAULT_LOCALE)
 
 const typedLocale = locale as Locale;
 
-// Try hub API first, fall back to content collection
-let serialized: SerializedTemplate[];
-try {
-  const entries = await listWorkflowIndex();
-  serialized = entries.map((e) => serializeIndexEntry(e, profiles));
-} catch (err) {
-  console.error('Hub API failed, falling back to content collection:', err);
-  const templates = await getCollection('templates');
-  const allTemplates = templates
-    .filter((tmpl) => !tmpl.id.includes('/'))
-    .sort((a, b) => (b.data.usage || 0) - (a.data.usage || 0));
-  serialized = allTemplates.map((tmpl) => serializeCollectionEntry(tmpl.data, profiles));
-}
+const serialized = await loadSerializedTemplates(() => getCollection('templates'));
 
 const canonicalUrl = absoluteUrl('/' + locale + '/workflows/');
 

--- a/site/src/pages/[locale]/workflows/model/[name].astro
+++ b/site/src/pages/[locale]/workflows/model/[name].astro
@@ -19,7 +19,7 @@ import { slugify } from '../../../../lib/slugify';
 import { SITE_ORIGIN, absoluteUrl } from '../../../../config/site';
 import { modelPath } from '../../../../lib/routes';
 import { badgeVariants } from '../../../../components/ui/badge';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate } from '../../../../lib/hub-api';
+import { loadSerializedTemplates, type SerializedTemplate } from '../../../../lib/hub-api';
 
 const { locale, name } = Astro.params;
 
@@ -29,18 +29,8 @@ if (!locale || !LOCALES.includes(locale as Locale) || locale === DEFAULT_LOCALE)
 }
 
 const typedLocale = locale as Locale;
-const profiles = await getProfileCache();
 
-// Try hub API first, fall back to content collection
-let allTemplates: SerializedTemplate[];
-try {
-  const entries = await listWorkflowIndex();
-  allTemplates = entries.map((e) => serializeIndexEntry(e, profiles));
-} catch (err) {
-  console.error('Hub API failed, falling back to content collection:', err);
-  const collection = (await getCollection('templates')).filter((t) => !t.id.includes('/'));
-  allTemplates = collection.map((t) => serializeCollectionEntry(t.data, profiles));
-}
+const allTemplates = await loadSerializedTemplates(() => getCollection('templates'));
 
 // Find templates matching this model slug
 const matchingTemplates = allTemplates.filter((tmpl) =>

--- a/site/src/pages/[locale]/workflows/tag/[tag].astro
+++ b/site/src/pages/[locale]/workflows/tag/[tag].astro
@@ -18,7 +18,7 @@ import { localizeUrl } from '../../../../i18n/utils';
 import { tagSlug, tagDisplayName } from '../../../../lib/tag-aliases';
 import { SITE_ORIGIN, absoluteUrl } from '../../../../config/site';
 import { badgeVariants } from '../../../../components/ui/badge';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate } from '../../../../lib/hub-api';
+import { loadSerializedTemplates, type SerializedTemplate } from '../../../../lib/hub-api';
 
 const { locale, tag } = Astro.params;
 
@@ -28,18 +28,8 @@ if (!locale || !LOCALES.includes(locale as Locale) || locale === DEFAULT_LOCALE)
 }
 
 const typedLocale = locale as Locale;
-const profiles = await getProfileCache();
 
-// Try hub API first, fall back to content collection
-let allTemplates: SerializedTemplate[];
-try {
-  const entries = await listWorkflowIndex();
-  allTemplates = entries.map((e) => serializeIndexEntry(e, profiles));
-} catch (err) {
-  console.error('Hub API failed, falling back to content collection:', err);
-  const collection = (await getCollection('templates')).filter((t) => !t.id.includes('/'));
-  allTemplates = collection.map((t) => serializeCollectionEntry(t.data, profiles));
-}
+const allTemplates = await loadSerializedTemplates(() => getCollection('templates'));
 
 // Find templates matching this tag slug
 const matchingTemplates = allTemplates.filter((tmpl) =>

--- a/site/src/pages/workflows/category/[type].astro
+++ b/site/src/pages/workflows/category/[type].astro
@@ -11,7 +11,7 @@ import { t } from '../../../i18n/ui';
 import { SITE_ORIGIN, absoluteUrl } from '../../../config/site';
 import { categoryPath } from '../../../lib/routes';
 import { badgeVariants } from '../../../components/ui/badge';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate, type MediaType } from '../../../lib/hub-api';
+import { loadSerializedTemplates, type SerializedTemplate, type MediaType } from '../../../lib/hub-api';
 
 const categoryTranslationKeys: Record<MediaType, string> = {
   image: 'category.image',
@@ -35,24 +35,8 @@ const categoryName = t(categoryTranslationKeys[type], locale);
 const title = `${categoryName} Workflows - ${t('meta.title', locale)}`;
 const description = t('meta.description', locale);
 
-// Try hub API first, fall back to content collection
-const profiles = await getProfileCache();
-let filteredSerialized: SerializedTemplate[];
-try {
-  const entries = await listWorkflowIndex();
-  filteredSerialized = entries
-    .filter((e) => (e.mediaType || 'image') === type)
-    .map((e) => serializeIndexEntry(e, profiles));
-} catch (err) {
-  console.error('Hub API failed, falling back to content collection:', err);
-  const allTemplates = await getCollection('templates');
-  filteredSerialized = allTemplates
-    .filter((tmpl) => !tmpl.id.includes('/'))
-    .filter((tmpl) => tmpl.data.mediaType === type)
-    .sort((a, b) => (b.data.usage || 0) - (a.data.usage || 0))
-    .map((tmpl) => serializeCollectionEntry(tmpl.data, profiles));
-}
-const templates = filteredSerialized;
+const allSerialized = await loadSerializedTemplates(() => getCollection('templates'));
+const templates = allSerialized.filter((t) => t.mediaType === type);
 
 const basePath = categoryPath(type);
 const canonicalUrl = absoluteUrl(localizeUrl(basePath, locale));

--- a/site/src/pages/workflows/category/[type].astro
+++ b/site/src/pages/workflows/category/[type].astro
@@ -36,7 +36,7 @@ const title = `${categoryName} Workflows - ${t('meta.title', locale)}`;
 const description = t('meta.description', locale);
 
 const allSerialized = await loadSerializedTemplates(() => getCollection('templates'));
-const templates = allSerialized.filter((t) => t.mediaType === type);
+const templates = allSerialized.filter((tmpl) => tmpl.mediaType === type);
 
 const basePath = categoryPath(type);
 const canonicalUrl = absoluteUrl(localizeUrl(basePath, locale));

--- a/site/src/pages/workflows/index.astro
+++ b/site/src/pages/workflows/index.astro
@@ -8,24 +8,11 @@ import SiteFooter from '../../components/hub/SiteFooter.astro';
 import { getLocaleFromPath, localizeUrl } from '../../i18n/utils';
 import { t } from '../../i18n/ui';
 import { absoluteUrl } from '../../config/site';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate } from '../../lib/hub-api';
+import { loadSerializedTemplates } from '../../lib/hub-api';
 
-const profiles = await getProfileCache();
 const locale = getLocaleFromPath(Astro.url.pathname);
 
-// Try hub API first, fall back to content collection
-let serialized: SerializedTemplate[];
-try {
-  const entries = await listWorkflowIndex();
-  serialized = entries.map((e) => serializeIndexEntry(e, profiles));
-} catch (err) {
-  console.error('Hub API failed, falling back to content collection:', err);
-  const templates = await getCollection('templates');
-  const allTemplates = templates
-    .filter((tmpl) => !tmpl.id.includes('/'))
-    .sort((a, b) => (b.data.usage || 0) - (a.data.usage || 0));
-  serialized = allTemplates.map((tmpl) => serializeCollectionEntry(tmpl.data, profiles));
-}
+const serialized = await loadSerializedTemplates(() => getCollection('templates'));
 
 const canonicalUrl = absoluteUrl(localizeUrl('/workflows/', locale));
 

--- a/site/src/pages/workflows/model/[name].astro
+++ b/site/src/pages/workflows/model/[name].astro
@@ -12,21 +12,10 @@ import { slugify } from '../../../lib/slugify';
 import { SITE_ORIGIN, absoluteUrl } from '../../../config/site';
 import { modelPath } from '../../../lib/routes';
 import { badgeVariants } from '../../../components/ui/badge';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate } from '../../../lib/hub-api';
+import { loadSerializedTemplates, type SerializedTemplate } from '../../../lib/hub-api';
 
 export async function getStaticPaths() {
-  const profiles = await getProfileCache();
-
-  // Try hub API first, fall back to content collection
-  let allSerialized: SerializedTemplate[];
-  try {
-    const entries = await listWorkflowIndex();
-    allSerialized = entries.map((e) => serializeIndexEntry(e, profiles));
-  } catch (err) {
-    console.error('Hub API failed, falling back to content collection:', err);
-    const collection = (await getCollection('templates')).filter((t) => !t.id.includes('/'));
-    allSerialized = collection.map((t) => serializeCollectionEntry(t.data, profiles));
-  }
+  const allSerialized = await loadSerializedTemplates(() => getCollection('templates'));
 
   const modelMap = new Map<string, SerializedTemplate[]>();
 

--- a/site/src/pages/workflows/tag/[tag].astro
+++ b/site/src/pages/workflows/tag/[tag].astro
@@ -11,21 +11,10 @@ import { t } from '../../../i18n/ui';
 import { tagSlug, tagDisplayName } from '../../../lib/tag-aliases';
 import { SITE_ORIGIN, absoluteUrl } from '../../../config/site';
 import { badgeVariants } from '../../../components/ui/badge';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, serializeCollectionEntry, type SerializedTemplate } from '../../../lib/hub-api';
+import { loadSerializedTemplates, type SerializedTemplate } from '../../../lib/hub-api';
 
 export async function getStaticPaths() {
-  const profiles = await getProfileCache();
-
-  // Try hub API first, fall back to content collection
-  let allSerialized: SerializedTemplate[];
-  try {
-    const entries = await listWorkflowIndex();
-    allSerialized = entries.map((e) => serializeIndexEntry(e, profiles));
-  } catch (err) {
-    console.error('Hub API failed, falling back to content collection:', err);
-    const collection = (await getCollection('templates')).filter((t) => !t.id.includes('/'));
-    allSerialized = collection.map((t) => serializeCollectionEntry(t.data, profiles));
-  }
+  const allSerialized = await loadSerializedTemplates(() => getCollection('templates'));
 
   const tagMap = new Map<
     string,


### PR DESCRIPTION
## Summary
- **Search index duplicate ID fix**: Use `shareId` instead of `name` as MiniSearch document ID. The hub API can return multiple workflows with the same `name` from different users, causing `MiniSearch: duplicate ID` crash (e.g. `image_chrono_edit_14B`). `shareId` is the actual unique identifier.
- **Prebuild failure handling**: Make Phase 2 failures fatal (`process.exit(1)`) instead of non-fatal warnings. Previously a failed `build-search-index` would let the deploy continue with stale/missing data.
- **Search URL routing**: Store `slug` (`{name}-{shareId}`) in the search index so search results link to the correct workflow detail page.
- **Cron interval**: Change production rebuild cron to once per day at midnight UTC (`0 0 * * *`).
- **Preview cron interval**: Change preview rebuild cron to once per day at midnight UTC (`0 0 * * *`).

Fixes: https://github.com/Comfy-Org/workflow_templates/actions/runs/24384123386/job/71213859091

## Test plan
- [ ] Verify search index builds without duplicate ID errors
- [ ] Verify search results link to correct workflow pages (`/workflows/{name}-{shareId}/`)
- [ ] Verify prebuild exits with code 1 when any Phase 2 task fails
- [ ] Verify production cron schedule is `0 0 * * *`
- [ ] Verify preview cron schedule is `0 0 * * *`
