### PR TITLE
Add label-based PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,22 +2,105 @@ name: Publish to PyPI
 
 # This workflow publishes packages to PyPI and creates GitHub releases.
 # Triggers:
-#   1. When pyproject.toml changes on main branch (version bump from PR merge)  
+#   1. When pyproject.toml changes on main branch (version bump from PR merge)
 #   2. Manual dispatch (for recovery/debugging)
-# 
+#
 # Features:
+#   - Conditional PyPI publishing (only when PR has 'release' label)
+#   - Always creates GitHub Release (regardless of label)
 #   - Version change detection (prevents unnecessary publishes)
 #   - Recovery mode (publishes packages out-of-sync with PyPI)
 #   - Dependency order publishing (subpackages before meta package)
 
 on:
   workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force publish to PyPI (bypass label check)'
+        required: false
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
       - "pyproject.toml"
 
 jobs:
+  check-pr-label:
+    runs-on: ubuntu-latest
+    outputs:
+      should-publish: ${{ steps.check.outputs.should_publish }}
+      pr-number: ${{ steps.pr.outputs.number }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Find associated PR
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // For workflow_dispatch, allow force publish
+            if (context.eventName === 'workflow_dispatch') {
+              const forcePublish = '${{ inputs.force_publish }}' === 'true';
+              core.setOutput('number', forcePublish ? 'manual' : '');
+              return;
+            }
+
+            // Find PR associated with this merge commit
+            const commit = context.sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: commit,
+            });
+
+            if (prs.length > 0) {
+              const pr = prs[0];
+              core.setOutput('number', pr.number);
+              console.log(`Found associated PR #${pr.number}`);
+            } else {
+              core.setOutput('number', '');
+              console.log('No associated PR found');
+            }
+
+      - name: Check for release label
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = '${{ steps.pr.outputs.number }}';
+
+            // Manual workflow with force_publish
+            if (prNumber === 'manual') {
+              core.setOutput('should_publish', 'true');
+              console.log('✅ Manual workflow dispatch with force_publish=true - will publish to PyPI');
+              return;
+            }
+
+            // No PR found - skip PyPI publish (but still create GitHub release)
+            if (!prNumber) {
+              core.setOutput('should_publish', 'false');
+              console.log('⚠️ No associated PR found - skipping PyPI publish (will only create GitHub release)');
+              return;
+            }
+
+            // Check if PR has 'release' label
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(prNumber),
+            });
+
+            const hasReleaseLabel = pr.labels.some(label => label.name === 'release');
+            core.setOutput('should_publish', hasReleaseLabel ? 'true' : 'false');
+
+            if (hasReleaseLabel) {
+              console.log(`✅ PR #${prNumber} has 'release' label - will publish to PyPI`);
+            } else {
+              console.log(`⚠️ PR #${prNumber} does NOT have 'release' label - skipping PyPI publish (will only create GitHub release)`);
+            }
+
   check-version-change:
     runs-on: ubuntu-latest
     # Prevent concurrent publish workflows to avoid race conditions
@@ -49,7 +132,7 @@ jobs:
           fi
 
   publish:
-    needs: check-version-change
+    needs: [check-version-change, check-pr-label]
     if: needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -83,7 +166,20 @@ jobs:
           source .venv/bin/activate
           pip install --upgrade pip build twine
 
+      - name: Check PyPI publish decision
+        run: |
+          SHOULD_PUBLISH="${{ needs.check-pr-label.outputs.should-publish }}"
+          PR_NUMBER="${{ needs.check-pr-label.outputs.pr-number }}"
+
+          if [ "$SHOULD_PUBLISH" = "true" ]; then
+            echo "📦 Will publish to PyPI (PR #$PR_NUMBER has 'release' label)"
+          else
+            echo "⏭️  Skipping PyPI publish (PR #$PR_NUMBER missing 'release' label)"
+            echo "   Only GitHub Release will be created"
+          fi
+
       - name: Determine packages to build
