### PR TITLE
fix(site): guard workflow URLs against undefined slugs (FE-223)

### DIFF
--- a/site/scripts/lib/search/build-index.ts
+++ b/site/scripts/lib/search/build-index.ts
@@ -57,9 +57,7 @@ async function fetchIndexEntries(): Promise<IndexEntry[] | null> {
   if (!apiUrl) return null;
 
   const approvedOnly = process.env.PUBLIC_APPROVED_ONLY === 'true';
-  const statuses = approvedOnly
-    ? 'approved'
-    : 'pending,approved,rejected,deprecated';
+  const statuses = approvedOnly ? 'approved' : 'pending,approved,rejected,deprecated';
   const res = await fetch(`${apiUrl}/api/hub/workflows/index?status=${statuses}`);
 
   if (!res.ok) {
@@ -107,17 +105,23 @@ export async function buildSearchIndex(): Promise<void> {
       }
     }
 
+    let skipped = 0;
     for (const data of hubEntries) {
+      // Drop entries that can't form a clean detail URL. Without this, the
+      // search index emits slugs like "undefined-<id>" or "<name>-undefined"
+      // and the popover renders /workflows/undefined/ links (FE-223).
+      if (!data.name || !data.shareId) {
+        skipped++;
+        continue;
+      }
       const username = data.username || 'ComfyUI';
       const creatorName = displayNames.get(username) || username;
       const tags = data.tags || [];
       const models = data.models || [];
-      const shareId = data.shareId || '';
-      const name = data.name || shareId;
+      const { name, shareId } = data;
       // Use shareId as the unique ID; name can be duplicated across users
-      const id = shareId || name;
-      // URL slug: "{name}-{shareId}" for hub entries, "{name}" for legacy
-      const slug = shareId ? `${name}-${shareId}` : name;
+      const id = shareId;
+      const slug = `${name}-${shareId}`;
 
       documents.push({
         id,
@@ -136,22 +140,33 @@ export async function buildSearchIndex(): Promise<void> {
         tagsArray: tags.map(tagDisplayName),
       });
     }
+    if (skipped > 0) {
+      logger.warn(`Skipped ${skipped} hub entries missing name or shareId — see FE-223`);
+    }
   } else {
     // No PUBLIC_HUB_API_URL — local/offline build, use content collection
-    const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.json') && !f.includes('/'));
-    logger.warn(`No hub API configured — building search index from content collection (${files.length} files)`);
+    const files = fs
+      .readdirSync(CONTENT_DIR)
+      .filter((f) => f.endsWith('.json') && !f.includes('/'));
+    logger.warn(
+      `No hub API configured — building search index from content collection (${files.length} files)`
+    );
 
     for (const file of files) {
       const filePath = path.join(CONTENT_DIR, file);
       const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+      // Legacy content-collection templates always have a name but may omit
+      // shareId. Drop nameless rows so we never index an empty slug (FE-223).
+      if (!data.name) continue;
 
       const username = data.username || 'ComfyUI';
       const tags: string[] = data.tags || [];
       const models: string[] = data.models || [];
       const thumbnails: string[] = data.thumbnails || [];
 
-      const shareId = data.shareId || '';
-      const name = data.name || shareId;
+      const shareId: string = data.shareId || '';
+      const name: string = data.name;
       const id = shareId || name;
       const slug = shareId ? `${name}-${shareId}` : name;
 
@@ -229,5 +244,7 @@ export async function buildSearchIndex(): Promise<void> {
 
   const sizeKB = (Buffer.byteLength(serialized) / 1024).toFixed(1);
   const duration = ((Date.now() - startTime) / 1000).toFixed(2);
-  logger.info(`Search index written to public/workflows/search-index.json (${sizeKB} KB, ${duration}s)`);
+  logger.info(
+    `Search index written to public/workflows/search-index.json (${sizeKB} KB, ${duration}s)`
+  );
 }

--- a/site/src/components/hub/HubWorkflowCard.vue
+++ b/site/src/components/hub/HubWorkflowCard.vue
@@ -12,6 +12,7 @@ import type { ThumbnailVariant } from '@/lib/hub-api';
 import { initCompareSlider } from '@/lib/initCompareSlider';
 import { getVideoFrameUrl } from '@/lib/video-thumbnail';
 import { isVideoFile, isAudioFile, isMediaFile } from '@/lib/media-utils';
+import { workflowDetailPath } from '@/lib/routes';
 
 const MODEL_TO_LOGO: Record<string, string> = {
   Grok: 'grok',
@@ -94,11 +95,7 @@ const logoPath = computed(() => (providerName.value ? getLogoPath(providerName.v
 
 const authorName = computed(() => props.creatorDisplayName || 'ComfyUI');
 
-const templateUrl = computed(() => {
-  const slug = props.shareId ? `${props.name}-${props.shareId}` : props.name;
-  const base = `/workflows/${slug}/`;
-  return props.locale && props.locale !== 'en' ? `/${props.locale}${base}` : base;
-});
+const templateUrl = computed(() => workflowDetailPath(props.name, props.shareId, props.locale));
 
 const primaryFile = computed(() => props.thumbnails[0] ?? null);
 const secondaryFile = computed(() => props.thumbnails[1] ?? null);
@@ -229,13 +226,15 @@ const creatorUrl = computed(() => {
 });
 
 function handleCardClick() {
+  if (!templateUrl.value) return;
   window.location.href = templateUrl.value;
 }
 </script>
 
 <template>
   <div
-    class="group transition-all duration-200 content-auto cursor-pointer"
+    class="group transition-all duration-200 content-auto"
+    :class="templateUrl ? 'cursor-pointer' : ''"
     @click="handleCardClick"
   >
     <!-- Thumbnail -->
@@ -291,10 +290,7 @@ function handleCardClick() {
       </div>
 
       <!-- Hover crossfade -->
-      <div
-        v-else-if="showHoverDissolve"
-        class="group/thumb relative h-full w-full overflow-hidden"
-      >
+      <div v-else-if="showHoverDissolve" class="group/thumb relative h-full w-full overflow-hidden">
         <img
           :src="primaryUrl || ''"
           :alt="`${title} - 1`"
@@ -441,10 +437,7 @@ function handleCardClick() {
         :alt="authorName"
         class="size-5 rounded-full shrink-0 object-cover"
       />
-      <div
-        v-else
-        class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand"
-      >
+      <div v-else class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand">
         <span class="text-black text-[10px] font-bold leading-none">{{
           authorName.charAt(0).toUpperCase()
         }}</span>
@@ -458,10 +451,7 @@ function handleCardClick() {
         :alt="authorName"
         class="size-5 rounded-full shrink-0 object-cover"
       />
-      <div
-        v-else
-        class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand"
-      >
+      <div v-else class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand">
         <span class="text-black text-[10px] font-bold leading-none">{{
           authorName.charAt(0).toUpperCase()
         }}</span>
@@ -470,15 +460,15 @@ function handleCardClick() {
     </div>
 
     <!-- Tag pills -->
-    <div data-testid="tag-pills" class="flex items-center gap-1.5 pt-4 overflow-x-auto scrollbar-hide">
-      <a
-        v-for="tag in displayTags"
-        :key="tag"
-        :href="getTagUrl(tag)"
-        class="tag-link"
-        @click.stop
-      >
-        <Badge variant="hub-pill" class="hover:bg-hub-surface transition-colors shrink-0 whitespace-nowrap">
+    <div
+      data-testid="tag-pills"
+      class="flex items-center gap-1.5 pt-4 overflow-x-auto scrollbar-hide"
+    >
+      <a v-for="tag in displayTags" :key="tag" :href="getTagUrl(tag)" class="tag-link" @click.stop>
+        <Badge
+          variant="hub-pill"
+          class="hover:bg-hub-surface transition-colors shrink-0 whitespace-nowrap"
+        >
           {{ tagDisplayName(tag).toLowerCase().replace(/\s+/g, '-') }}
         </Badge>
       </a>

--- a/site/src/components/hub/SearchPopover.vue
+++ b/site/src/components/hub/SearchPopover.vue
@@ -23,9 +23,11 @@ import { trackSearchPerformed, trackFilterApplied } from '@/lib/posthog';
 import type { MediaType } from '@/lib/hub-api';
 import { isAudioFile, isVideoFile } from '@/lib/media-utils';
 import { getVideoFrameUrl } from '@/lib/video-thumbnail';
+import { workflowDetailPath, workflowDetailSlug } from '@/lib/routes';
 
 export interface SearchTemplate {
   name: string;
+  shareId: string;
   title: string;
   description: string;
   mediaType: MediaType;
@@ -213,20 +215,29 @@ const displayedWorkflows = computed(() => {
   if (hasQuery.value && searchResults.value) {
     return searchResults.value.workflows;
   }
-  // Badge-only → show all filtered templates as workflow-like items
+  // Badge-only → show all filtered templates as workflow-like items.
+  // Drop rows we can't link to and surface a real `slug` so the click target
+  // can never become /workflows/undefined/ (FE-223).
   if (hasBadges.value) {
-    return badgeOnlyResults.value.map((t) => ({
-      id: t.name,
-      title: t.title,
-      mediaType: t.mediaType,
-      mediaTypeLabel: MEDIA_TYPE_LABELS[t.mediaType] || t.mediaType,
-      thumbnail: t.thumbnails[0] || '',
-      username: t.username,
-      creatorName: t.creatorDisplayName,
-      usage: t.usage,
-      tags: t.tags,
-      score: 0,
-    }));
+    return badgeOnlyResults.value
+      .map((t) => {
+        const slug = workflowDetailSlug(t.name, t.shareId);
+        if (!slug) return null;
+        return {
+          id: t.name,
+          slug,
+          title: t.title,
+          mediaType: t.mediaType,
+          mediaTypeLabel: MEDIA_TYPE_LABELS[t.mediaType] || t.mediaType,
+          thumbnail: t.thumbnails[0] || '',
+          username: t.username,
+          creatorName: t.creatorDisplayName,
+          usage: t.usage,
+          tags: t.tags,
+          score: 0,
+        };
+      })
+      .filter((hit): hit is NonNullable<typeof hit> => hit !== null);
   }
   return [];
 });
@@ -268,10 +279,14 @@ const MEDIA_TYPE_LABELS: Record<string, string> = {
 
 // ── Helpers ──
 
-function getTemplateUrl(name: string): string {
+// Build a workflow detail URL from a pre-computed slug (search-index `slug`
+// field). Returns null when the slug is empty/undefined so callers can avoid
+// rendering /workflows/undefined/ links when the search index is malformed.
+function getTemplateUrl(slug: string | null | undefined): string | null {
+  if (!slug) return null;
   return props.locale && props.locale !== 'en'
-    ? `/${props.locale}/workflows/${name}/`
-    : `/workflows/${name}/`;
+    ? `/${props.locale}/workflows/${slug}/`
+    : `/workflows/${slug}/`;
 }
 
 function getCreatorUrl(username: string): string {
@@ -289,9 +304,14 @@ watch(
   }
 );
 
-// Popular workflows — top 4 by usage
+// Popular workflows — top 4 by usage. Drop entries that can't form a clean
+// detail URL so we don't surface /workflows/undefined-<id>/ or /workflows/<name>-/
+// links from malformed index rows (FE-223).
 const popularWorkflows = computed(() =>
-  [...props.templates].sort((a, b) => b.usage - a.usage).slice(0, 4)
+  [...props.templates]
+    .filter((t) => Boolean(t.name) && Boolean(t.shareId))
+    .sort((a, b) => b.usage - a.usage)
+    .slice(0, 4)
 );
 
 // Top creators from hub API profiles, enriched with workflow count + total usage
@@ -415,7 +435,8 @@ function activateItem(index: number) {
       if (creator) window.location.href = getCreatorUrl(creator.username);
     } else {
       const wf = displayedWorkflows.value[index - sugTotal - matchedCreators.value.length];
-      if (wf) window.location.href = getTemplateUrl(wf.slug);
+      const url = wf ? getTemplateUrl(wf.slug) : null;
+      if (url) window.location.href = url;
     }
   } else {
     const popCount = popularWorkflows.value.length;
@@ -424,7 +445,8 @@ function activateItem(index: number) {
 
     if (index < popCount) {
       const wf = popularWorkflows.value[index];
-      if (wf) window.location.href = getTemplateUrl(`${wf.name}-${wf.shareId}`);
+      const url = wf ? workflowDetailPath(wf.name, wf.shareId, props.locale) : null;
+      if (url) window.location.href = url;
     } else if (index < popCount + creatorCount) {
       const creator = topCreators.value[index - popCount];
       if (creator) window.location.href = getCreatorUrl(creator.username);
@@ -746,7 +768,7 @@ onUnmounted(() => {
                 <a
                   v-for="(wf, i) in popularWorkflows"
                   :key="wf.name"
-                  :href="getTemplateUrl(`${wf.name}-${wf.shareId}`)"
+                  :href="workflowDetailPath(wf.name, wf.shareId, props.locale) ?? '/workflows/'"
                   :data-nav-index="i"
                   class="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-lg hover:bg-hub-surface transition-colors group"
                   :class="{ 'bg-hub-surface': activeIndex === i }"
@@ -1106,7 +1128,7 @@ onUnmounted(() => {
                 <a
                   v-for="(hit, i) in displayedWorkflows"
                   :key="hit.id"
-                  :href="getTemplateUrl(hit.slug)"
+                  :href="getTemplateUrl(hit.slug) ?? '/workflows/'"
                   :data-nav-index="activeWorkflowOffset + i"
                   class="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-lg hover:bg-hub-surface transition-colors group"
                   :class="{ 'bg-hub-surface': activeIndex === activeWorkflowOffset + i }"

--- a/site/src/lib/routes.ts
+++ b/site/src/lib/routes.ts
@@ -4,4 +4,21 @@ export const categoryPath = (type: string) => `/workflows/category/${type}/`;
 export const modelPath = (name: string) => `/workflows/model/${name}/`;
 export const tagPath = (tag: string) => `/workflows/tag/${tagSlug(tag)}/`;
 export const thumbnailPath = (asset: string) =>
-  asset.startsWith('http://') || asset.startsWith('https://') ? asset : `/workflows/thumbnails/${asset}`;
+  asset.startsWith('http://') || asset.startsWith('https://')
+    ? asset
+    : `/workflows/thumbnails/${asset}`;
+
+/**
+ * Build a workflow detail URL. Returns null when `name` is missing so callers
+ * can render a non-clickable card instead of a `/workflows/undefined/` link.
+ */
+export function workflowDetailPath(
+  name: string | null | undefined,
+  shareId?: string | null,
+  locale?: string
+): string | null {
+  if (!name) return null;
+  const slug = shareId ? `${name}-${shareId}` : name;
+  const base = `/workflows/${slug}/`;
+  return locale && locale !== 'en' ? `/${locale}${base}` : base;
+}

--- a/site/src/lib/routes.ts
+++ b/site/src/lib/routes.ts
@@ -9,6 +9,19 @@ export const thumbnailPath = (asset: string) =>
     : `/workflows/thumbnails/${asset}`;
 
 /**
+ * Build the URL slug component (no `/workflows/` prefix, no locale). Returns
+ * null when `name` is missing so callers can avoid persisting `undefined-...`
+ * or `<name>-undefined` slugs into the search index or rendered hrefs.
+ */
+export function workflowDetailSlug(
+  name: string | null | undefined,
+  shareId?: string | null
+): string | null {
+  if (!name) return null;
+  return shareId ? `${name}-${shareId}` : name;
+}
+
+/**
  * Build a workflow detail URL. Returns null when `name` is missing so callers
  * can render a non-clickable card instead of a `/workflows/undefined/` link.
  */
@@ -17,8 +30,8 @@ export function workflowDetailPath(
   shareId?: string | null,
   locale?: string
 ): string | null {
-  if (!name) return null;
-  const slug = shareId ? `${name}-${shareId}` : name;
+  const slug = workflowDetailSlug(name, shareId);
+  if (!slug) return null;
   const base = `/workflows/${slug}/`;
   return locale && locale !== 'en' ? `/${locale}${base}` : base;
 }

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -18,14 +18,20 @@ import BackButton from '../../../components/BackButton.astro';
 import WorkflowGrid from '../../../components/hub/WorkflowGrid.vue';
 import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
 import { SITE_ORIGIN, absoluteUrl } from '../../../config/site';
-import { listWorkflowIndex, getProfile, getWorkflow, toTemplateData, extractShareId, getProfileCache, serializeIndexEntry, type SerializedTemplate } from '../../../lib/hub-api';
+import {
+  listWorkflowIndex,
+  getProfile,
+  getWorkflow,
+  toTemplateData,
+  extractShareId,
+  getProfileCache,
+  serializeIndexEntry,
+  type SerializedTemplate,
+} from '../../../lib/hub-api';
 import { workflowOgUrl, creatorOgUrl } from '../../../lib/og-url';
 
 // ISR: cache for 60s, serve stale for up to 10 min while revalidating
-Astro.response.headers.set(
-  'CDN-Cache-Control',
-  'public, max-age=60, stale-while-revalidate=600'
-);
+Astro.response.headers.set('CDN-Cache-Control', 'public, max-age=60, stale-while-revalidate=600');
 
 const { locale, slug } = Astro.params;
 
@@ -82,12 +88,14 @@ if (!isDetailPage) {
 }
 
 // Fetch profile — try dedicated endpoint first, fall back to index-embedded profiles
+let profileFound = false;
 let displayName = slug;
 let avatarUrl: string | null = null;
 let description = '';
 let websiteUrls: string[] = [];
 try {
   const profile = await getProfile(slug);
+  profileFound = true;
   displayName = profile.display_name || slug;
   avatarUrl = profile.avatar_url || null;
   description = profile.description || '';
@@ -97,6 +105,7 @@ try {
   const cachedProfiles = await getProfileCache();
   const cached = cachedProfiles.get(slug);
   if (cached) {
+    profileFound = true;
     displayName = cached.display_name || slug;
     avatarUrl = cached.avatar_url || null;
     description = cached.description || '';
@@ -117,8 +126,10 @@ try {
   // Index API failed — show empty grid
 }
 
-// If no profile and no workflows and not a detail page, redirect
-if (!isDetailPage && !displayName && serialized.length === 0) {
+// Slug is bogus (e.g. "undefined" or a malformed "<name>-" suffix from a broken
+// link): no profile and no workflows — redirect instead of rendering a page
+// that would title itself "<slug> (@<slug>)" and get indexed by Google.
+if (!isDetailPage && !profileFound && serialized.length === 0) {
   return Astro.redirect(`/${locale}/workflows/`);
 }
 
@@ -126,18 +137,19 @@ const canonicalUrl = absoluteUrl(`/workflows/${slug}/`);
 
 // Parse social links from website_urls
 function getSocialDisplay(social: string): { label: string; url: string } {
-  const url = social.startsWith('http://') || social.startsWith('https://')
-    ? social
-    : `https://${social}`;
+  const url =
+    social.startsWith('http://') || social.startsWith('https://') ? social : `https://${social}`;
 
   if (social.includes('x.com') || social.includes('twitter.com')) return { label: 'X', url };
   if (social.includes('instagram.com')) return { label: 'Instagram', url };
-  if (social.includes('youtube.com') || social.includes('youtu.be')) return { label: 'YouTube', url };
+  if (social.includes('youtube.com') || social.includes('youtu.be'))
+    return { label: 'YouTube', url };
   if (social.includes('tiktok.com')) return { label: 'TikTok', url };
   if (social.includes('linkedin.com')) return { label: 'LinkedIn', url };
   if (social.includes('github.com')) return { label: 'GitHub', url };
   if (social.includes('facebook.com')) return { label: 'Facebook', url };
-  if (social.includes('threads.net') || social.includes('threads.com')) return { label: 'Threads', url };
+  if (social.includes('threads.net') || social.includes('threads.com'))
+    return { label: 'Threads', url };
   return { label: 'Website', url };
 }
 
@@ -148,139 +160,146 @@ const detailTitle = detailData ? `${detailData.title || detailData.name} - Comfy
 const detailCanonicalUrl = detailData ? absoluteUrl(`/workflows/${slug}/`) : '';
 const detailThumbnails = detailData?.thumbnails || [];
 const detailPrimaryThumbnail = detailThumbnails[0] || null;
-const detailOgImage = detailData ? workflowOgUrl(
-  detailData.title || detailData.name,
-  detailPrimaryThumbnail || undefined,
-  detailData.username || undefined
-) : '';
-const detailStructuredData = detailData ? {
-  '@context': 'https://schema.org',
-  '@type': 'TechArticle',
-  headline: detailData.title || detailData.name,
-  description: detailData.description,
-  image: detailPrimaryThumbnail || undefined,
-  datePublished: detailData.date,
-  inLanguage: locale,
-} : null;
-const detailBreadcrumb = detailData ? {
-  '@context': 'https://schema.org',
-  '@type': 'BreadcrumbList',
-  itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_ORIGIN },
-    { '@type': 'ListItem', position: 2, name: 'Workflows', item: absoluteUrl('/workflows/') },
-    { '@type': 'ListItem', position: 3, name: detailData.title || detailData.name, item: detailCanonicalUrl },
-  ],
-} : null;
+const detailOgImage = detailData
+  ? workflowOgUrl(
+      detailData.title || detailData.name,
+      detailPrimaryThumbnail || undefined,
+      detailData.username || undefined
+    )
+  : '';
+const detailStructuredData = detailData
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'TechArticle',
+      headline: detailData.title || detailData.name,
+      description: detailData.description,
+      image: detailPrimaryThumbnail || undefined,
+      datePublished: detailData.date,
+      inLanguage: locale,
+    }
+  : null;
+const detailBreadcrumb = detailData
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_ORIGIN },
+        { '@type': 'ListItem', position: 2, name: 'Workflows', item: absoluteUrl('/workflows/') },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: detailData.title || detailData.name,
+          item: detailCanonicalUrl,
+        },
+      ],
+    }
+  : null;
 
-const structuredData = !isDetailPage ? {
-  '@context': 'https://schema.org',
-  '@type': 'ProfilePage',
-  name: displayName,
-  description: description || `Workflows by ${displayName}`,
-  url: canonicalUrl,
-  inLanguage: locale,
-} : null;
+const structuredData = !isDetailPage
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'ProfilePage',
+      name: displayName,
+      description: description || `Workflows by ${displayName}`,
+      url: canonicalUrl,
+      inLanguage: locale,
+    }
+  : null;
 ---
 
-{isDetailPage && detailData ? (
-<BaseLayout
-  title={detailTitle}
-  description={detailData.metaDescription || detailData.description}
-  canonicalUrl={detailCanonicalUrl}
-  ogImage={detailOgImage}
-  ogType="article"
-  structuredData={detailStructuredData ?? undefined}
-  hreflangBasePath={`/workflows/${slug}/`}
-  locale={typedLocale}
-  theme="dark"
-  hideDefaultFooter
->
-  <HubNavbar />
-  <TemplateDetailPage template={{ data: detailData }} locale={typedLocale} />
-  <script
-    is:inline
-    type="application/ld+json"
-    set:html={JSON.stringify(detailBreadcrumb)}
-  />
-  <Fragment slot="footer">
-    <SiteFooter />
-  </Fragment>
-</BaseLayout>
-) : (
-<BaseLayout
-  title={`${displayName} (@${slug}) - ComfyUI Workflow Templates`}
-  description={description || `Workflows by ${displayName}`}
-  canonicalUrl={canonicalUrl}
-  ogImage={creatorOgUrl(displayName, slug!, avatarUrl || undefined)}
-  structuredData={structuredData ?? undefined}
-  locale={typedLocale}
-  theme="dark"
-  hideDefaultFooter
->
-  <HubNavbar />
+{
+  isDetailPage && detailData ? (
+    <BaseLayout
+      title={detailTitle}
+      description={detailData.metaDescription || detailData.description}
+      canonicalUrl={detailCanonicalUrl}
+      ogImage={detailOgImage}
+      ogType="article"
+      structuredData={detailStructuredData ?? undefined}
+      hreflangBasePath={`/workflows/${slug}/`}
+      locale={typedLocale}
+      theme="dark"
+      hideDefaultFooter
+    >
+      <HubNavbar />
+      <TemplateDetailPage template={{ data: detailData }} locale={typedLocale} />
+      <script is:inline type="application/ld+json" set:html={JSON.stringify(detailBreadcrumb)} />
+      <Fragment slot="footer">
+        <SiteFooter />
+      </Fragment>
+    </BaseLayout>
+  ) : (
+    <BaseLayout
+      title={`${displayName} (@${slug}) - ComfyUI Workflow Templates`}
+      description={description || `Workflows by ${displayName}`}
+      canonicalUrl={canonicalUrl}
+      ogImage={creatorOgUrl(displayName, slug!, avatarUrl || undefined)}
+      structuredData={structuredData ?? undefined}
+      locale={typedLocale}
+      theme="dark"
+      hideDefaultFooter
+    >
+      <HubNavbar />
 
-  <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pb-20">
-    <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 pt-8">
-      <aside class="w-full lg:w-[328px] shrink-0">
-        <div class="lg:sticky lg:top-16 flex flex-col gap-8 pt-8">
-          <BackButton locale={typedLocale} class="self-start" />
-          <SidebarSection contentClass="p-8 gap-6">
-            <div class="flex flex-col gap-4">
-              {avatarUrl ? (
-                <img
-                  src={avatarUrl}
-                  alt={displayName}
-                  class="size-16 rounded-full object-cover"
-                />
-              ) : (
-                <div class="size-16 rounded-full bg-brand flex items-center justify-center">
-                  <span class="text-black text-2xl font-bold">
-                    {displayName.charAt(0).toUpperCase()}
-                  </span>
+      <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pb-20">
+        <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 pt-8">
+          <aside class="w-full lg:w-[328px] shrink-0">
+            <div class="lg:sticky lg:top-16 flex flex-col gap-8 pt-8">
+              <BackButton locale={typedLocale} class="self-start" />
+              <SidebarSection contentClass="p-8 gap-6">
+                <div class="flex flex-col gap-4">
+                  {avatarUrl ? (
+                    <img
+                      src={avatarUrl}
+                      alt={displayName}
+                      class="size-16 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div class="size-16 rounded-full bg-brand flex items-center justify-center">
+                      <span class="text-black text-2xl font-bold">
+                        {displayName.charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+                  )}
+                  <div class="flex flex-col">
+                    <p class="text-content text-base font-bold">{displayName}</p>
+                    <p class="text-hub-muted text-sm">@{slug}</p>
+                  </div>
                 </div>
-              )}
-              <div class="flex flex-col">
-                <p class="text-content text-base font-bold">{displayName}</p>
-                <p class="text-hub-muted text-sm">@{slug}</p>
-              </div>
+
+                {description && <p class="text-hub-muted text-sm leading-normal">{description}</p>}
+
+                {socialLinks.length > 0 && (
+                  <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-hub-muted">
+                    {socialLinks.map((link) => (
+                      <a
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="underline hover:text-content transition-colors"
+                      >
+                        {link.label}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </SidebarSection>
             </div>
+          </aside>
 
-            {description && (
-              <p class="text-hub-muted text-sm leading-normal">{description}</p>
-            )}
-
-            {
-              socialLinks.length > 0 && (
-                <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-hub-muted">
-                  {socialLinks.map((link) => (
-                    <a
-                      href={link.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="underline hover:text-content transition-colors"
-                    >
-                      {link.label}
-                    </a>
-                  ))}
-                </div>
-              )
-            }
-          </SidebarSection>
+          <WorkflowGrid
+            client:load
+            templates={serialized}
+            locale={typedLocale}
+            gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+            hideAuthor
+          />
         </div>
-      </aside>
+      </div>
 
-      <WorkflowGrid
-        client:load
-        templates={serialized}
-        locale={typedLocale}
-        gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-        hideAuthor
-      />
-    </div>
-  </div>
-
-  <Fragment slot="footer">
-    <SiteFooter />
-  </Fragment>
-</BaseLayout>
-)}
+      <Fragment slot="footer">
+        <SiteFooter />
+      </Fragment>
+    </BaseLayout>
+  )
+}

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -119,7 +119,11 @@ let serialized: SerializedTemplate[] = [];
 
 try {
   const entries = await listWorkflowIndex();
-  const filtered = entries.filter((e) => (e.profile?.username || e.username) === slug);
+  // Match by username AND drop rows missing name/shareId so the grid never
+  // renders a card that links to /workflows/undefined/ (FE-223).
+  const filtered = entries.filter(
+    (e) => (e.profile?.username || e.username) === slug && Boolean(e.name) && Boolean(e.shareId)
+  );
   serialized = filtered.map((e) => serializeIndexEntry(e, profiles));
 } catch (err) {
   console.error('Hub API failed for creator grid:', err);

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -34,12 +34,18 @@ export async function getStaticPaths() {
   }
 
   const paths = [];
+  let skipped = 0;
 
   for (const entry of entries) {
     // Skip entries that can't form a valid /workflows/{name}-{shareId}/ slug.
     // Without this, Astro statically renders indexable broken pages like
-    // /workflows/<name>-/ that Google then surfaces as real results.
-    if (!entry.name || !entry.shareId) continue;
+    // /workflows/<name>-/ that Google then surfaces as real results (FE-223).
+    // Hub entries lacking either field are filtered out everywhere (cards,
+    // search index, grids), so dropping them here keeps routing consistent.
+    if (!entry.name || !entry.shareId) {
+      skipped++;
+      continue;
+    }
 
     const { name, shareId } = entry;
 
@@ -54,6 +60,12 @@ export async function getStaticPaths() {
       params: { slug: name },
       props: { entry: null, legacySlug: name, legacyShareId: shareId },
     });
+  }
+
+  if (skipped > 0) {
+    console.warn(
+      `[slug].astro getStaticPaths: skipped ${skipped} hub entries missing name or shareId — see FE-223`
+    );
   }
 
   return paths;

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -15,10 +15,7 @@ import TemplateDetailPage from '../../components/template-detail/TemplateDetailP
 import { DEFAULT_LOCALE } from '../../i18n/config';
 import { getTemplatesForLocale } from '../../lib/templates';
 import { SITE_ORIGIN, absoluteUrl } from '../../config/site';
-import {
-  listWorkflowIndex,
-  type HubWorkflowTemplateEntry,
-} from '../../lib/hub-api';
+import { listWorkflowIndex, type HubWorkflowTemplateEntry } from '../../lib/hub-api';
 import { workflowOgUrl } from '../../lib/og-url';
 
 export async function getStaticPaths() {
@@ -28,19 +25,24 @@ export async function getStaticPaths() {
   } catch {
     // Fallback to content collection
     const templates = await getTemplatesForLocale(DEFAULT_LOCALE);
-    return templates.map((t) => ({
-      params: { slug: t.data.name },
-      props: { entry: null, legacySlug: t.data.name, legacyShareId: null },
-    }));
+    return templates
+      .filter((t) => Boolean(t.data.name))
+      .map((t) => ({
+        params: { slug: t.data.name },
+        props: { entry: null, legacySlug: t.data.name, legacyShareId: null },
+      }));
   }
 
   const paths = [];
 
   for (const entry of entries) {
-    const shareId = entry.shareId || '';
-    const name = entry.name || shareId;
+    // Skip entries that can't form a valid /workflows/{name}-{shareId}/ slug.
+    // Without this, Astro statically renders indexable broken pages like
+    // /workflows/<name>-/ that Google then surfaces as real results.
+    if (!entry.name || !entry.shareId) continue;
 
-    // New URL: /workflows/{name}-{shareId}/
+    const { name, shareId } = entry;
+
     paths.push({
       params: { slug: `${name}-${shareId}` },
       props: { entry, legacySlug: null, legacyShareId: null },

--- a/site/src/pages/workflows/[username].astro
+++ b/site/src/pages/workflows/[username].astro
@@ -93,9 +93,10 @@ try {
 }
 
 // Slug is bogus (e.g. "undefined" or a malformed "<name>-" suffix from a broken
-// link): no profile and no workflows — redirect instead of rendering a page that
-// would title itself "<slug> (@<slug>)" and get indexed by Google.
-if (!profileFound && serialized.length === 0) {
+// link): not a workflow detail, no profile, and no workflows — redirect instead
+// of rendering a page that would title itself "<slug> (@<slug>)" and get
+// indexed by Google.
+if (!isDetailPage && !profileFound && serialized.length === 0) {
   return Astro.redirect('/workflows/');
 }
 

--- a/site/src/pages/workflows/[username].astro
+++ b/site/src/pages/workflows/[username].astro
@@ -86,7 +86,14 @@ let serialized: SerializedTemplate[] = [];
 
 try {
   const entries = await listWorkflowIndex();
-  const filtered = entries.filter((e) => (e.profile?.username || e.username) === slugParam);
+  // Match by username AND drop rows missing name/shareId so the grid never
+  // renders a card that links to /workflows/undefined/ (FE-223).
+  const filtered = entries.filter(
+    (e) =>
+      (e.profile?.username || e.username) === slugParam &&
+      Boolean(e.name) &&
+      Boolean(e.shareId)
+  );
   serialized = filtered.map((e) => serializeIndexEntry(e, profiles));
 } catch {
   // Index API failed — show empty grid

--- a/site/src/pages/workflows/[username].astro
+++ b/site/src/pages/workflows/[username].astro
@@ -55,12 +55,14 @@ if (detailShareId) {
 }
 
 // Fetch profile — try dedicated endpoint first, fall back to index-embedded profiles
+let profileFound = false;
 let displayName = slugParam;
 let avatarUrl: string | null = null;
 let description = '';
 let websiteUrls: string[] = [];
 try {
   const profile = await getProfile(slugParam);
+  profileFound = true;
   displayName = profile.display_name || slugParam;
   avatarUrl = profile.avatar_url || null;
   description = profile.description || '';
@@ -70,6 +72,7 @@ try {
   const profiles = await getProfileCache();
   const cached = profiles.get(slugParam);
   if (cached) {
+    profileFound = true;
     displayName = cached.display_name || slugParam;
     avatarUrl = cached.avatar_url || null;
     description = cached.description || '';
@@ -89,8 +92,10 @@ try {
   // Index API failed — show empty grid
 }
 
-// If no profile and no workflows, redirect
-if (!displayName && serialized.length === 0) {
+// Slug is bogus (e.g. "undefined" or a malformed "<name>-" suffix from a broken
+// link): no profile and no workflows — redirect instead of rendering a page that
+// would title itself "<slug> (@<slug>)" and get indexed by Google.
+if (!profileFound && serialized.length === 0) {
   return Astro.redirect('/workflows/');
 }
 

--- a/site/tests/unit/routes.test.ts
+++ b/site/tests/unit/routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { workflowDetailPath } from '../../src/lib/routes';
+import { workflowDetailPath, workflowDetailSlug } from '../../src/lib/routes';
 
 describe('workflowDetailPath', () => {
   it('builds a {name}-{shareId} URL when both are present', () => {
@@ -28,5 +28,25 @@ describe('workflowDetailPath', () => {
     expect(workflowDetailPath(null)).toBeNull();
     expect(workflowDetailPath('')).toBeNull();
     expect(workflowDetailPath(undefined, 'abc123')).toBeNull();
+  });
+});
+
+describe('workflowDetailSlug', () => {
+  it('joins name and shareId with a hyphen', () => {
+    expect(workflowDetailSlug('flux-schnell', 'e90e933d6c5d')).toBe('flux-schnell-e90e933d6c5d');
+  });
+
+  it('returns the bare name when shareId is missing', () => {
+    expect(workflowDetailSlug('legacy-name')).toBe('legacy-name');
+    expect(workflowDetailSlug('legacy-name', null)).toBe('legacy-name');
+    expect(workflowDetailSlug('legacy-name', '')).toBe('legacy-name');
+  });
+
+  it('returns null when name is missing — keeps malformed entries out of search index', () => {
+    expect(workflowDetailSlug(undefined)).toBeNull();
+    expect(workflowDetailSlug(null)).toBeNull();
+    expect(workflowDetailSlug('')).toBeNull();
+    expect(workflowDetailSlug(undefined, 'abc123')).toBeNull();
+    expect(workflowDetailSlug('', 'abc123')).toBeNull();
   });
 });

--- a/site/tests/unit/routes.test.ts
+++ b/site/tests/unit/routes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { workflowDetailPath } from '../../src/lib/routes';
+
+describe('workflowDetailPath', () => {
+  it('builds a {name}-{shareId} URL when both are present', () => {
+    expect(workflowDetailPath('flux-schnell', 'e90e933d6c5d')).toBe(
+      '/workflows/flux-schnell-e90e933d6c5d/'
+    );
+  });
+
+  it('falls back to {name} when shareId is missing', () => {
+    expect(workflowDetailPath('legacy-name')).toBe('/workflows/legacy-name/');
+    expect(workflowDetailPath('legacy-name', '')).toBe('/workflows/legacy-name/');
+  });
+
+  it('prefixes non-default locales', () => {
+    expect(workflowDetailPath('flux-schnell', 'e90e933d6c5d', 'ja')).toBe(
+      '/ja/workflows/flux-schnell-e90e933d6c5d/'
+    );
+  });
+
+  it('does not prefix the default locale', () => {
+    expect(workflowDetailPath('flux-schnell', 'abc', 'en')).toBe('/workflows/flux-schnell-abc/');
+  });
+
+  it('returns null when name is missing — prevents /workflows/undefined/ links', () => {
+    expect(workflowDetailPath(undefined)).toBeNull();
+    expect(workflowDetailPath(null)).toBeNull();
+    expect(workflowDetailPath('')).toBeNull();
+    expect(workflowDetailPath(undefined, 'abc123')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

PostHog shows two related bugs producing **~2,015 broken pageviews/week** on `www.comfy.org` / `comfy.org`, with the broken URL traffic flat-to-rising over the past 14 days.

| URL pattern | 7d views | What's undefined |
|---|---|---|
| `/workflows/undefined/` | 1,771 | both `name` and `shareId` |
| `/workflows/video_wan2_2_14B_i2v-/` | 135 | only `shareId` (note trailing dash) |
| `/workflows/api_seedance2_0_r2v-/` | 52 | only `shareId` |
| `/workflows/api_grok_image_edit-/` | 31 | only `shareId` |
| `/workflows/api_seedance2_0_t2v-/` | 22 | only `shareId` |
| 2 more `*-/` slugs | 4 | only `shareId` |

Google indexed `/workflows/undefined/` and is referring **570 views/wk** — the page returns HTTP 200 with `<title>undefined (@undefined) - ComfyUI Workflow Templates</title>`.

## Root causes

Five places, layered:

1. `src/components/hub/HubWorkflowCard.vue:97-101` — when `props.name` was undefined, the template literal stringified it to literal `"undefined"`, and `handleCardClick` hard-navigated users to `/workflows/undefined/`.
2. `src/pages/workflows/[slug].astro:39-55` — `getStaticPaths` built a static page even when `entry.shareId` (or `entry.name`) was missing, producing slugs like `<name>-/` with empty suffix. Astro pre-rendered these as indexable HTML returning 200.
3. `src/pages/workflows/[username].astro` and `src/pages/[locale]/workflows/[slug].astro` — once the static page fix above stops generating the bad files, requests fall through to the on-demand creator-profile route. That route accepted any slug, fell back to `displayName = slugParam`, and rendered a profile page titled `<slug> (@<slug>)`. The existing redirect guard `!displayName && serialized.length === 0` never fired because `displayName` always falls back to the slug itself.
4. `src/components/hub/SearchPopover.vue:746-750, 1109` — the navbar search island built popular-result hrefs by interpolating `wf.name`/`wf.shareId` directly, and the badge-only mapped hits omitted the `slug` field entirely. A malformed index row could still produce `/workflows/undefined-<id>/`, `/workflows/<name>-undefined/`, or `/workflows/<name>-/` from the search popover. _(Surfaced by Codex adversarial review.)_
5. `scripts/lib/search/build-index.ts` — the prebuilt MiniSearch index used `name = data.name || shareId` and `slug = shareId ? \`${name}-${shareId}\` : name`, so a hub entry missing `name` was silently rebuilt as `<shareId>-<shareId>` and a name-only entry with empty `data.name` produced an empty slug. _(Surfaced by Codex adversarial review.)_

## Fix

- New `workflowDetailPath(name, shareId?, locale?)` helper in `src/lib/routes.ts` returning `null` when `name` is missing, plus a sibling `workflowDetailSlug(name, shareId?)` returning just the slug component for callers (search index, badge-only hits) that don't need the full URL.
- `HubWorkflowCard.vue` uses the helper; click handler bails out when null; `cursor-pointer` is conditional so cards without a target URL aren't visually clickable.
- `[slug].astro` `getStaticPaths` skips entries missing `name` or `shareId` (with `console.warn`); the content-collection fallback also filters by `name`.
- `[username].astro` and `[locale]/workflows/[slug].astro` track `profileFound` explicitly and redirect to the gallery when the slug isn't a detail page, isn't a known profile, and has no workflows. Creator-grid filters now also drop rows missing `name`/`shareId` so cards never render with a broken target.
- `SearchPopover.vue`: added `shareId` to the local `SearchTemplate` interface (was missing despite being read at runtime); routed popular-workflow hrefs and click handlers through `workflowDetailPath`; filtered `popularWorkflows` to drop rows lacking either field; fixed the badge-only `displayedWorkflows` mapping to attach a real `slug` (the missing field was its own latent bug).
- `build-index.ts`: skip hub entries lacking `name` or `shareId` before adding to the search index (with `logger.warn`); content-collection fallback drops nameless rows. Strict input contract means the prebuilt index can never contain `undefined-...` or empty slugs.

The strategy on shareId-only entries is "filter everywhere consistently" rather than "preserve via fallback slug" — PostHog data shows zero shareId-only URL traffic in production, so a name-less workflow has no human-readable display anyway. Filtering at every entry point (cards, search index, grids, static paths) guarantees a malformed row can't surface as a broken link from any UI surface.

## Behavioural impact after deploy

- New static-build run drops indexable `/workflows/<name>-/` pages → those URLs become real 404s, which Google will eventually drop from the index. A Google Search Console "Removals" request can speed this up.
- Card clicks for malformed entries become no-ops instead of `/workflows/undefined/` navigation.
- Bogus slugs that bleed through to the on-demand creator-profile route now redirect to `/workflows/` instead of rendering as fake profiles.
- Search popover popular-workflows rows and badge-only hits never render undefined-slug hrefs.
- Search index size shrinks slightly (skipped hub entries logged as warnings during build).

## Verification

### Unit tests

- `pnpm test` — **106 unit tests pass** (8 in `tests/unit/routes.test.ts` covering both helpers, all branches, including the null-on-missing-name guard and shareId-only edge cases).
- Prettier clean on touched files.
- ESLint clean on touched files (5 pre-existing repo-wide errors are unchanged versus `main`).
- `pnpm check` — 0 errors, 0 warnings.

### Vercel preview probes (commit `b0b1f13`, preview `workflow-templates-8tvpu4abo-comfyui.vercel.app`)

| URL | Before | After | Expected | Notes |
|---|---|---|---|---|
| `/workflows/undefined/` | 200 | 302 → `/workflows/` | 302 | ✅ Bug fixed |
| `/workflows/video_wan2_2_14B_i2v-/` | 200 | 302 → `/workflows/` | 302 | ✅ Bug fixed |
| `/workflows/api_grok_image_edit-/` | 200 | 302 → `/workflows/` | 302 | ✅ Bug fixed |
| `/workflows/api_seedance2_0_r2v-/` | 200 | 302 → `/workflows/` | 302 | ✅ Bug fixed |
| `/workflows/api_seedance2_0_t2v-/` | 200 | 302 → `/workflows/` | 302 | ✅ Bug fixed |
| `/workflows/comfyui/` (real creator) | 200 | 200 | 200 | ✅ Real creator profile preserved |
| `/workflows/` (gallery) | 200 | 200 | 200 | ✅ Gallery loads |
| `/workflows/api_seedance2_0_r2v-64f4db9e3e33/` (real detail) | 200 | 302 → `/workflows/` | 200 | ⚠ Preview Hub API returned no workflow entries at build time, so `[slug].astro` couldn't generate static detail pages. Falls through to `[username].astro`'s pre-existing detail-catch redirect (line 64, unchanged by this PR). Confirmed prod still 200s these URLs. Production build will populate detail pages from the real Hub API and serve them statically — preview false negative on this row only. |

### Search index audit (commit `b0b1f13`)

Pulled the live preview's `/workflows/search-index.json` and audited:

```
total docs: 420
bad slug (empty/undefined): 0
bad name (empty/undefined): 0
slug ending in -: 0
```

Zero malformed slugs reach the client search index, confirming the `build-index.ts` filter and that the SearchPopover popular/badge-only paths can never receive undefined-slug rows.

### Production validation (post-deploy)

Plan to re-run the same probe set against `www.comfy.org` after merge + deploy. Expected:

```bash
curl -o /dev/null -w "%{http_code}\n" https://www.comfy.org/workflows/undefined/
# expect: 302 (currently 200)

curl -o /dev/null -w "%{http_code}\n" https://www.comfy.org/workflows/video_wan2_2_14B_i2v-/
# expect: 302 (currently 200)

curl -o /dev/null -w "%{http_code}\n" https://www.comfy.org/workflows/api_seedance2_0_r2v-64f4db9e3e33/
# expect: 200 (must still serve)
```

PostHog query 24h post-deploy:
```sql
SELECT toDate(timestamp) AS day, properties.$pathname AS path, count() AS views
FROM events
WHERE event = '$pageview'
  AND timestamp >= now() - interval 3 day
  AND (properties.$pathname = '/workflows/undefined/' OR properties.$pathname LIKE '/workflows/%-/')
GROUP BY day, path ORDER BY day DESC, views DESC
```
Expected: `/workflows/undefined/` and `*-/` views drop toward 0 by next day.

## Notes

This bug requires malformed upstream data to repro in a browser, so no clean before/after browser screenshot — the unit tests + preview probes + search-index audit cover the behaviour. Google Search Console "Removals" request for `/workflows/undefined/` after deploy will speed up de-indexing.

Codex adversarial review pass on commit `00a520d` flagged two additional leaks (SearchPopover URL builders and shareId-only routing inconsistency), addressed in commit `b0b1f13` and re-verified against the new preview.

Fixes FE-223
