### PR TITLE
fix preview Vercel deploy path regression

### DIFF
--- a/.github/workflows/cron-rebuild-site.yml
+++ b/.github/workflows/cron-rebuild-site.yml
@@ -50,7 +50,7 @@ jobs:
           PUBLIC_APPROVED_ONLY: 'true'
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v42
+        uses: amondnet/vercel-action@v41.1.4
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/cron-rebuild-site.yml
+++ b/.github/workflows/cron-rebuild-site.yml
@@ -68,7 +68,7 @@ jobs:
 
           mkdir -p "$GITHUB_WORKSPACE/.vercel"
           rm -rf "$root_output_dir"
-          ln -s "$site_output_dir" "$root_output_dir"
+          cp -R "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --prod --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/cron-rebuild-site.yml
+++ b/.github/workflows/cron-rebuild-site.yml
@@ -50,13 +50,21 @@ jobs:
           PUBLIC_APPROVED_ONLY: 'true'
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v41.1.4
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: site
-          root-directory: site
-          vercel-output-dir: site/.vercel/output
-          prebuilt: true
-          target: production
+        working-directory: site
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          stdout_file="$RUNNER_TEMP/vercel-production.stdout"
+          stderr_file="$RUNNER_TEMP/vercel-production.stderr"
+
+          if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --prod --yes \
+            --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+          else
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+            exit 1
+          fi

--- a/.github/workflows/cron-rebuild-site.yml
+++ b/.github/workflows/cron-rebuild-site.yml
@@ -50,10 +50,13 @@ jobs:
           PUBLIC_APPROVED_ONLY: 'true'
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v42
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: site
-          vercel-args: '--prebuilt --prod'
+          root-directory: site
+          vercel-output-dir: site/.vercel/output
+          prebuilt: true
+          target: production

--- a/.github/workflows/cron-rebuild-site.yml
+++ b/.github/workflows/cron-rebuild-site.yml
@@ -58,6 +58,17 @@ jobs:
         run: |
           stdout_file="$RUNNER_TEMP/vercel-production.stdout"
           stderr_file="$RUNNER_TEMP/vercel-production.stderr"
+          site_output_dir="$GITHUB_WORKSPACE/site/.vercel/output"
+          root_output_dir="$GITHUB_WORKSPACE/.vercel/output"
+
+          if [ ! -d "$site_output_dir" ]; then
+            echo "Expected prebuilt output in $site_output_dir" >&2
+            exit 1
+          fi
+
+          mkdir -p "$GITHUB_WORKSPACE/.vercel"
+          rm -rf "$root_output_dir"
+          ln -s "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --prod --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -96,7 +96,7 @@ jobs:
 
           mkdir -p "$GITHUB_WORKSPACE/.vercel"
           rm -rf "$root_output_dir"
-          ln -s "$site_output_dir" "$root_output_dir"
+          cp -R "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --prod --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -86,6 +86,17 @@ jobs:
         run: |
           stdout_file="$RUNNER_TEMP/vercel-production.stdout"
           stderr_file="$RUNNER_TEMP/vercel-production.stderr"
+          site_output_dir="$GITHUB_WORKSPACE/site/.vercel/output"
+          root_output_dir="$GITHUB_WORKSPACE/.vercel/output"
+
+          if [ ! -d "$site_output_dir" ]; then
+            echo "Expected prebuilt output in $site_output_dir" >&2
+            exit 1
+          fi
+
+          mkdir -p "$GITHUB_WORKSPACE/.vercel"
+          rm -rf "$root_output_dir"
+          ln -s "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --prod --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -78,7 +78,7 @@ jobs:
           PUBLIC_APPROVED_ONLY: 'true'
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v42
+        uses: amondnet/vercel-action@v41.1.4
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -78,13 +78,21 @@ jobs:
           PUBLIC_APPROVED_ONLY: 'true'
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v41.1.4
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: site
-          root-directory: site
-          vercel-output-dir: site/.vercel/output
-          prebuilt: true
-          target: production
+        working-directory: site
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          stdout_file="$RUNNER_TEMP/vercel-production.stdout"
+          stderr_file="$RUNNER_TEMP/vercel-production.stderr"
+
+          if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --prod --yes \
+            --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+          else
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+            exit 1
+          fi

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -78,10 +78,13 @@ jobs:
           PUBLIC_APPROVED_ONLY: 'true'
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v42
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: site
-          vercel-args: '--prebuilt --prod'
+          root-directory: site
+          vercel-output-dir: site/.vercel/output
+          prebuilt: true
+          target: production

--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy
-        uses: amondnet/vercel-action@v42
+        uses: amondnet/vercel-action@v41.1.4
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -85,13 +85,16 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v42
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: site
-          vercel-args: '--prebuilt'
+          root-directory: site
+          vercel-output-dir: site/.vercel/output
+          prebuilt: true
+          target: preview
 
       - name: Alias main preview
         if: matrix.is_main

--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -103,7 +103,7 @@ jobs:
 
           mkdir -p "$GITHUB_WORKSPACE/.vercel"
           rm -rf "$root_output_dir"
