### PR TITLE
ci: deploy fork-PR previews via label-gated workflow_run

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,104 @@
+name: Deploy Preview
+
+on:
+  workflow_run:
+    workflows: ['Preview Site']
+    types: [completed]
+
+concurrency:
+  group: deploy-preview-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download prebuilt output
+        uses: actions/download-artifact@v4
+        with:
+          name: vercel-preview-output
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve PR number
+        id: pr
+        run: |
+          number="$(tr -d '[:space:]' < artifact/preview-meta/pr-number)"
+          if [ -z "$number" ]; then
+            echo "No PR number in artifact; nothing to deploy."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "number=$number" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for preview label
+        id: gate
+        if: steps.pr.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          labels="$(gh pr view "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')"
+          if printf '%s\n' "$labels" | grep -qx 'preview'; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+            echo "PR #${{ steps.pr.outputs.number }} has no 'preview' label — skipping deploy."
+          fi
+
+      - name: Deploy preview to Vercel
+        id: deploy
+        if: steps.gate.outputs.approved == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          stdout_file="$RUNNER_TEMP/vercel-preview.stdout"
+          stderr_file="$RUNNER_TEMP/vercel-preview.stderr"
+          output_dir="$GITHUB_WORKSPACE/.vercel/output"
+
+          if [ ! -d "artifact/site/.vercel/output" ]; then
+            echo "Prebuilt output missing from artifact" >&2
+            exit 1
+          fi
+
+          mkdir -p "$GITHUB_WORKSPACE/.vercel"
+          rm -rf "$output_dir"
+          cp -R "artifact/site/.vercel/output" "$output_dir"
+
+          if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
+            --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+
+            preview_url="$(tail -n 1 "$stdout_file" | tr -d '\r')"
+            if [[ ! "$preview_url" =~ ^https?:// ]]; then
+              echo "Could not parse preview URL from Vercel CLI output" >&2
+              exit 1
+            fi
+
+            echo "preview-url=$preview_url" >> "$GITHUB_OUTPUT"
+          else
+            cat "$stderr_file" >&2
+            cat "$stdout_file"
+            exit 1
+          fi
+
+      - name: Comment preview URL
+        if: steps.deploy.outputs.preview-url != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          header: vercel-preview
+          message: |
+            🚀 **Preview deployed:** ${{ steps.deploy.outputs.preview-url }}

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -2,6 +2,7 @@ name: Preview Site
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'site/**'
   workflow_dispatch:
@@ -12,7 +13,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   preview:
@@ -45,50 +45,18 @@ jobs:
           PUBLIC_HUB_API_URL: ${{ secrets.HUB_API_URL_PREVIEW }}
           PUBLIC_COMFY_CLOUD_URL: ${{ secrets.COMFY_CLOUD_URL_PREVIEW }}
 
-      - name: Deploy preview to Vercel
-        id: deploy
-        working-directory: site
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      - name: Save PR metadata
         run: |
-          stdout_file="$RUNNER_TEMP/vercel-preview.stdout"
-          stderr_file="$RUNNER_TEMP/vercel-preview.stderr"
-          site_output_dir="$GITHUB_WORKSPACE/site/.vercel/output"
-          root_output_dir="$GITHUB_WORKSPACE/.vercel/output"
+          mkdir -p preview-meta
+          echo "${{ github.event.pull_request.number }}" > preview-meta/pr-number
 
-          if [ ! -d "$site_output_dir" ]; then
-            echo "Expected prebuilt output in $site_output_dir" >&2
-            exit 1
-          fi
-
-          mkdir -p "$GITHUB_WORKSPACE/.vercel"
-          rm -rf "$root_output_dir"
-          cp -R "$site_output_dir" "$root_output_dir"
-
-          if npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --yes \
-            --token="$VERCEL_TOKEN" >"$stdout_file" 2>"$stderr_file"; then
-            cat "$stderr_file" >&2
-            cat "$stdout_file"
-
-            preview_url="$(tail -n 1 "$stdout_file" | tr -d '\r')"
-            if [[ ! "$preview_url" =~ ^https?:// ]]; then
-              echo "Could not parse preview URL from Vercel CLI output" >&2
-              exit 1
-            fi
-
-            echo "preview-url=$preview_url" >> "$GITHUB_OUTPUT"
-          else
-            cat "$stderr_file" >&2
-            cat "$stdout_file"
-            exit 1
-          fi
-
-      - name: Comment preview URL
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: Upload prebuilt output
+        uses: actions/upload-artifact@v4
         with:
-          header: vercel-preview
-          message: |
-            🚀 **Preview deployed:** ${{ steps.deploy.outputs.preview-url }}
+          name: vercel-preview-output
+          path: |
+            site/.vercel/output
+            preview-meta/pr-number
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## Problem

Preview deploys fail for PRs opened from forks (e.g. #950). On `pull_request` events from a fork, GitHub withholds repository secrets, so the Vercel step runs with an empty token:

```
Error: You defined "--token", but it's missing a value
```

The build itself passes — only the deploy step fails, surfacing a red X to external contributors.

## Approach

Split the preview into build (untrusted, no secrets) and deploy (trusted, secrets) so the Vercel token never touches fork-authored build code:

- **`preview-site.yml`** (`pull_request`) now only builds the Astro site and uploads the prebuilt `.vercel/output` + PR number as an artifact. No secrets, no deploy. Added `labeled` to the trigger types so applying the label re-runs the build and chains a deploy.
- **`deploy-preview.yml`** (`workflow_run`) runs in the base-repo context (secrets available), is gated by the maintainer-only **`preview`** label, downloads the prebuilt artifact, and runs `vercel deploy --prebuilt`. It posts the preview URL as a sticky PR comment.

Because the deploy job only ships an already-built artifact (no `pnpm build` of fork code runs with the token in scope), this avoids the secret-exfiltration risk of `pull_request_target`/`issue_comment` patterns.

## Maintainer usage

Add the **`preview`** label to a fork PR → the build re-runs → a preview is deployed and the URL is commented. Remove + re-add the label to redeploy after reviewing new commits.

## Notes

- `PUBLIC_HUB_API_URL` / `PUBLIC_COMFY_CLOUD_URL` are baked at build time and remain unset for fork builds (pre-existing). If correct preview endpoints are needed for fork PRs, move these non-secret public values to repo Variables. Out of scope here.
- `workflow_run` workflows don't appear as PR status checks, so contributors no longer see a red X for the deploy.
- actionlint passes on both files.