### PR TITLE
Use comfy.org (no www) for canonical URLs and footer links.

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -35,7 +35,7 @@ const locales = ['en', 'zh', 'zh-TW', 'ja', 'ko', 'es', 'fr', 'ru', 'tr', 'ar', 
 const nonDefaultLocales = locales.filter((l) => l !== 'en');
 
 // Custom sitemap pages for ISR routes not discovered at build time
-const siteOrigin = (process.env.PUBLIC_SITE_ORIGIN || 'https://www.comfy.org').replace(/\/$/, '');
+const siteOrigin = (process.env.PUBLIC_SITE_ORIGIN || 'https://comfy.org').replace(/\/$/, '');
 
 // Creator profile pages — extract unique usernames from synced templates
 const creatorUsernames = new Set();
@@ -59,7 +59,7 @@ const customPages = [...creatorPages, ...localeCustomPages];
 
 // https://astro.build/config
 export default defineConfig({
-  site: (process.env.PUBLIC_SITE_ORIGIN || 'https://www.comfy.org').replace(/\/$/, ''),
+  site: (process.env.PUBLIC_SITE_ORIGIN || 'https://comfy.org').replace(/\/$/, ''),
   prefetch: {
     prefetchAll: false,
     defaultStrategy: 'hover',
@@ -76,7 +76,7 @@ export default defineConfig({
       // Use custom filename to avoid collision with Framer's /sitemap.xml
       filenameBase: 'sitemap-workflows',
       // Include Framer's marketing sitemap in the index
-      customSitemaps: ['https://www.comfy.org/sitemap.xml'],
+      customSitemaps: ['https://comfy.org/sitemap.xml'],
       // Include on-demand locale pages that aren't discovered at build time
       customPages: customPages,
       serialize(item) {

--- a/site/docs/archive/upwork-designer-posting/design-brief.md
+++ b/site/docs/archive/upwork-designer-posting/design-brief.md
@@ -91,7 +91,7 @@ None are particularly well-designed. **We want to be significantly better.**
 
 ### 1. Header/Navigation
 
-- Logo linking to [comfy.org](https://www.comfy.org)
+- Logo linking to [comfy.org](https://comfy.org)
 - Simple nav (e.g., "Templates", "Try ComfyUI")
 
 ### 2. Hero Section
@@ -195,10 +195,10 @@ We'll share our complete brand kit after hiring:
 
 | Site          | URL                                                                  |
 | ------------- | -------------------------------------------------------------------- |
-| Main site     | [comfy.org](https://www.comfy.org)                                   |
+| Main site     | [comfy.org](https://comfy.org)                                   |
 | Cloud app     | [cloud.comfy.org](https://cloud.comfy.org)                           |
 | Documentation | [docs.comfy.org](https://docs.comfy.org)                             |
-| About page    | [comfy.org/about](https://www.comfy.org/about)                       |
+| About page    | [comfy.org/about](https://comfy.org/about)                       |
 | GitHub        | [github.com/Comfy-Org/ComfyUI](https://github.com/Comfy-Org/ComfyUI) |
 
 ---
@@ -268,7 +268,7 @@ We make tools for the artist of the future — a human equipped with AI who can 
 
 **Who we are:** The original team behind ComfyUI — engineers and artists from Stability AI and Google. Our work is used by millions of users worldwide.
 
-Learn more: [comfy.org/about](https://www.comfy.org/about)
+Learn more: [comfy.org/about](https://comfy.org/about)
 
 **Contact:** cbyrne@comfy.org or hello@comfy.org
 

--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -10,7 +10,7 @@
     <div class="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-12">
       <!-- Left column: Logo + Social -->
       <div>
-        <a href="https://www.comfy.org" class="inline-block">
+        <a href="https://comfy.org" class="inline-block">
           <img src="/brand/comfy-wordmark-yellow.svg" alt="Comfy" class="h-[40px] w-auto" />
         </a>
 
@@ -98,7 +98,7 @@
           <ul class="space-y-3">
             <li>
               <a
-                href="https://www.comfy.org/download"
+                href="https://comfy.org/download"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
@@ -108,7 +108,7 @@
             </li>
             <li>
               <a
-                href="https://www.comfy.org/cloud"
+                href="https://comfy.org/cloud"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
@@ -118,7 +118,7 @@
             </li>
             <li>
               <a
-                href="https://www.comfy.org/cloud/enterprise"
+                href="https://comfy.org/cloud/enterprise"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
@@ -128,7 +128,7 @@
             </li>
             <li>
               <a
-                href="https://www.comfy.org/gallery"
+                href="https://comfy.org/gallery"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
@@ -265,7 +265,7 @@
           <ul class="space-y-3">
             <li>
               <a
-                href="https://www.comfy.org/about"
+                href="https://comfy.org/about"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
@@ -275,7 +275,7 @@
             </li>
             <li>
               <a
-                href="https://www.comfy.org/careers"
+                href="https://comfy.org/careers"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
@@ -285,7 +285,7 @@
             </li>
             <li>
               <a
-                href="https://www.comfy.org/terms-of-service"
+                href="https://comfy.org/terms-of-service"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
@@ -295,7 +295,7 @@
             </li>
             <li>
               <a
-                href="https://www.comfy.org/privacy"
+                href="https://comfy.org/privacy"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-content-secondary text-sm hover:text-content transition-colors"

--- a/site/src/config/site.ts
+++ b/site/src/config/site.ts
@@ -1,4 +1,4 @@
-const DEFAULT_ORIGIN = 'https://www.comfy.org';
+const DEFAULT_ORIGIN = 'https://comfy.org';
 
 function normalizeOrigin(raw?: string): string {
   const v = raw?.trim();


### PR DESCRIPTION
Align default PUBLIC_SITE_ORIGIN, sitemap references, and outbound links with the apex domain for consistent SEO.