### PR TITLE
chore(site): update footer contact email from hello@comfy.org to support@comfy.org

### DIFF
--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -312,10 +312,10 @@
           <ul class="space-y-3">
             <li>
               <a
-                href="mailto:hello@comfy.org"
+                href="mailto:support@comfy.org"
                 class="text-content-secondary text-sm hover:text-content transition-colors"
               >
-                hello@comfy.org
+                support@comfy.org
               </a>
             </li>
             <li>


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Updates the public footer on **templates.comfy.org** to point at the support inbox instead of the catch-all `hello@` address.

- `site/src/components/hub/SiteFooter.astro` — Contact section, both the `mailto:` href and the visible link text.

Other contact entries in the footer (`press@comfy.org`, etc.) are unchanged.

## Why

Requested in #support: route public inbound mail to the support inbox.

## Verification

- `prettier --check` and `eslint --max-warnings 0` pass on `SiteFooter.astro`.
- `astro check` reports 0 errors across all 123 files.
- Spun up `pnpm run dev` and verified in a real browser at `http://localhost:4321/`:
  - `support@comfy.org` is the only address rendered in the footer
  - `<a href="mailto:support@comfy.org">` is present, `mailto:hello@comfy.org` is gone
  - Screenshot of the rendered footer attached below.

## Screenshots

![templates.comfy.org footer Contact section showing support@comfy.org](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ab87033accdab466d793d1037edcb78f77a090c9e5399fafa5daa25f9a627a19/pr-images/1781114695924-18e201b5-24f9-4241-accd-3426090a79ae.png)