### PR TITLE
fix: resolve publish workflow race condition and quota gate size accuracy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,14 +168,20 @@ jobs:
             .github/pypi-packages.json
             pyproject.toml
             packages/
+            templates/
+            bundles.json
             scripts/ci/check_pypi_quota.py
             scripts/ci/comfyui_reference.py
+            scripts/sync_bundles.py
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+
+      - name: Sync bundle assets before size measurement
+        run: python scripts/sync_bundles.py
 
       - name: Block publish when PyPI quota is critical
         env:


### PR DESCRIPTION
## Summary

- **Race condition fix**: `listPullRequestsAssociatedWithCommit` can return empty immediately after a PR merge because GitHub's internal index hasn't updated yet. The `check-pr-label` job now retries up to 5 times with a 10s delay between attempts, giving the API up to 40 seconds to catch up. This was the root cause of 0.9.90 failing to publish to PyPI despite having the `release` label.

- **Quota gate size fix**: `pypi-quota-gate` was measuring package directory sizes before `sync_bundles.py` runs, so it only saw empty stub directories (e.g. 151 B for `media-image`). Now it runs `sync_bundles.py` first so the measured size matches the actual wheel contents (templates + thumbnails).

## Root cause (0.9.90 not published)

PR #906 merged → push triggered publish workflow → `check-pr-label` ran in ~5s → GitHub API returned no associated PR (race condition) → `should_publish=false` → PyPI skipped → only GitHub Release created.