### PR TITLE
Fix: Ensure GitHub Release is created for all version changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,7 +193,7 @@ jobs:
           
           # Check for package version changes (primary trigger)
           echo -e "\n--- Checking for changed package versions ---"
-          for pkg in core media_api media_video media_image media_other; do
+          for pkg in core media_api media_video media_image media_other blueprints; do
             if echo "$CHANGED_FILES" | grep -q "packages/$pkg/pyproject.toml"; then
               PACKAGES="$PACKAGES $pkg"
               echo "✓ Will publish $pkg (version file changed)"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -19,6 +19,8 @@ on:
     paths:
       - 'templates/**'
       - 'bundles.json'
+      - 'blueprints/**'
+      - 'blueprints_bundles.json'
       - 'pyproject.toml'
 
 permissions:
@@ -58,7 +60,12 @@ jobs:
           # To temporarily disable it and ship all templates, add --no-filter:
           #   python scripts/sync_bundles.py --no-filter
           python scripts/sync_bundles.py
-          echo "✅ Manifest sync complete"
+          echo "✅ Template manifest sync complete"
+
+          echo "=== Syncing blueprints manifests ==="
+          # Sync blueprints from blueprints/ to packages/blueprints/
+          python scripts/sync_blueprints.py
+          echo "✅ Blueprint manifest sync complete"
 
       - name: Check package sizes
         id: size_check

--- a/scripts/ci_version_manager.py
+++ b/scripts/ci_version_manager.py
@@ -160,6 +160,12 @@ def get_files_affecting_package(pkg: str, since_commit: str) -> List[str]:
             # Core package affects meta
             elif pkg == "meta" and (file.startswith("packages/") or file == "pyproject.toml"):
                 filtered_files.append(file)
+            # Blueprints package: affected by blueprints/ directory and blueprints_bundles.json
+            elif pkg == "blueprints":
+                if file.startswith("blueprints/") or file == "blueprints_bundles.json":
+                    filtered_files.append(file)
+                elif file == "packages/core/src/comfyui_workflow_templates_core/blueprints_manifest.json":
+                    filtered_files.append(file)
             # Template files affecting this package's bundle
             elif pkg_bundle and file.startswith("templates/"):
                 template_name = Path(file).stem.split('-')[0]
@@ -198,7 +204,7 @@ def get_files_affecting_package(pkg: str, since_commit: str) -> List[str]:
 def get_changed_packages() -> Set[str]:
     """Determine which packages need version bumps based on changes since their last version bump"""
     try:
-        packages = ["core", "media_api", "media_video", "media_image", "media_other", "meta"]
+        packages = ["core", "media_api", "media_video", "media_image", "media_other", "blueprints", "meta"]
         affected = set()
 
         for pkg in packages:


### PR DESCRIPTION
## 🎯 Purpose

Fixes blueprint changes not creating GitHub Releases, breaking cloud repo version checkout.

## 🐛 Problem

PR #798 modified blueprints/ but didn't create GitHub Release because:
- version-check.yml didn't monitor blueprints/
- ci_version_manager.py didn't track blueprints package
- publish.yml didn't include blueprints in package list

## ✅ Solution

1. **version-check.yml**: Add blueprints paths + sync_blueprints.py call
2. **ci_version_manager.py**: Add blueprints package detection
3. **publish.yml**: Add blueprints to package list

## 📊 Result

All content changes → version bump → GitHub Release (with tag) → cloud repo can checkout

## Related

- Builds on PR #799 (label-based PyPI publishing)
- Fixes missing release for PR #798