### PR TITLE
fix(site): close /workflows/undefined/ leak from SearchPopover badge filters (FE-223)

### DIFF
--- a/site/scripts/lib/search/build-index.ts
+++ b/site/scripts/lib/search/build-index.ts
@@ -57,9 +57,7 @@ async function fetchIndexEntries(): Promise<IndexEntry[] | null> {
   if (!apiUrl) return null;
 
   const approvedOnly = process.env.PUBLIC_APPROVED_ONLY === 'true';
-  const statuses = approvedOnly
-    ? 'approved'
-    : 'pending,approved,rejected,deprecated';
+  const statuses = approvedOnly ? 'approved' : 'pending,approved,rejected,deprecated';
   const res = await fetch(`${apiUrl}/api/hub/workflows/index?status=${statuses}`);
 
   if (!res.ok) {
@@ -114,9 +112,9 @@ export async function buildSearchIndex(): Promise<void> {
       const models = data.models || [];
       const shareId = data.shareId || '';
       const name = data.name || shareId;
-      // Use shareId as the unique ID; name can be duplicated across users
+      // shareId is the unique key — only skip if neither field can identify the workflow.
+      if (!name) continue;
       const id = shareId || name;
-      // URL slug: "{name}-{shareId}" for hub entries, "{name}" for legacy
       const slug = shareId ? `${name}-${shareId}` : name;
 
       documents.push({
@@ -138,8 +136,12 @@ export async function buildSearchIndex(): Promise<void> {
     }
   } else {
     // No PUBLIC_HUB_API_URL — local/offline build, use content collection
-    const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.json') && !f.includes('/'));
-    logger.warn(`No hub API configured — building search index from content collection (${files.length} files)`);
+    const files = fs
+      .readdirSync(CONTENT_DIR)
+      .filter((f) => f.endsWith('.json') && !f.includes('/'));
+    logger.warn(
+      `No hub API configured — building search index from content collection (${files.length} files)`
+    );
 
     for (const file of files) {
       const filePath = path.join(CONTENT_DIR, file);
@@ -229,5 +231,7 @@ export async function buildSearchIndex(): Promise<void> {
 
   const sizeKB = (Buffer.byteLength(serialized) / 1024).toFixed(1);
   const duration = ((Date.now() - startTime) / 1000).toFixed(2);
-  logger.info(`Search index written to public/workflows/search-index.json (${sizeKB} KB, ${duration}s)`);
+  logger.info(
+    `Search index written to public/workflows/search-index.json (${sizeKB} KB, ${duration}s)`
+  );
 }

--- a/site/src/components/hub/HubWorkflowCard.vue
+++ b/site/src/components/hub/HubWorkflowCard.vue
@@ -12,6 +12,7 @@ import type { ThumbnailVariant } from '@/lib/hub-api';
 import { initCompareSlider } from '@/lib/initCompareSlider';
 import { getVideoFrameUrl } from '@/lib/video-thumbnail';
 import { isVideoFile, isAudioFile, isMediaFile } from '@/lib/media-utils';
+import { workflowDetailPath } from '@/lib/routes';
 
 const MODEL_TO_LOGO: Record<string, string> = {
   Grok: 'grok',
@@ -94,11 +95,7 @@ const logoPath = computed(() => (providerName.value ? getLogoPath(providerName.v
 
 const authorName = computed(() => props.creatorDisplayName || 'ComfyUI');
 
-const templateUrl = computed(() => {
-  const slug = props.shareId ? `${props.name}-${props.shareId}` : props.name;
-  const base = `/workflows/${slug}/`;
-  return props.locale && props.locale !== 'en' ? `/${props.locale}${base}` : base;
-});
+const templateUrl = computed(() => workflowDetailPath(props.name, props.shareId, props.locale));
 
 const primaryFile = computed(() => props.thumbnails[0] ?? null);
 const secondaryFile = computed(() => props.thumbnails[1] ?? null);
@@ -229,13 +226,15 @@ const creatorUrl = computed(() => {
 });
 
 function handleCardClick() {
+  if (!templateUrl.value) return;
   window.location.href = templateUrl.value;
 }
 </script>
 
 <template>
   <div
-    class="group transition-all duration-200 content-auto cursor-pointer"
+    class="group transition-all duration-200 content-auto"
+    :class="templateUrl ? 'cursor-pointer' : ''"
     @click="handleCardClick"
   >
     <!-- Thumbnail -->
@@ -291,10 +290,7 @@ function handleCardClick() {
       </div>
 
       <!-- Hover crossfade -->
-      <div
-        v-else-if="showHoverDissolve"
-        class="group/thumb relative h-full w-full overflow-hidden"
-      >
+      <div v-else-if="showHoverDissolve" class="group/thumb relative h-full w-full overflow-hidden">
         <img
           :src="primaryUrl || ''"
           :alt="`${title} - 1`"
@@ -441,10 +437,7 @@ function handleCardClick() {
         :alt="authorName"
         class="size-5 rounded-full shrink-0 object-cover"
       />
-      <div
-        v-else
-        class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand"
-      >
+      <div v-else class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand">
         <span class="text-black text-[10px] font-bold leading-none">{{
           authorName.charAt(0).toUpperCase()
         }}</span>
@@ -458,10 +451,7 @@ function handleCardClick() {
         :alt="authorName"
         class="size-5 rounded-full shrink-0 object-cover"
       />
-      <div
-        v-else
-        class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand"
-      >
+      <div v-else class="size-5 rounded-full shrink-0 flex items-center justify-center bg-brand">
         <span class="text-black text-[10px] font-bold leading-none">{{
           authorName.charAt(0).toUpperCase()
         }}</span>
@@ -470,15 +460,15 @@ function handleCardClick() {
     </div>
 
     <!-- Tag pills -->
-    <div data-testid="tag-pills" class="flex items-center gap-1.5 pt-4 overflow-x-auto scrollbar-hide">
-      <a
-        v-for="tag in displayTags"
-        :key="tag"
-        :href="getTagUrl(tag)"
-        class="tag-link"
-        @click.stop
-      >
-        <Badge variant="hub-pill" class="hover:bg-hub-surface transition-colors shrink-0 whitespace-nowrap">
+    <div
+      data-testid="tag-pills"
+      class="flex items-center gap-1.5 pt-4 overflow-x-auto scrollbar-hide"
+    >
+      <a v-for="tag in displayTags" :key="tag" :href="getTagUrl(tag)" class="tag-link" @click.stop>
+        <Badge
+          variant="hub-pill"
+          class="hover:bg-hub-surface transition-colors shrink-0 whitespace-nowrap"
+        >
           {{ tagDisplayName(tag).toLowerCase().replace(/\s+/g, '-') }}
         </Badge>
       </a>

--- a/site/src/components/hub/SearchPopover.vue
+++ b/site/src/components/hub/SearchPopover.vue
@@ -23,9 +23,11 @@ import { trackSearchPerformed, trackFilterApplied } from '@/lib/posthog';
 import type { MediaType } from '@/lib/hub-api';
 import { isAudioFile, isVideoFile } from '@/lib/media-utils';
 import { getVideoFrameUrl } from '@/lib/video-thumbnail';
+import { workflowDetailPath, workflowDetailSlug } from '@/lib/routes';
 
 export interface SearchTemplate {
   name: string;
+  shareId: string;
   title: string;
   description: string;
   mediaType: MediaType;
@@ -213,10 +215,13 @@ const displayedWorkflows = computed(() => {
   if (hasQuery.value && searchResults.value) {
     return searchResults.value.workflows;
   }
-  // Badge-only → show all filtered templates as workflow-like items
+  // Badge-only → show all filtered templates as workflow-like items.
+  // Populate `slug` so the click target is a real workflow URL, never
+  // `/workflows/undefined/` (FE-223 root cause was this field being absent).
   if (hasBadges.value) {
     return badgeOnlyResults.value.map((t) => ({
       id: t.name,
+      slug: workflowDetailSlug(t.name, t.shareId) ?? '',
       title: t.title,
       mediaType: t.mediaType,
       mediaTypeLabel: MEDIA_TYPE_LABELS[t.mediaType] || t.mediaType,
@@ -268,10 +273,14 @@ const MEDIA_TYPE_LABELS: Record<string, string> = {
 
 // ── Helpers ──
 
-function getTemplateUrl(name: string): string {
+// Build a workflow detail URL from a pre-computed slug (search-index `slug`
+// field). Returns null when the slug is empty/undefined so callers can avoid
+// rendering /workflows/undefined/ links when the search index is malformed.
+function getTemplateUrl(slug: string | null | undefined): string | null {
+  if (!slug) return null;
   return props.locale && props.locale !== 'en'
-    ? `/${props.locale}/workflows/${name}/`
-    : `/workflows/${name}/`;
+    ? `/${props.locale}/workflows/${slug}/`
+    : `/workflows/${slug}/`;
 }
 
 function getCreatorUrl(username: string): string {
@@ -289,7 +298,7 @@ watch(
   }
 );
 
-// Popular workflows — top 4 by usage
+// Popular workflows — top 4 by usage.
 const popularWorkflows = computed(() =>
   [...props.templates].sort((a, b) => b.usage - a.usage).slice(0, 4)
 );
@@ -415,7 +424,8 @@ function activateItem(index: number) {
       if (creator) window.location.href = getCreatorUrl(creator.username);
     } else {
       const wf = displayedWorkflows.value[index - sugTotal - matchedCreators.value.length];
-      if (wf) window.location.href = getTemplateUrl(wf.slug);
+      const url = wf ? getTemplateUrl(wf.slug) : null;
+      if (url) window.location.href = url;
     }
   } else {
     const popCount = popularWorkflows.value.length;
@@ -424,7 +434,8 @@ function activateItem(index: number) {
 
     if (index < popCount) {
       const wf = popularWorkflows.value[index];
-      if (wf) window.location.href = getTemplateUrl(`${wf.name}-${wf.shareId}`);
+      const url = wf ? workflowDetailPath(wf.name, wf.shareId, props.locale) : null;
+      if (url) window.location.href = url;
     } else if (index < popCount + creatorCount) {
       const creator = topCreators.value[index - popCount];
       if (creator) window.location.href = getCreatorUrl(creator.username);
@@ -746,7 +757,7 @@ onUnmounted(() => {
                 <a
                   v-for="(wf, i) in popularWorkflows"
                   :key="wf.name"
-                  :href="getTemplateUrl(`${wf.name}-${wf.shareId}`)"
+                  :href="workflowDetailPath(wf.name, wf.shareId, props.locale) ?? '/workflows/'"
                   :data-nav-index="i"
                   class="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-lg hover:bg-hub-surface transition-colors group"
                   :class="{ 'bg-hub-surface': activeIndex === i }"
@@ -1106,7 +1117,7 @@ onUnmounted(() => {
                 <a
                   v-for="(hit, i) in displayedWorkflows"
                   :key="hit.id"
-                  :href="getTemplateUrl(hit.slug)"
+                  :href="getTemplateUrl(hit.slug) ?? '/workflows/'"
                   :data-nav-index="activeWorkflowOffset + i"
                   class="flex items-center gap-3 px-2 py-2.5 -mx-2 rounded-lg hover:bg-hub-surface transition-colors group"
                   :class="{ 'bg-hub-surface': activeIndex === activeWorkflowOffset + i }"

--- a/site/src/lib/routes.ts
+++ b/site/src/lib/routes.ts
@@ -4,4 +4,39 @@ export const categoryPath = (type: string) => `/workflows/category/${type}/`;
 export const modelPath = (name: string) => `/workflows/model/${name}/`;
 export const tagPath = (tag: string) => `/workflows/tag/${tagSlug(tag)}/`;
 export const thumbnailPath = (asset: string) =>
-  asset.startsWith('http://') || asset.startsWith('https://') ? asset : `/workflows/thumbnails/${asset}`;
+  asset.startsWith('http://') || asset.startsWith('https://')
+    ? asset
+    : `/workflows/thumbnails/${asset}`;
+
+/**
+ * Build the URL slug component (no `/workflows/` prefix, no locale).
+ *
+ * Falls back to `shareId` as the name when `name` is missing — a workflow with
+ * a `shareId` is still findable, so we never hide it from the user. Only
+ * returns `null` when both `name` and `shareId` are missing, which is the only
+ * case where no detail page can exist.
+ */
+export function workflowDetailSlug(
+  name: string | null | undefined,
+  shareId?: string | null
+): string | null {
+  const effectiveName = name || shareId;
+  if (!effectiveName) return null;
+  return shareId ? `${effectiveName}-${shareId}` : effectiveName;
+}
+
+/**
+ * Build a workflow detail URL. Returns `null` only when both `name` and
+ * `shareId` are missing (no detail page can exist); otherwise falls back
+ * to `shareId` so the workflow stays linkable.
+ */
+export function workflowDetailPath(
+  name: string | null | undefined,
+  shareId?: string | null,
+  locale?: string
+): string | null {
+  const slug = workflowDetailSlug(name, shareId);
+  if (!slug) return null;
+  const base = `/workflows/${slug}/`;
+  return locale && locale !== 'en' ? `/${locale}${base}` : base;
+}

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -18,14 +18,20 @@ import BackButton from '../../../components/BackButton.astro';
 import WorkflowGrid from '../../../components/hub/WorkflowGrid.vue';
 import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
 import { SITE_ORIGIN, absoluteUrl } from '../../../config/site';
-import { listWorkflowIndex, getProfile, getWorkflow, toTemplateData, extractShareId, getProfileCache, serializeIndexEntry, type SerializedTemplate } from '../../../lib/hub-api';
+import {
+  listWorkflowIndex,
+  getProfile,
+  getWorkflow,
+  toTemplateData,
+  extractShareId,
+  getProfileCache,
+  serializeIndexEntry,
+  type SerializedTemplate,
+} from '../../../lib/hub-api';
 import { workflowOgUrl, creatorOgUrl } from '../../../lib/og-url';
 
 // ISR: cache for 60s, serve stale for up to 10 min while revalidating
-Astro.response.headers.set(
-  'CDN-Cache-Control',
-  'public, max-age=60, stale-while-revalidate=600'
-);
+Astro.response.headers.set('CDN-Cache-Control', 'public, max-age=60, stale-while-revalidate=600');
 
 const { locale, slug } = Astro.params;
 
@@ -82,12 +88,14 @@ if (!isDetailPage) {
 }
 
 // Fetch profile — try dedicated endpoint first, fall back to index-embedded profiles
+let profileFound = false;
 let displayName = slug;
 let avatarUrl: string | null = null;
 let description = '';
 let websiteUrls: string[] = [];
 try {
   const profile = await getProfile(slug);
+  profileFound = true;
   displayName = profile.display_name || slug;
   avatarUrl = profile.avatar_url || null;
   description = profile.description || '';
@@ -97,6 +105,7 @@ try {
   const cachedProfiles = await getProfileCache();
   const cached = cachedProfiles.get(slug);
   if (cached) {
+    profileFound = true;
     displayName = cached.display_name || slug;
     avatarUrl = cached.avatar_url || null;
     description = cached.description || '';
@@ -117,8 +126,10 @@ try {
   // Index API failed — show empty grid
 }
 
-// If no profile and no workflows and not a detail page, redirect
-if (!isDetailPage && !displayName && serialized.length === 0) {
+// Slug is bogus (e.g. "undefined" or a malformed "<name>-" suffix from a broken
+// link): no profile and no workflows — redirect instead of rendering a page
+// that would title itself "<slug> (@<slug>)" and get indexed by Google.
+if (!isDetailPage && !profileFound && serialized.length === 0) {
   return Astro.redirect(`/${locale}/workflows/`);
 }
 
@@ -126,18 +137,19 @@ const canonicalUrl = absoluteUrl(`/workflows/${slug}/`);
 
 // Parse social links from website_urls
 function getSocialDisplay(social: string): { label: string; url: string } {
-  const url = social.startsWith('http://') || social.startsWith('https://')
-    ? social
-    : `https://${social}`;
+  const url =
+    social.startsWith('http://') || social.startsWith('https://') ? social : `https://${social}`;
 
   if (social.includes('x.com') || social.includes('twitter.com')) return { label: 'X', url };
   if (social.includes('instagram.com')) return { label: 'Instagram', url };
-  if (social.includes('youtube.com') || social.includes('youtu.be')) return { label: 'YouTube', url };
+  if (social.includes('youtube.com') || social.includes('youtu.be'))
+    return { label: 'YouTube', url };
   if (social.includes('tiktok.com')) return { label: 'TikTok', url };
   if (social.includes('linkedin.com')) return { label: 'LinkedIn', url };
   if (social.includes('github.com')) return { label: 'GitHub', url };
   if (social.includes('facebook.com')) return { label: 'Facebook', url };
-  if (social.includes('threads.net') || social.includes('threads.com')) return { label: 'Threads', url };
+  if (social.includes('threads.net') || social.includes('threads.com'))
+    return { label: 'Threads', url };
   return { label: 'Website', url };
 }
 
@@ -148,139 +160,146 @@ const detailTitle = detailData ? `${detailData.title || detailData.name} - Comfy
 const detailCanonicalUrl = detailData ? absoluteUrl(`/workflows/${slug}/`) : '';
 const detailThumbnails = detailData?.thumbnails || [];
 const detailPrimaryThumbnail = detailThumbnails[0] || null;
-const detailOgImage = detailData ? workflowOgUrl(
-  detailData.title || detailData.name,
-  detailPrimaryThumbnail || undefined,
-  detailData.username || undefined
-) : '';
-const detailStructuredData = detailData ? {
-  '@context': 'https://schema.org',
-  '@type': 'TechArticle',
-  headline: detailData.title || detailData.name,
-  description: detailData.description,
-  image: detailPrimaryThumbnail || undefined,
-  datePublished: detailData.date,
-  inLanguage: locale,
-} : null;
-const detailBreadcrumb = detailData ? {
-  '@context': 'https://schema.org',
-  '@type': 'BreadcrumbList',
-  itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_ORIGIN },
-    { '@type': 'ListItem', position: 2, name: 'Workflows', item: absoluteUrl('/workflows/') },
-    { '@type': 'ListItem', position: 3, name: detailData.title || detailData.name, item: detailCanonicalUrl },
-  ],
-} : null;
+const detailOgImage = detailData
+  ? workflowOgUrl(
+      detailData.title || detailData.name,
+      detailPrimaryThumbnail || undefined,
+      detailData.username || undefined
+    )
+  : '';
+const detailStructuredData = detailData
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'TechArticle',
+      headline: detailData.title || detailData.name,
+      description: detailData.description,
+      image: detailPrimaryThumbnail || undefined,
+      datePublished: detailData.date,
+      inLanguage: locale,
+    }
+  : null;
+const detailBreadcrumb = detailData
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_ORIGIN },
+        { '@type': 'ListItem', position: 2, name: 'Workflows', item: absoluteUrl('/workflows/') },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: detailData.title || detailData.name,
+          item: detailCanonicalUrl,
+        },
+      ],
+    }
+  : null;
 
-const structuredData = !isDetailPage ? {
-  '@context': 'https://schema.org',
-  '@type': 'ProfilePage',
-  name: displayName,
-  description: description || `Workflows by ${displayName}`,
-  url: canonicalUrl,
-  inLanguage: locale,
-} : null;
+const structuredData = !isDetailPage
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'ProfilePage',
+      name: displayName,
+      description: description || `Workflows by ${displayName}`,
+      url: canonicalUrl,
+      inLanguage: locale,
+    }
+  : null;
 ---
 
-{isDetailPage && detailData ? (
-<BaseLayout
-  title={detailTitle}
-  description={detailData.metaDescription || detailData.description}
-  canonicalUrl={detailCanonicalUrl}
-  ogImage={detailOgImage}
-  ogType="article"
-  structuredData={detailStructuredData ?? undefined}
-  hreflangBasePath={`/workflows/${slug}/`}
-  locale={typedLocale}
-  theme="dark"
-  hideDefaultFooter
->
-  <HubNavbar />
-  <TemplateDetailPage template={{ data: detailData }} locale={typedLocale} />
-  <script
-    is:inline
-    type="application/ld+json"
-    set:html={JSON.stringify(detailBreadcrumb)}
-  />
-  <Fragment slot="footer">
-    <SiteFooter />
-  </Fragment>
-</BaseLayout>
-) : (
-<BaseLayout
-  title={`${displayName} (@${slug}) - ComfyUI Workflow Templates`}
-  description={description || `Workflows by ${displayName}`}
-  canonicalUrl={canonicalUrl}
-  ogImage={creatorOgUrl(displayName, slug!, avatarUrl || undefined)}
-  structuredData={structuredData ?? undefined}
-  locale={typedLocale}
-  theme="dark"
-  hideDefaultFooter
->
-  <HubNavbar />
+{
+  isDetailPage && detailData ? (
+    <BaseLayout
+      title={detailTitle}
+      description={detailData.metaDescription || detailData.description}
+      canonicalUrl={detailCanonicalUrl}
+      ogImage={detailOgImage}
+      ogType="article"
+      structuredData={detailStructuredData ?? undefined}
+      hreflangBasePath={`/workflows/${slug}/`}
+      locale={typedLocale}
+      theme="dark"
+      hideDefaultFooter
+    >
+      <HubNavbar />
+      <TemplateDetailPage template={{ data: detailData }} locale={typedLocale} />
+      <script is:inline type="application/ld+json" set:html={JSON.stringify(detailBreadcrumb)} />
+      <Fragment slot="footer">
+        <SiteFooter />
+      </Fragment>
+    </BaseLayout>
+  ) : (
+    <BaseLayout
+      title={`${displayName} (@${slug}) - ComfyUI Workflow Templates`}
+      description={description || `Workflows by ${displayName}`}
+      canonicalUrl={canonicalUrl}
+      ogImage={creatorOgUrl(displayName, slug!, avatarUrl || undefined)}
+      structuredData={structuredData ?? undefined}
+      locale={typedLocale}
+      theme="dark"
+      hideDefaultFooter
+    >
+      <HubNavbar />
 
-  <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pb-20">
-    <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 pt-8">
-      <aside class="w-full lg:w-[328px] shrink-0">
-        <div class="lg:sticky lg:top-16 flex flex-col gap-8 pt-8">
-          <BackButton locale={typedLocale} class="self-start" />
-          <SidebarSection contentClass="p-8 gap-6">
-            <div class="flex flex-col gap-4">
-              {avatarUrl ? (
-                <img
-                  src={avatarUrl}
-                  alt={displayName}
-                  class="size-16 rounded-full object-cover"
-                />
-              ) : (
-                <div class="size-16 rounded-full bg-brand flex items-center justify-center">
-                  <span class="text-black text-2xl font-bold">
-                    {displayName.charAt(0).toUpperCase()}
-                  </span>
+      <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pb-20">
+        <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 pt-8">
+          <aside class="w-full lg:w-[328px] shrink-0">
+            <div class="lg:sticky lg:top-16 flex flex-col gap-8 pt-8">
+              <BackButton locale={typedLocale} class="self-start" />
+              <SidebarSection contentClass="p-8 gap-6">
+                <div class="flex flex-col gap-4">
+                  {avatarUrl ? (
+                    <img
+                      src={avatarUrl}
+                      alt={displayName}
+                      class="size-16 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div class="size-16 rounded-full bg-brand flex items-center justify-center">
+                      <span class="text-black text-2xl font-bold">
+                        {displayName.charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+                  )}
+                  <div class="flex flex-col">
+                    <p class="text-content text-base font-bold">{displayName}</p>
+                    <p class="text-hub-muted text-sm">@{slug}</p>
+                  </div>
                 </div>
-              )}
-              <div class="flex flex-col">
-                <p class="text-content text-base font-bold">{displayName}</p>
-                <p class="text-hub-muted text-sm">@{slug}</p>
-              </div>
+
+                {description && <p class="text-hub-muted text-sm leading-normal">{description}</p>}
+
+                {socialLinks.length > 0 && (
+                  <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-hub-muted">
+                    {socialLinks.map((link) => (
+                      <a
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="underline hover:text-content transition-colors"
+                      >
+                        {link.label}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </SidebarSection>
             </div>
+          </aside>
 
-            {description && (
-              <p class="text-hub-muted text-sm leading-normal">{description}</p>
-            )}
-
-            {
-              socialLinks.length > 0 && (
-                <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-hub-muted">
-                  {socialLinks.map((link) => (
-                    <a
-                      href={link.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="underline hover:text-content transition-colors"
-                    >
-                      {link.label}
-                    </a>
-                  ))}
-                </div>
-              )
-            }
-          </SidebarSection>
+          <WorkflowGrid
+            client:load
+            templates={serialized}
+            locale={typedLocale}
+            gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+            hideAuthor
+          />
         </div>
-      </aside>
+      </div>
 
-      <WorkflowGrid
-        client:load
-        templates={serialized}
-        locale={typedLocale}
-        gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-        hideAuthor
-      />
-    </div>
-  </div>
-
-  <Fragment slot="footer">
-    <SiteFooter />
-  </Fragment>
-</BaseLayout>
-)}
+      <Fragment slot="footer">
+        <SiteFooter />
+      </Fragment>
+    </BaseLayout>
+  )
+}

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -15,10 +15,7 @@ import TemplateDetailPage from '../../components/template-detail/TemplateDetailP
 import { DEFAULT_LOCALE } from '../../i18n/config';
 import { getTemplatesForLocale } from '../../lib/templates';
 import { SITE_ORIGIN, absoluteUrl } from '../../config/site';
-import {
-  listWorkflowIndex,
-  type HubWorkflowTemplateEntry,
-} from '../../lib/hub-api';
+import { listWorkflowIndex, type HubWorkflowTemplateEntry } from '../../lib/hub-api';
 import { workflowOgUrl } from '../../lib/og-url';
 
 export async function getStaticPaths() {
@@ -28,10 +25,12 @@ export async function getStaticPaths() {
   } catch {
     // Fallback to content collection
     const templates = await getTemplatesForLocale(DEFAULT_LOCALE);
-    return templates.map((t) => ({
-      params: { slug: t.data.name },
-      props: { entry: null, legacySlug: t.data.name, legacyShareId: null },
-    }));
+    return templates
+      .filter((t) => Boolean(t.data.name))
+      .map((t) => ({
+        params: { slug: t.data.name },
+        props: { entry: null, legacySlug: t.data.name, legacyShareId: null },
+      }));
   }
 
   const paths = [];
@@ -39,19 +38,28 @@ export async function getStaticPaths() {
   for (const entry of entries) {
     const shareId = entry.shareId || '';
     const name = entry.name || shareId;
+    // Need at least one of name or shareId to form any slug.
+    if (!name) continue;
 
-    // New URL: /workflows/{name}-{shareId}/
-    paths.push({
-      params: { slug: `${name}-${shareId}` },
-      props: { entry, legacySlug: null, legacyShareId: null },
-    });
-
-    // Legacy redirect: /workflows/{name}/ → /workflows/{name}-{shareId}/
-    // Also handles UGC where name == shareId (card links use /workflows/{name}/)
-    paths.push({
-      params: { slug: name },
-      props: { entry: null, legacySlug: name, legacyShareId: shareId },
-    });
+    if (shareId) {
+      // Canonical: /workflows/{name}-{shareId}/
+      paths.push({
+        params: { slug: `${name}-${shareId}` },
+        props: { entry, legacySlug: null, legacyShareId: null },
+      });
+      // Legacy redirect: /workflows/{name}/ → /workflows/{name}-{shareId}/
+      // Also handles UGC where name == shareId (card links use /workflows/{name}/).
+      paths.push({
+        params: { slug: name },
+        props: { entry: null, legacySlug: name, legacyShareId: shareId },
+      });
+    } else {
+      // Legacy entry without shareId — render directly, no redirect needed.
+      paths.push({
+        params: { slug: name },
+        props: { entry, legacySlug: null, legacyShareId: null },
+      });
+    }
   }
 
   return paths;

--- a/site/src/pages/workflows/[username].astro
+++ b/site/src/pages/workflows/[username].astro
@@ -55,12 +55,14 @@ if (detailShareId) {
 }
 
 // Fetch profile — try dedicated endpoint first, fall back to index-embedded profiles
+let profileFound = false;
 let displayName = slugParam;
 let avatarUrl: string | null = null;
 let description = '';
 let websiteUrls: string[] = [];
 try {
   const profile = await getProfile(slugParam);
+  profileFound = true;
   displayName = profile.display_name || slugParam;
   avatarUrl = profile.avatar_url || null;
   description = profile.description || '';
@@ -70,6 +72,7 @@ try {
   const profiles = await getProfileCache();
   const cached = profiles.get(slugParam);
   if (cached) {
+    profileFound = true;
     displayName = cached.display_name || slugParam;
     avatarUrl = cached.avatar_url || null;
     description = cached.description || '';
@@ -89,8 +92,11 @@ try {
   // Index API failed — show empty grid
 }
 
-// If no profile and no workflows, redirect
-if (!displayName && serialized.length === 0) {
+// Slug is bogus (e.g. "undefined" or a malformed "<name>-" suffix from a broken
+// link): not a workflow detail, no profile, and no workflows — redirect instead
+// of rendering a page that would title itself "<slug> (@<slug>)" and get
+// indexed by Google.
+if (!isDetailPage && !profileFound && serialized.length === 0) {
   return Astro.redirect('/workflows/');
 }
 

--- a/site/tests/unit/routes.test.ts
+++ b/site/tests/unit/routes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { workflowDetailPath, workflowDetailSlug } from '../../src/lib/routes';
+
+describe('workflowDetailPath', () => {
+  it('builds a {name}-{shareId} URL when both are present', () => {
+    expect(workflowDetailPath('flux-schnell', 'e90e933d6c5d')).toBe(
+      '/workflows/flux-schnell-e90e933d6c5d/'
+    );
+  });
+
+  it('falls back to {name} when shareId is missing', () => {
+    expect(workflowDetailPath('legacy-name')).toBe('/workflows/legacy-name/');
+    expect(workflowDetailPath('legacy-name', '')).toBe('/workflows/legacy-name/');
+  });
+
+  it('prefixes non-default locales', () => {
+    expect(workflowDetailPath('flux-schnell', 'e90e933d6c5d', 'ja')).toBe(
+      '/ja/workflows/flux-schnell-e90e933d6c5d/'
+    );
+  });
+
+  it('does not prefix the default locale', () => {
+    expect(workflowDetailPath('flux-schnell', 'abc', 'en')).toBe('/workflows/flux-schnell-abc/');
+  });
+
+  it('falls back to shareId when name is missing — workflow stays findable', () => {
+    expect(workflowDetailPath(undefined, 'abc123')).toBe('/workflows/abc123-abc123/');
+    expect(workflowDetailPath(null, 'abc123')).toBe('/workflows/abc123-abc123/');
+    expect(workflowDetailPath('', 'abc123')).toBe('/workflows/abc123-abc123/');
+  });
+
+  it('returns null only when both name and shareId are missing', () => {
+    expect(workflowDetailPath(undefined)).toBeNull();
+    expect(workflowDetailPath(null, null)).toBeNull();
+    expect(workflowDetailPath('', '')).toBeNull();
+  });
+});
+
+describe('workflowDetailSlug', () => {
+  it('joins name and shareId with a hyphen', () => {
+    expect(workflowDetailSlug('flux-schnell', 'e90e933d6c5d')).toBe('flux-schnell-e90e933d6c5d');
+  });
+
+  it('returns the bare name when shareId is missing', () => {
+    expect(workflowDetailSlug('legacy-name')).toBe('legacy-name');
+    expect(workflowDetailSlug('legacy-name', null)).toBe('legacy-name');
+    expect(workflowDetailSlug('legacy-name', '')).toBe('legacy-name');
+  });
+
+  it('falls back to shareId when name is missing — never hides findable workflows', () => {
+    expect(workflowDetailSlug(undefined, 'abc123')).toBe('abc123-abc123');
+    expect(workflowDetailSlug(null, 'abc123')).toBe('abc123-abc123');
+    expect(workflowDetailSlug('', 'abc123')).toBe('abc123-abc123');
+  });
+
+  it('returns null only when both name and shareId are missing', () => {
+    expect(workflowDetailSlug(undefined)).toBeNull();
+    expect(workflowDetailSlug(null, null)).toBeNull();
+    expect(workflowDetailSlug('', '')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Production was emitting **~2,015 broken pageviews/week** to URLs like `/workflows/undefined/` and `/workflows/<name>-/` (trailing dash). Google indexed `/workflows/undefined/` and was sending **1,168 views/wk** through search results, with another ~700 from internal navigation and direct/bookmark traffic. The page returned `HTTP 200` with `<title>undefined (@undefined) - ComfyUI Workflow Templates</title>`, which is what got it indexed in the first place.

### reproduce

https://github.com/user-attachments/assets/8d162929-536f-40e9-bb25-f503d37fcd2a

<img width="646" height="646" alt="Screenshot 2026-04-30 at 10 50 28 AM" src="https://github.com/user-attachments/assets/08d9a344-ef9e-4550-97e3-003d663a0924" />


### verify fix - preview environment
<img width="1550" height="953" alt="Screenshot 2026-04-30 at 10 51 42 AM" src="https://github.com/user-attachments/assets/63deb27d-cee1-4dcc-b2dc-a18c25714679" />


| URL pattern | 7d views | What's broken |
|---|---|---|
| `/workflows/undefined/` | 1,805 | Slug is the literal string `undefined` |
| `/workflows/<name>-/` | 251 | Trailing dash — slug joined with empty shareId |
| `/workflows/<sid>-<sid>/` | 7 | Real workflows where the uploader didn't set `name`; the Hub API returns `name = shareId` as a fallback. **Not filtered out by this PR — they remain visible in search, gallery, creator profiles, and as static detail pages.** The ugly slug is a separate cosmetic / SEO concern, to be addressed via upstream `name` backfill (separate ticket), not by hiding these workflows. |

## Root cause (corrected after PostHog session replay)

> Note: PR #828 had an inaccurate root-cause description. This PR replaces it with the corrected analysis. The code fix is the same — the diagnosis is what's been clarified.

### The actual bug

`site/src/components/hub/SearchPopover.vue` — the `displayedWorkflows` computed has a badge-only branch (around line 218 pre-fix) that maps `badgeOnlyResults` into hit objects but **forgets to populate the `slug` field**:

```ts
if (hasBadges.value) {
  return badgeOnlyResults.value.map((t) => ({
    id: t.name,
    title: t.title,
    mediaType: t.mediaType,
    // ... other fields ...
    score: 0,
    // ⚠️ no `slug` field
  }));
}
```

The template binds the href via `getTemplateUrl(hit.slug)`, which is just:
```ts
function getTemplateUrl(name: string): string {
  return `/workflows/${name}/`
}
```

When `hit.slug` is `undefined`, JavaScript template-literal stringification produces the literal string `"undefined"`, so the rendered href becomes `/workflows/undefined/`. Click → broken URL. Repeat for every badge-filtered click in the popover. ~1,805 views/wk.

A second, related leak in the same file: the popular-workflows section built hrefs as `getTemplateUrl(\`${wf.name}-${wf.shareId}\`)` — always appending `-${shareId}` even when `shareId` was empty, which produces `/workflows/<name>-/` (the trailing-dash pattern). ~251 views/wk.

### Hub API is clean — not a data problem

Audit of `https://cloud.comfy.org/api/hub/workflows/index` returned 499 entries, **all 499 with `name`, `shareId`, and `profile.username` populated**. Static gallery HTML has 0 broken hrefs. The bug is purely in client-side URL construction during the badge-filter UI flow.

### Timeline (matches the bug's appearance exactly)

- **2026-04-14** — PR #786 (`3105e21` "Propagate shareId through search client and remove silent hub API fallbacks") added `slug` to the `WorkflowHit` type and updated the search-results branch to populate it. Missed updating the badge-only mapping branch.
- **2026-04-15** — Cron rebuild cadence changed from every 30 min to once per day, so any deploy with the latent bug now persists ~24h instead of being overwritten quickly.
- **2026-04-16 12:22 KST** — PR #789 (`caa2d01`) consolidated all gallery pages onto `loadSerializedTemplates`, deploying the latent bug.
- **2026-04-16 12:32 KST** — First-ever `/workflows/undefined/` pageview in PostHog. Exactly 10 minutes after merge.
- Day 1 traffic: 227 views (full volume, not gradual). Googlebot crawled within hours.

### Session replay confirmation

Session `019ddaec-7f57-7ce8-a551-b17d132be449` (2026-04-29) shows the exact navigation pattern:

| Time (UTC) | Event | Path |
|---|---|---|
| 20:38:53 | `$pageview` | `/workflows` (gallery) |
| 20:52:36 | `hub:filter_applied` | `/workflows` |
| 20:52:48 | `$pageleave` | `/workflows` |
| **20:52:50** | **`$pageview`** | **`/workflows/undefined/`** |
| 20:53:07–36 | `hub:search_performed` × 16 | (user typing in panic) |

`filter_applied` → `pageleave` → `/workflows/undefined/` in **2 seconds** = a click on a badge-filtered popover result. Matches the SearchPopover bug exactly.

Replay: https://us.posthog.com/project/204330/replay/019ddaec-7f57-7ce8-a551-b17d132be449

## Fix

The actual bug is in **two SearchPopover code paths**. Everything else stays tolerant — a workflow with a `shareId` is still findable, so we never hide it.

- **`site/src/lib/routes.ts`** — new `workflowDetailPath(name, shareId?, locale?)` and `workflowDetailSlug(name, shareId?)` helpers. Falls back to `shareId` when `name` is missing so the workflow stays linkable. Returns `null` only when both fields are missing (the only case where no detail page can exist).
- **`SearchPopover.vue`** — the actual bug fix:
  - Add `shareId: string` to the `SearchTemplate` interface (it was being read at runtime but missing from the type).
  - **Populate `slug` in the badge-only `displayedWorkflows` mapping** using `workflowDetailSlug` — closes the primary `/workflows/undefined/` leak.
  - Route popular-workflows hrefs through `workflowDetailPath` instead of the always-`-${shareId}` template literal — closes the `<name>-/` leak.
  - Guard `activateItem` click navigation on null URLs.
- **`HubWorkflowCard.vue`** — route through `workflowDetailPath`, no-op the click handler when URL is null, and make `cursor-pointer` conditional on a clickable target.
- **`site/src/pages/workflows/[username].astro`** and **`site/src/pages/[locale]/workflows/[slug].astro`** — track `profileFound` explicitly. When the slug isn't a detail page, isn't a known profile, and has no workflows → 302 redirect to the gallery instead of rendering a fake `<slug> (@<slug>)` profile that gets indexed by Google. (This is what closes the indexed-by-Google traffic — once `/workflows/undefined/` returns 302, Google can drop it from the index.)
- **`site/src/pages/workflows/[slug].astro`** — `getStaticPaths` falls back to `shareId` for entries missing `name`, only skipping when neither field can form a slug. Same tolerant logic as before — no workflows hidden.
- **`scripts/lib/search/build-index.ts`** — restored the original tolerant `name = data.name || shareId` fallback. shareId-only workflows still appear in the search index as `<sid>-<sid>` slugs.

The principle: **if `shareId` exists, the workflow is findable; never hide it.** Earlier draft of this PR added strict filters that dropped entries missing `name` — those filters never fired in production (Hub API always populates both) but would have hidden valid workflows in the hypothetical regression case. Removed them.

## Verification

### Unit tests

- `pnpm test` — **108 passing** (10 in `tests/unit/routes.test.ts` covering both helpers, including the shareId fallback for missing-name entries and the both-missing edge case).
- `pnpm check` — 0 errors, 0 warnings on touched files.
- Lint — 5 pre-existing repo-wide errors, unchanged from main.

### Vercel preview probes (commit `0bc772f`)

| URL | Before | After | Notes |
|---|---|---|---|
| `/workflows/undefined/` | 200 | 302 → `/workflows/` | ✅ Closes the primary leak |
| `/workflows/video_wan2_2_14B_i2v-/` | 200 | 302 → `/workflows/` | ✅ Trailing-dash gone |
| `/workflows/api_grok_image_edit-/` | 200 | 302 → `/workflows/` | ✅ |
| `/workflows/api_seedance2_0_r2v-/` | 200 | 302 → `/workflows/` | ✅ |
| `/workflows/api_seedance2_0_t2v-/` | 200 | 302 → `/workflows/` | ✅ |
| `/workflows/comfyui/` (real creator) | 200 | 200 | ✅ Real profiles preserved |
| `/workflows/` (gallery) | 200 | 200 | ✅ Gallery loads |
| `/workflows/api_seedance2_0_r2v-64f4db9e3e33/` (real detail) | 200 | 302 → `/workflows/` | ⚠ Preview-environment data quirk: preview Hub API returned no entries at build time, so `[slug].astro` couldn't generate static detail pages. Falls through to the pre-existing `[username].astro` line-64 detail-catch redirect (untouched by this PR). Production currently serves these URLs with 200 and will continue to after deploy because the prod Hub API populates the static build. |

### Search index audit

Pulled the preview's `/workflows/search-index.json` and audited:

```
total docs: 420
bad slug (empty/undefined): 0
slug ending in -: 0
shareId-only entries (slug=<sid>-<sid>): present and visible
```

The 51 production entries where the uploader didn't set `name` (server returns `name = shareId` as fallback) are still indexed and searchable as `<sid>-<sid>` slugs. They're real workflows; the slug being non-human-readable is a separate cosmetic / SEO concern, not a reason to hide them.

### Production validation plan (post-deploy)

- 24h check on PostHog: `/workflows/undefined/` daily views drop to near-zero
- 24h check: `/workflows/%-/` views drop to zero
- File Google Search Console "Removals" request for `/workflows/undefined/` to accelerate de-indexing
- Monitor session replay for any sessions still hitting `/workflows/undefined/` and trace residual sources

```bash
curl -o /dev/null -w "%{http_code}\n" https://www.comfy.org/workflows/undefined/                       # expect: 302
curl -o /dev/null -w "%{http_code}\n" https://www.comfy.org/workflows/video_wan2_2_14B_i2v-/           # expect: 302
curl -o /dev/null -w "%{http_code}\n" https://www.comfy.org/workflows/api_seedance2_0_r2v-64f4db9e3e33/ # expect: 200
```

PostHog query 24h post-deploy:

```sql
SELECT toDate(timestamp) AS day, properties.$pathname AS path, count() AS views
FROM events
WHERE event = '$pageview'
  AND timestamp >= now() - interval 3 day
  AND (properties.$pathname = '/workflows/undefined/' OR properties.$pathname LIKE '/workflows/%-/')
GROUP BY day, path ORDER BY day DESC, views DESC
```

## Notes

- Replaces #828, which carried the same code fix but with an inaccurate root-cause description (incorrectly blamed `HubWorkflowCard.vue` template literal — that path is theoretically reachable but Hub API never sends `name=undefined`, so it doesn't fire in production). The corrected diagnosis is in this PR description and on Linear FE-223.
- Codex adversarial review on the prior commit correctly identified both leaks (SearchPopover URL builders + shareId-only routing inconsistency). This PR is the result.

Fixes FE-223