-          ln -s "$site_output_dir" "$root_output_dir"
+          cp -R "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -85,16 +85,32 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy
-        uses: amondnet/vercel-action@v41.1.4
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: site
-          root-directory: site
-          vercel-output-dir: site/.vercel/output
-          prebuilt: true
-          target: preview
+        working-directory: site
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          stdout_file="$RUNNER_TEMP/vercel-preview.stdout"
+          stderr_file="$RUNNER_TEMP/vercel-preview.stderr"
+
+          if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
+            --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+
+            preview_url="$(tail -n 1 "$stdout_file" | tr -d '\r')"
+            if [[ ! "$preview_url" =~ ^https?:// ]]; then
+              echo "Could not parse preview URL from Vercel CLI output" >&2
+              exit 1
+            fi
+
+            echo "preview-url=$preview_url" >> "$GITHUB_OUTPUT"
+          else
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+            exit 1
+          fi
 
       - name: Alias main preview
         if: matrix.is_main

--- a/.github/workflows/preview-cron.yml
+++ b/.github/workflows/preview-cron.yml
@@ -93,6 +93,17 @@ jobs:
         run: |
           stdout_file="$RUNNER_TEMP/vercel-preview.stdout"
           stderr_file="$RUNNER_TEMP/vercel-preview.stderr"
+          site_output_dir="$GITHUB_WORKSPACE/site/.vercel/output"
+          root_output_dir="$GITHUB_WORKSPACE/.vercel/output"
+
+          if [ ! -d "$site_output_dir" ]; then
+            echo "Expected prebuilt output in $site_output_dir" >&2
+            exit 1
+          fi
+
+          mkdir -p "$GITHUB_WORKSPACE/.vercel"
+          rm -rf "$root_output_dir"
+          ln -s "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -66,7 +66,7 @@ jobs:
 
           mkdir -p "$GITHUB_WORKSPACE/.vercel"
           rm -rf "$root_output_dir"
-          ln -s "$site_output_dir" "$root_output_dir"
+          cp -R "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -56,6 +56,17 @@ jobs:
         run: |
           stdout_file="$RUNNER_TEMP/vercel-preview.stdout"
           stderr_file="$RUNNER_TEMP/vercel-preview.stderr"
+          site_output_dir="$GITHUB_WORKSPACE/site/.vercel/output"
+          root_output_dir="$GITHUB_WORKSPACE/.vercel/output"
+
+          if [ ! -d "$site_output_dir" ]; then
+            echo "Expected prebuilt output in $site_output_dir" >&2
+            exit 1
+          fi
+
+          mkdir -p "$GITHUB_WORKSPACE/.vercel"
+          rm -rf "$root_output_dir"
+          ln -s "$site_output_dir" "$root_output_dir"
 
           if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
             --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Deploy preview to Vercel
         id: deploy
-        uses: amondnet/vercel-action@v42
+        uses: amondnet/vercel-action@v41.1.4
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -53,7 +53,6 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-version: latest
           working-directory: site
           vercel-args: '--prebuilt'
 

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -48,16 +48,32 @@ jobs:
 
       - name: Deploy preview to Vercel
         id: deploy
-        uses: amondnet/vercel-action@v41.1.4
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: site
-          root-directory: site
-          vercel-output-dir: site/.vercel/output
-          prebuilt: true
-          target: preview
+        working-directory: site
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          stdout_file="$RUNNER_TEMP/vercel-preview.stdout"
+          stderr_file="$RUNNER_TEMP/vercel-preview.stderr"
+
+          if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
+            --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+
+            preview_url="$(tail -n 1 "$stdout_file" | tr -d '\r')"
+            if [[ ! "$preview_url" =~ ^https?:// ]]; then
+              echo "Could not parse preview URL from Vercel CLI output" >&2
+              exit 1
+            fi
+
+            echo "preview-url=$preview_url" >> "$GITHUB_OUTPUT"
+          else
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+            exit 1
+          fi
 
       - name: Comment preview URL
         if: github.event_name == 'pull_request'

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -48,13 +48,16 @@ jobs:
 
       - name: Deploy preview to Vercel
         id: deploy
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v42
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: site
-          vercel-args: '--prebuilt'
+          root-directory: site
+          vercel-output-dir: site/.vercel/output
+          prebuilt: true
+          target: preview
 
       - name: Comment preview URL
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

Remove the `vercel-version: latest` override from the preview deploy workflow.

## Why

The `Preview Site` workflow started failing in the `preview` job after `main` picked up `ci: pin vercel-action to latest CLI (#804)`.

In the failing run (`24551479805`, job `71778020776`), the `Deploy preview to Vercel` step invoked `vercel@51.6.1` and failed with:

`Error: The provided path "~/work/workflow_templates/workflow_templates/site/site" does not exist`

This points to a path-resolution mismatch between `amondnet/vercel-action@v25`, the newer Vercel CLI, and the existing `working-directory: site` configuration.

## Impact

- Restores preview deploys for PRs that touch the site or templates
- Keeps preview behavior aligned with the previously working workflow configuration
- Avoids blocking unrelated PRs on a workflow-level regression

## Validation

- Confirmed the failure location and error from the GitHub Actions logs for run `24551479805`
- Verified the fix is scoped to one line in `.github/workflows/preview-site.yml`
- Ran `git diff --check`

## Follow-up

After merge, rerun the affected preview workflow to confirm Vercel deploys succeed again.