### PR TITLE
ci: pin vercel-action to latest CLI

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -53,6 +53,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-version: latest
           working-directory: site
           vercel-args: '--prebuilt'
 


### PR DESCRIPTION
## Summary
- `amondnet/vercel-action@v25` ships with a stale default Vercel CLI, causing the preview deploy job to fail with `Your Vercel CLI version is outdated. This endpoint requires version 47.2.2 or later.` (see [failed run](https://github.com/Comfy-Org/workflow_templates/actions/runs/24547117680/job/71765031441?pr=803)).
- Added `vercel-version: latest` to the action step in `preview-site.yml` so the CLI is reinstalled fresh on each run.

## Test plan
- [ ] Preview Site workflow completes the Vercel deploy step on this PR