+        if: needs.check-pr-label.outputs.should-publish == 'true'
         id: changed-packages
         run: |
           echo "=== Package Detection Logic ==="
@@ -183,6 +279,7 @@ jobs:
           fi
 
       - name: Validate bundles before publishing
+        if: needs.check-pr-label.outputs.should-publish == 'true'
         run: |
           echo "=== Pre-publish Bundle Validation ==="
           # Safety check: ensure all templates are assigned to bundles
@@ -190,6 +287,7 @@ jobs:
           ./scripts/ci/validate_bundles.sh
 
       - name: Sync manifest and bundle assets
+        if: needs.check-pr-label.outputs.should-publish == 'true'
         run: |
           source .venv/bin/activate
           echo "=== Syncing manifests and bundle assets ==="
@@ -197,6 +295,7 @@ jobs:
           echo "✅ Manifest and bundle sync complete"
 
       - name: Build and publish packages in dependency order
+        if: needs.check-pr-label.outputs.should-publish == 'true'
         run: |
           source .venv/bin/activate
           rm -rf dist
@@ -282,9 +381,22 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
       - name: Create GitHub Release
+        if: always() && needs.check-version-change.outputs.new-version
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v${{ needs.check-version-change.outputs.new-version }}" \
-          --title "v${{ needs.check-version-change.outputs.new-version }}" \
-          --generate-notes
+          SHOULD_PUBLISH="${{ needs.check-pr-label.outputs.should-publish }}"
+          VERSION="${{ needs.check-version-change.outputs.new-version }}"
+
+          # Create release with appropriate notes
+          if [ "$SHOULD_PUBLISH" = "true" ]; then
+            gh release create "v$VERSION" \
+              --title "v$VERSION" \
+              --notes "📦 **Published to PyPI**: Packages are available via \`pip install comfyui-workflow-templates==$VERSION\`" \
+              --generate-notes
+          else
+            gh release create "v$VERSION" \
+              --title "v$VERSION" \
+              --notes "⚠️ **Not published to PyPI**: This release was created without PyPI packages (PR missing \`release\` label). To publish, add the \`release\` label to the PR and re-trigger the workflow." \
+              --generate-notes
+          fi

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,154 @@
+# Publishing Guide
+
+## Overview
+
+This repository uses a **label-based publishing workflow** that separates GitHub releases from PyPI package publishing. This helps reduce unnecessary package builds and saves storage space.
+
+## Two Types of Releases
+
+### 1. GitHub Release Only (Default)
+- **When**: PR merged to `main` without `release` label
+- **What happens**:
+  - ✅ GitHub Release is created with release notes
+  - ⏭️ PyPI packages are **not** built or published
+  - 💾 Saves storage space and avoids unnecessary builds
+
+### 2. Full Release with PyPI Publish
+- **When**: PR merged to `main` **with** `release` label
+- **What happens**:
+  - ✅ GitHub Release is created with release notes
+  - ✅ Packages are built and published to PyPI
+  - 📦 Users can install via `pip install comfyui-workflow-templates`
+
+## Publishing Workflow
+
+### For Regular Changes (No PyPI Publish Needed)
+
+1. Create PR with your changes
+2. **Do NOT add** the `release` label
+3. Merge to `main`
+4. Workflow creates GitHub Release only
+
+**Use cases:**
+- Internal template updates
+- Development builds
+- Cloud-only deployments
+- Template metadata changes
+
+### For PyPI Releases
+
+1. Create PR with your changes
+2. **Add the `release` label** to the PR
+3. Merge to `main`
+4. Workflow creates GitHub Release **and** publishes to PyPI
+
+**Use cases:**
+- Public releases for pip users
+- Official version releases
+- Breaking changes that need distribution
+- New features for local ComfyUI installations
+
+## Manual Publishing
+
+If you need to publish to PyPI after a PR was already merged without the `release` label:
+
+1. Go to **Actions** tab
+2. Select **"Publish to PyPI"** workflow
+3. Click **"Run workflow"**
+4. Check **"Force publish to PyPI"**
+5. Click **"Run workflow"**
+
+This bypasses the label check and publishes packages for the current version.
+
+## Version Bumping
+
+Version bumping is **automatic** via the `version-check.yml` workflow:
+
+1. When templates change in a PR, versions are auto-bumped
+2. Only the root `pyproject.toml` version is bumped
+3. Sub-package versions are synced automatically by `scripts/sync_bundles.py`
+4. **Never manually edit package versions** unless necessary
+
+## Label Management
+
+### Creating the `release` Label
+
+If the `release` label doesn't exist in your repository:
+
+```bash
+gh label create release \
+  --description "Publish packages to PyPI when merged" \
+  --color "0e8a16"
+```
+
+Or via GitHub web UI:
+1. Go to **Issues** → **Labels**
+2. Click **"New label"**
+3. Name: `release`
+4. Description: `Publish packages to PyPI when merged`
+5. Color: Green (`#0e8a16`)
+
+### Adding Label to PR
+
+**Via GitHub UI:**
+1. Open the PR
+2. Click **"Labels"** in the right sidebar
+3. Select `release`
+
+**Via GitHub CLI:**
+```bash
+gh pr edit <PR-NUMBER> --add-label release
+```
+
+## Workflow Files
+
+- `.github/workflows/version-check.yml` - Auto-bump versions on PR
+- `.github/workflows/publish.yml` - Publish to PyPI and create GitHub releases
+
+## Package Size Considerations
+
+PyPI has a 100MB per-file upload limit. Our current package sizes:
+- `media_image`: ~47MB
+- `media_other`: ~93MB
+- `media_video`: ~95MB (approaching limit)
+- `media_api`: ~79MB
+
+By using label-based publishing, we avoid building packages multiple times, which would waste storage and approach limits faster.
+
+## Troubleshooting
+
+### Release created but packages not published?
+
+**Cause**: PR was merged without the `release` label.
+
+**Solution**: Use manual workflow dispatch with "Force publish to PyPI" option.
+
+### How to unpublish from PyPI?
+
+**You cannot** remove versions from PyPI once published. Use `pip install --force-reinstall` if you need to replace a version locally.
+
+### Version mismatch between GitHub and PyPI?
+
+This is expected if you merge PRs without the `release` label. GitHub releases will be ahead of PyPI versions. This is by design to support development workflows.
+
+## Best Practices
+
+1. **Use `release` label sparingly** - Only for public pip releases
+2. **Test before labeling** - Merge without label first, test, then manually publish if needed
+3. **Coordinate team** - Communicate when publishing to PyPI
+4. **Monitor package sizes** - Check workflow logs for size warnings
+5. **Document breaking changes** - Update CHANGELOG.md before adding `release` label
+
+## Recovery Mode
+
+The publish workflow includes **automatic recovery mode**:
+- Detects packages out-of-sync with PyPI
+- Publishes missing versions automatically
+- Validates dependencies before publishing meta package
+- Use `workflow_dispatch` to trigger recovery manually
+
+## Related Documentation
+
+- [CLAUDE.md](../CLAUDE.md) - Repository overview
+- [SPEC.md](SPEC.md) - Template specification
+- [I18N_GUIDE.md](I18N_GUIDE.md) - Translation workflow


### PR DESCRIPTION
## 🎯 Purpose

This PR adds a **label-based conditional publishing workflow** to separate development releases from public PyPI releases.

## 🔧 Changes

- `.github/workflows/publish.yml` - Add conditional PyPI publishing
- `docs/PUBLISHING.md` - New publishing documentation

## 📋 How It Works

**Without `release` label:**
- ✅ GitHub Release created
- ⏭️ PyPI publish skipped

**With `release` label:**
- ✅ GitHub Release created  
- ✅ Packages published to PyPI

## 🧪 Testing

This is a test PR. Merge without label to test the new workflow.

See `docs/PUBLISHING.md` for complete guide.