### PR TITLE
fix(seo): default canonical/sitemap origin to apex comfy.org

### DIFF
--- a/site/.env.example
+++ b/site/.env.example
@@ -1,6 +1,6 @@
 # === Domain Configuration ===
 # Canonical origin for SEO (scheme+host, no trailing slash, no path)
-# Default: https://templates.comfy.org
+# Default: https://comfy.org (apex; set explicitly in Vercel production)
 # Production: https://comfy.org
 # PUBLIC_SITE_ORIGIN=https://comfy.org
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -35,7 +35,7 @@ const locales = ['en', 'zh', 'zh-TW', 'ja', 'ko', 'es', 'fr', 'ru', 'tr', 'ar', 
 const nonDefaultLocales = locales.filter((l) => l !== 'en');
 
 // Custom sitemap pages for ISR routes not discovered at build time
-const siteOrigin = (process.env.PUBLIC_SITE_ORIGIN || 'https://www.comfy.org').replace(/\/$/, '');
+const siteOrigin = (process.env.PUBLIC_SITE_ORIGIN || 'https://comfy.org').replace(/\/$/, '');
 
 // Creator profile pages — extract unique usernames from synced templates
 const creatorUsernames = new Set();
@@ -59,7 +59,7 @@ const customPages = [...creatorPages, ...localeCustomPages];
 
 // https://astro.build/config
 export default defineConfig({
-  site: (process.env.PUBLIC_SITE_ORIGIN || 'https://www.comfy.org').replace(/\/$/, ''),
+  site: (process.env.PUBLIC_SITE_ORIGIN || 'https://comfy.org').replace(/\/$/, ''),
   prefetch: {
     prefetchAll: false,
     defaultStrategy: 'hover',
@@ -76,7 +76,7 @@ export default defineConfig({
       // Use custom filename to avoid collision with Framer's /sitemap.xml
       filenameBase: 'sitemap-workflows',
       // Include Framer's marketing sitemap in the index
-      customSitemaps: ['https://www.comfy.org/sitemap.xml'],
+      customSitemaps: ['https://comfy.org/sitemap.xml'],
       // Include on-demand locale pages that aren't discovered at build time
       customPages: customPages,
       serialize(item) {

--- a/site/src/config/site.ts
+++ b/site/src/config/site.ts
@@ -1,4 +1,4 @@
-const DEFAULT_ORIGIN = 'https://www.comfy.org';
+const DEFAULT_ORIGIN = 'https://comfy.org';
 
 function normalizeOrigin(raw?: string): string {
   const v = raw?.trim();

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -3,6 +3,11 @@
   "github": {
     "enabled": false
   },
+  "build": {
+    "env": {
+      "PUBLIC_SITE_ORIGIN": "https://comfy.org"
+    }
+  },
   "headers": [
     {
       "source": "/workflows/:path*",


### PR DESCRIPTION
## Problem / Goal

The canonical SEO origin defaulted to `https://www.comfy.org` in `astro.config.mjs` (`site` → sitemap `<loc>`s, `siteOrigin` → custom sitemap pages) and `src/config/site.ts` (`DEFAULT_ORIGIN` → canonical `<link>` tags + structured data). When `PUBLIC_SITE_ORIGIN` is unset, the build emits `www.comfy.org` URLs. The comfy-router canonicalizes everything to apex `comfy.org` (and now normalizes workflow pages to trailing-slash form, Comfy-Org/comfy-router#31), so any `www` URL in the sitemap or a canonical tag becomes a 301 — the sitemap would advertise redirecting URLs, an SEO anti-pattern. The unified `/sitemap-index.xml` only rewrites the **index** `<loc>`s to apex; the page `<loc>`s inside child sitemaps are proxied raw, so they depend entirely on what this app emits.

## Proposed Solution

Make the apex origin **declarative / IaC** instead of relying on a manually-set Vercel dashboard env var:

1. **`site/vercel.json` → `build.env.PUBLIC_SITE_ORIGIN = "https://comfy.org"`** — committed source of truth, applied during the Astro build. No dashboard step, reproducible per-deploy. (`build.env` is valid per the `openapi.vercel.sh/vercel.json` schema.)
2. **Code default → `https://comfy.org`** in `site.ts` + `astro.config.mjs` — fallback for local dev / CI / any non-Vercel build (these don't get `vercel.json` build env).

Trailing-slash is already correct here (Astro emits `/workflows/{slug}/`); this closes the host-origin gap.

## Acceptance Criteria

- [x] `PUBLIC_SITE_ORIGIN` pinned to apex in `site/vercel.json` (`build.env`).
- [x] `site`, `siteOrigin`, `DEFAULT_ORIGIN` default to `https://comfy.org`.
- [x] No test/CI asserts the old `www` default (`seo-smoke-test.yml` asserts apex).
- [x] `Lint & Format` + `build-and-test` green. (`preview` job fails on an **unrelated** Hub API 403 in `build-search-index` — secret/permission issue, not from this change.)
- [ ] After deploy, `seo-smoke-test` continues to pass (canonical = `https://comfy.org/`).

Note (out of scope): `src/components/hub/SiteFooter.astro` still hardcodes `https://www.comfy.org/*` nav links — not SEO/sitemap-affecting, each adds a 301 hop. Worth a follow-up.
