### PR TITLE
Split workflow JSON from legacy media pip bundles

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,7 @@ jobs:
           source .venv/bin/activate
           rm -rf dist
           mkdir dist
-          for pkg in core media_api media_video media_image media_other meta; do
+          for pkg in core json media_api media_video media_image media_other media_assets_01 meta; do
             python -m build --outdir dist packages/$pkg
           done
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run tests
         env:
-          PYTHONPATH: packages/meta/src:packages/core/src:packages/media_api/src:packages/media_video/src:packages/media_image/src:packages/media_other/src
+          PYTHONPATH: packages/meta/src:packages/core/src:packages/json/src:packages/media_api/src:packages/media_video/src:packages/media_image/src:packages/media_other/src:packages/media_assets_01/src
         run: |
           source .venv/bin/activate
           pytest packages/core/tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,7 +253,7 @@ jobs:
           
           # Check for package version changes (primary trigger)
           echo -e "\n--- Checking for changed package versions ---"
-          for pkg in core media_api media_video media_image media_other blueprints; do
+          for pkg in core json media_api media_video media_image media_other media_assets_01 blueprints; do
             if echo "$CHANGED_FILES" | grep -q "packages/$pkg/pyproject.toml"; then
               PACKAGES="$PACKAGES $pkg"
               echo "✓ Will publish $pkg (version file changed)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The script moves the workflow JSON and thumbnails to `archived/`, removes the en
 ## Architecture
 - **Monorepo** with Nx, Python packages, and Astro site
 - `templates/` — Source workflow JSON files and thumbnails (index.json is the manifest)
-- `packages/` — Python packages: core (loader), media_* (templates by type: api, image, video, other)
+- `packages/` — Python packages: core (loader + manifest), json (all workflow JSON), media_* (legacy frozen assets), media_assets_* (new assets)
 - `site/` — Astro static site (independently managed; see below)
 - `scripts/` — Python validation/sync scripts for CI and local dev (see `scripts/README.md`)
 

--- a/bundles.json
+++ b/bundles.json
@@ -567,5 +567,6 @@
     "api_happyhorse1_1_i2v",
     "api_happyhorse1_1_t2v",
     "api_happyhorse1_1_r2v"
-  ]
+  ],
+  "media-assets-01": []
 }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -105,6 +105,16 @@ gh pr edit <PR-NUMBER> --add-label release
 - `.github/workflows/version-check.yml` - Auto-bump versions on PR
 - `.github/workflows/publish.yml` - Publish to PyPI and create GitHub releases
 
+## Package layout (split bundles)
+
+| PyPI package | Contents | Status |
+|--------------|----------|--------|
+| `comfyui-workflow-templates-json` | All workflow + index JSON | Active |
+| `comfyui-workflow-templates-media-assets-01` | New template thumbnails/media | Active |
+| `comfyui-workflow-templates-media-{api,image,video,other}` | Legacy assets only (JSON stripped) | Frozen |
+
+JSON fixes bump only the `json` package (~28MB). New templates assign assets via `bundles.json` → `media-assets-01`.
+
 ## Package Size Considerations
 
 PyPI has a 100MB per-file upload limit. Our current package sizes:

--- a/docs/cicd/README.md
+++ b/docs/cicd/README.md
@@ -3,11 +3,13 @@
 ## Package Architecture
 ```
 comfyui-workflow-templates/           # Meta package (depends on all others)
-├── comfyui-workflow-templates-core   # Manifest + core logic
-├── comfyui-workflow-templates-media-api     # API templates
-├── comfyui-workflow-templates-media-video   # Video templates  
-├── comfyui-workflow-templates-media-image   # Image templates
-├── comfyui-workflow-templates-media-other   # Other templates
+├── comfyui-workflow-templates-core   # Manifest + loader
+├── comfyui-workflow-templates-json   # All workflow/index JSON
+├── comfyui-workflow-templates-media-api     # Legacy API assets (frozen)
+├── comfyui-workflow-templates-media-video   # Legacy video assets (frozen)
+├── comfyui-workflow-templates-media-image   # Legacy image assets (frozen)
+├── comfyui-workflow-templates-media-other   # Legacy other assets (frozen)
+├── comfyui-workflow-templates-media-assets-01  # New template assets
 └── comfyui-subgraph-blueprints              # Subgraph blueprints
 ```
 

--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,9 @@
   },
   "projects": {
     "core": "packages/core",
+    "json": "packages/json",
     "media-api": "packages/media_api",
+    "media-assets-01": "packages/media_assets_01",
     "media-video": "packages/media_video",
     "media-image": "packages/media_image",
     "media-other": "packages/media_other",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-core"
-version = "0.3.264"
+version = "0.3.265"
 description = "Core helpers for ComfyUI workflow templates"
 readme = {text = "Core helpers for ComfyUI workflow templates.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/packages/core/src/comfyui_workflow_templates_core/loader.py
+++ b/packages/core/src/comfyui_workflow_templates_core/loader.py
@@ -24,7 +24,10 @@ BUNDLE_PACKAGE_MAP = {
     "media-video": "comfyui_workflow_templates_media_video",
     "media-image": "comfyui_workflow_templates_media_image",
     "media-other": "comfyui_workflow_templates_media_other",
+    "media-assets-01": "comfyui_workflow_templates_media_assets_01",
 }
+
+JSON_PACKAGE = "comfyui_workflow_templates_json"
 
 BLUEPRINT_BUNDLE_PACKAGE_MAP = {
     "blueprints": "comfyui_subgraph_blueprints",
@@ -100,6 +103,12 @@ def _bundle_package(bundle_name: str) -> str:
         raise KeyError(f"No package mapping defined for bundle '{bundle_name}'") from exc
 
 
+def _asset_package(entry: TemplateEntry, filename: str) -> str:
+    if filename.endswith(".json"):
+        return JSON_PACKAGE
+    return _bundle_package(entry.bundle)
+
+
 def get_asset_path(template_id: str, filename: str) -> str:
     """
     Resolve the absolute path for an asset belonging to `template_id`.
@@ -108,12 +117,13 @@ def get_asset_path(template_id: str, filename: str) -> str:
         FileNotFoundError: if the bundle package or asset is missing.
     """
     entry = get_template_entry(template_id)
-    package_name = _bundle_package(entry.bundle)
+    package_name = _asset_package(entry, filename)
     try:
         package_files = resources.files(package_name)
     except ModuleNotFoundError as exc:
         raise FileNotFoundError(
-            f"Media package '{package_name}' is not installed for bundle '{entry.bundle}'"
+            f"Package '{package_name}' is not installed for asset '{filename}' "
+            f"(template '{template_id}', bundle '{entry.bundle}')"
         ) from exc
     asset = package_files / "templates" / filename
     if not asset.exists():

--- a/packages/core/src/comfyui_workflow_templates_core/manifest.json
+++ b/packages/core/src/comfyui_workflow_templates_core/manifest.json
@@ -12,6 +12,9 @@
     },
     "media-other": {
       "version": "0.0.0"
+    },
+    "media-assets-01": {
+      "version": "0.0.0"
     }
   },
   "templates": [

--- a/packages/core/tests/test_bundles_config.py
+++ b/packages/core/tests/test_bundles_config.py
@@ -6,10 +6,12 @@ from pathlib import Path
 PACKAGE_ROOTS = [
     "packages/core/src",
     "packages/meta/src",
+    "packages/json/src",
     "packages/media_api/src",
     "packages/media_video/src",
     "packages/media_image/src",
     "packages/media_other/src",
+    "packages/media_assets_01/src",
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/packages/core/tests/test_loader.py
+++ b/packages/core/tests/test_loader.py
@@ -7,10 +7,12 @@ import pytest
 PACKAGE_ROOTS = [
     "packages/core/src",
     "packages/meta/src",
+    "packages/json/src",
     "packages/media_api/src",
     "packages/media_video/src",
     "packages/media_image/src",
     "packages/media_other/src",
+    "packages/media_assets_01/src",
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -49,8 +51,19 @@ def test_missing_template_raises():
 
 def test_missing_bundle_resolves(monkeypatch):
     entries = list(loader.iter_templates())
-    sample = entries[0]
+    sample = next(
+        e for e in entries if any(not a.filename.endswith(".json") for a in e.assets)
+    )
+    media_asset = next(a for a in sample.assets if not a.filename.endswith(".json"))
     monkeypatch.setitem(loader.BUNDLE_PACKAGE_MAP, sample.bundle, "_does_not_exist")
     with pytest.raises(FileNotFoundError):
-        loader.get_asset_path(sample.template_id, sample.assets[0].filename)
+        loader.get_asset_path(sample.template_id, media_asset.filename)
     reload(loader)
+
+
+def test_json_assets_use_json_package():
+    entry = next(e for e in loader.iter_templates() if e.bundle == "media-api")
+    json_name = f"{entry.template_id}.json"
+    assert loader._asset_package(entry, json_name) == loader.JSON_PACKAGE
+    webp_name = next(a.filename for a in entry.assets if a.filename.endswith(".webp"))
+    assert loader._asset_package(entry, webp_name) == loader.BUNDLE_PACKAGE_MAP[entry.bundle]

--- a/packages/json/project.json
+++ b/packages/json/project.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/project-schema.json",
+  "name": "json",
+  "projectType": "library",
+  "sourceRoot": "packages/json/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/json",
+        "command": "python3 -m build"
+      },
+      "dependsOn": [
+        {
+          "projects": "tooling",
+          "target": "sync"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "implicitDependencies": ["core"]
+}

--- a/packages/json/pyproject.toml
+++ b/packages/json/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "comfyui-workflow-templates-json"
+version = "0.1.0"
+description = "Workflow template JSON definitions for ComfyUI"
+readme = {text = "Workflow template JSON definitions for ComfyUI.", content-type = "text/plain"}
+requires-python = ">=3.9"
+license = "MIT"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+comfyui_workflow_templates_json = ["templates/*"]

--- a/packages/json/src/comfyui_workflow_templates_json/__init__.py
+++ b/packages/json/src/comfyui_workflow_templates_json/__init__.py
@@ -1,0 +1,6 @@
+"""
+Workflow template JSON bundle.
+
+All workflow and index JSON files live under ``templates/`` within this package.
+Content is populated during the build step.
+"""

--- a/packages/media_api/pyproject.toml
+++ b/packages/media_api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-api"
-version = "0.3.82"
+version = "0.3.83"
 description = "Media bundle containing API-driven workflow assets"
 readme = {text = "Media bundle containing API-driven workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/packages/media_assets_01/project.json
+++ b/packages/media_assets_01/project.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/project-schema.json",
+  "name": "media-assets-01",
+  "projectType": "library",
+  "sourceRoot": "packages/media_assets_01/src",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/media_assets_01",
+        "command": "python3 -m build"
+      },
+      "dependsOn": [
+        {
+          "projects": "tooling",
+          "target": "sync"
+        }
+      ]
+    }
+  },
+  "tags": [],
+  "implicitDependencies": ["core"]
+}

--- a/packages/media_assets_01/pyproject.toml
+++ b/packages/media_assets_01/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "comfyui-workflow-templates-media-assets-01"
+version = "0.1.0"
+description = "Media assets bundle 01 for ComfyUI workflow templates"
+readme = {text = "Media assets bundle 01 for ComfyUI workflow templates.", content-type = "text/plain"}
+requires-python = ">=3.9"
+license = "MIT"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+comfyui_workflow_templates_media_assets_01 = ["templates/*", "templates/**/*"]

--- a/packages/media_assets_01/src/comfyui_workflow_templates_media_assets_01/__init__.py
+++ b/packages/media_assets_01/src/comfyui_workflow_templates_media_assets_01/__init__.py
@@ -1,0 +1,6 @@
+"""
+Media assets bundle 01: thumbnails and preview media for new workflow templates.
+
+Static assets live under ``templates/`` within this package. Content is
+populated during the build step.
+"""

--- a/packages/media_image/pyproject.toml
+++ b/packages/media_image/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-image"
-version = "0.3.158"
+version = "0.3.159"
 description = "Media bundle containing image workflow assets"
 readme = {text = "Media bundle containing image workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/packages/media_other/pyproject.toml
+++ b/packages/media_other/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-other"
-version = "0.3.227"
+version = "0.3.228"
 description = "Media bundle containing audio/3D/misc workflow assets"
 readme = {text = "Media bundle containing audio, 3D, and other workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/packages/media_video/pyproject.toml
+++ b/packages/media_video/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-video"
-version = "0.3.99"
+version = "0.3.100"
 description = "Media bundle containing video workflow assets"
 readme = {text = "Media bundle containing video workflow assets for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.10.8"
+version = "0.11.0"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -18,23 +18,29 @@ classifiers = [
 ]
 
 dependencies = [
-    "comfyui-workflow-templates-core==0.3.264",
-    "comfyui-workflow-templates-media-api==0.3.82",
-    "comfyui-workflow-templates-media-video==0.3.99",
-    "comfyui-workflow-templates-media-image==0.3.158",
-    "comfyui-workflow-templates-media-other==0.3.227",
+    "comfyui-workflow-templates-core==0.3.265",
+    "comfyui-workflow-templates-json==0.1.0",
+    "comfyui-workflow-templates-media-api==0.3.83",
+    "comfyui-workflow-templates-media-video==0.3.100",
+    "comfyui-workflow-templates-media-image==0.3.159",
+    "comfyui-workflow-templates-media-other==0.3.228",
+    "comfyui-workflow-templates-media-assets-01==0.1.0",
 ]
 
 [project.optional-dependencies]
-api = ["comfyui-workflow-templates-media-api==0.3.82"]
-video = ["comfyui-workflow-templates-media-video==0.3.99"]
-image = ["comfyui-workflow-templates-media-image==0.3.158"]
-other = ["comfyui-workflow-templates-media-other==0.3.227"]
+json = ["comfyui-workflow-templates-json==0.1.0"]
+assets = ["comfyui-workflow-templates-media-assets-01==0.1.0"]
+api = ["comfyui-workflow-templates-media-api==0.3.83"]
+video = ["comfyui-workflow-templates-media-video==0.3.100"]
+image = ["comfyui-workflow-templates-media-image==0.3.159"]
+other = ["comfyui-workflow-templates-media-other==0.3.228"]
 all = [
-    "comfyui-workflow-templates-media-api==0.3.82",
-    "comfyui-workflow-templates-media-video==0.3.99",
-    "comfyui-workflow-templates-media-image==0.3.158",
-    "comfyui-workflow-templates-media-other==0.3.227",
+    "comfyui-workflow-templates-json==0.1.0",
+    "comfyui-workflow-templates-media-assets-01==0.1.0",
+    "comfyui-workflow-templates-media-api==0.3.83",
+    "comfyui-workflow-templates-media-video==0.3.100",
+    "comfyui-workflow-templates-media-image==0.3.159",
+    "comfyui-workflow-templates-media-other==0.3.228",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/ci/ci_version_manager.py
+++ b/scripts/ci/ci_version_manager.py
@@ -8,9 +8,77 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Set, List, Dict
+from typing import Set, List
 
 ROOT = Path.cwd()
+
+MEDIA_ASSET_EXTENSIONS = {
+    ".webp", ".png", ".jpg", ".jpeg", ".gif", ".mp4", ".webm",
+    ".mp3", ".wav", ".ogg", ".flac", ".m4a",
+}
+
+BUNDLE_PACKAGE_MAP = {
+    "media-api": "media_api",
+    "media-video": "media_video",
+    "media-image": "media_image",
+    "media-other": "media_other",
+    "media-assets-01": "media_assets_01",
+}
+
+
+def _is_json_template_path(file: str) -> bool:
+    return file.startswith("templates/") and file.endswith(".json")
+
+
+def _is_media_template_path(file: str) -> bool:
+    if not file.startswith("templates/"):
+        return False
+    suffix = Path(file).suffix.lower()
+    return suffix in MEDIA_ASSET_EXTENSIONS or file.startswith("templates/logo/")
+
+
+def _template_id_from_path(file: str) -> str:
+    name = Path(file).name
+    if name.endswith(".json"):
+        return Path(name).stem
+    return Path(name).stem.split("-")[0]
+
+
+def _json_asset_fingerprints(manifest: dict) -> dict[str, str]:
+    fingerprints: dict[str, str] = {}
+    for entry in manifest.get("templates", []):
+        for asset in entry.get("assets", []):
+            filename = asset.get("filename", "")
+            if filename.endswith(".json"):
+                fingerprints[filename] = asset.get("sha256", "")
+    return fingerprints
+
+
+def _media_asset_fingerprints(manifest: dict, bundle: str) -> dict[str, str]:
+    fingerprints: dict[str, str] = {}
+    for entry in manifest.get("templates", []):
+        if entry.get("bundle") != bundle:
+            continue
+        for asset in entry.get("assets", []):
+            filename = asset.get("filename", "")
+            if not filename.endswith(".json"):
+                fingerprints[filename] = asset.get("sha256", "")
+    return fingerprints
+
+
+def _manifest_json_assets_changed(old_manifest: dict, cur_manifest: dict) -> bool:
+    return _json_asset_fingerprints(old_manifest) != _json_asset_fingerprints(cur_manifest)
+
+
+def _manifest_media_assets_changed(old_manifest: dict, cur_manifest: dict, bundle: str) -> bool:
+    old_ids = {e["id"] for e in old_manifest.get("templates", []) if e.get("bundle") == bundle}
+    cur_ids = {e["id"] for e in cur_manifest.get("templates", []) if e.get("bundle") == bundle}
+    if old_ids != cur_ids:
+        return True
+    return _media_asset_fingerprints(old_manifest, bundle) != _media_asset_fingerprints(
+        cur_manifest, bundle
+    )
+
 
 def run_git(args: List[str]) -> str:
     return subprocess.check_output(["git", *args], cwd=ROOT).decode().strip()
@@ -135,16 +203,10 @@ def get_files_affecting_package(pkg: str, since_commit: str) -> List[str]:
         filtered_files = []
         
         bundles = json.loads(Path("bundles.json").read_text()) if Path("bundles.json").exists() else {}
-        bundle_mapping = {
-            "media-api": "media_api",
-            "media-video": "media_video", 
-            "media-image": "media_image",
-            "media-other": "media_other"
-        }
-        
-        # Find which bundle this package corresponds to
+
+        # Find which bundle this package corresponds to (media bundles only)
         pkg_bundle = None
-        for bundle_name, bundle_pkg in bundle_mapping.items():
+        for bundle_name, bundle_pkg in BUNDLE_PACKAGE_MAP.items():
             if bundle_pkg == pkg:
                 pkg_bundle = bundle_name
                 break
@@ -166,23 +228,38 @@ def get_files_affecting_package(pkg: str, since_commit: str) -> List[str]:
                     filtered_files.append(file)
                 elif file == "packages/core/src/comfyui_workflow_templates_core/blueprints_manifest.json":
                     filtered_files.append(file)
-            # Template files affecting this package's bundle
+            # JSON package: any workflow/index JSON change
+            elif pkg == "json" and _is_json_template_path(file):
+                filtered_files.append(file)
+            # Media asset packages: non-JSON template assets for this bundle
             elif pkg_bundle and file.startswith("templates/"):
-                template_name = Path(file).stem.split('-')[0]
+                if _is_json_template_path(file):
+                    continue
+                if not _is_media_template_path(file):
+                    continue
+                template_name = _template_id_from_path(file)
                 if pkg_bundle in bundles and template_name in bundles[pkg_bundle]:
                     filtered_files.append(file)
-            # manifest.json changes: check if this bundle's template set actually changed
+            # manifest.json changes: JSON sha -> json; media sha -> bundle package
+            elif pkg == "json" and file == "packages/core/src/comfyui_workflow_templates_core/manifest.json":
+                try:
+                    old_manifest = json.loads(run_git(["show", f"{since_commit}:{file}"]))
+                    cur_manifest = json.loads(Path(file).read_text())
+                    if _manifest_json_assets_changed(old_manifest, cur_manifest):
+                        filtered_files.append(file)
+                except Exception:
+                    filtered_files.append(file)
             elif pkg_bundle and file == "packages/core/src/comfyui_workflow_templates_core/manifest.json":
                 try:
                     old_manifest = json.loads(run_git(["show", f"{since_commit}:{file}"]))
-                    old_ids = {e["id"] for e in old_manifest.get("templates", []) if e.get("bundle") == pkg_bundle}
                     cur_manifest = json.loads(Path(file).read_text())
-                    cur_ids = {e["id"] for e in cur_manifest.get("templates", []) if e.get("bundle") == pkg_bundle}
-                    if old_ids != cur_ids:
+                    if _manifest_media_assets_changed(old_manifest, cur_manifest, pkg_bundle):
                         filtered_files.append(file)
                 except Exception:
                     filtered_files.append(file)
             # bundles.json changes affecting this package's bundle
+            elif pkg == "json" and file == "bundles.json":
+                filtered_files.append(file)
             elif pkg_bundle and file == "bundles.json":
                 try:
                     # First check if bundles.json existed in the old commit
@@ -204,7 +281,17 @@ def get_files_affecting_package(pkg: str, since_commit: str) -> List[str]:
 def get_changed_packages() -> Set[str]:
     """Determine which packages need version bumps based on changes since their last version bump"""
     try:
-        packages = ["core", "media_api", "media_video", "media_image", "media_other", "blueprints", "meta"]
+        packages = [
+            "core",
+            "json",
+            "media_api",
+            "media_video",
+            "media_image",
+            "media_other",
+            "media_assets_01",
+            "blueprints",
+            "meta",
+        ]
         affected = set()
 
         for pkg in packages:
@@ -229,7 +316,16 @@ def get_changed_packages() -> Set[str]:
         return affected
     except Exception as e:
         print(f"Error in change detection: {e}")
-        return {"core", "media_api", "media_video", "media_image", "media_other", "meta"}
+        return {
+            "core",
+            "json",
+            "media_api",
+            "media_video",
+            "media_image",
+            "media_other",
+            "media_assets_01",
+            "meta",
+        }
 
 def bump_versions(packages: Set[str]) -> None:
     # Auto-bump individual packages (core, media-api, etc.) but not the root meta package
@@ -269,10 +365,12 @@ def update_dependencies() -> None:
     
     pyprojects = {
         "core": "packages/core/pyproject.toml",
-        "media_api": "packages/media_api/pyproject.toml", 
+        "json": "packages/json/pyproject.toml",
+        "media_api": "packages/media_api/pyproject.toml",
         "media_video": "packages/media_video/pyproject.toml",
         "media_image": "packages/media_image/pyproject.toml",
         "media_other": "packages/media_other/pyproject.toml",
+        "media_assets_01": "packages/media_assets_01/pyproject.toml",
     }
     
     # Get versions for packages that were auto-bumped

--- a/scripts/ci/ci_version_manager.py
+++ b/scripts/ci/ci_version_manager.py
@@ -8,7 +8,7 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Set, List
+from typing import Set, List, Optional
 
 ROOT = Path.cwd()
 
@@ -37,11 +37,26 @@ def _is_media_template_path(file: str) -> bool:
     return suffix in MEDIA_ASSET_EXTENSIONS or file.startswith("templates/logo/")
 
 
-def _template_id_from_path(file: str) -> str:
+_THUMBNAIL_SUFFIX = re.compile(r"-\d+$")
+
+
+def _template_id_from_path(file: str, bundles: Optional[dict] = None) -> str:
+    """Extract template id from a template asset path."""
     name = Path(file).name
     if name.endswith(".json"):
         return Path(name).stem
-    return Path(name).stem.split("-")[0]
+
+    stem = Path(name).stem
+    candidate = _THUMBNAIL_SUFFIX.sub("", stem)
+
+    if bundles:
+        all_ids = {tid for ids in bundles.values() for tid in ids}
+        if candidate in all_ids:
+            return candidate
+        if stem in all_ids:
+            return stem
+
+    return candidate
 
 
 def _json_asset_fingerprints(manifest: dict) -> dict[str, str]:
@@ -237,7 +252,7 @@ def get_files_affecting_package(pkg: str, since_commit: str) -> List[str]:
                     continue
                 if not _is_media_template_path(file):
                     continue
-                template_name = _template_id_from_path(file)
+                template_name = _template_id_from_path(file, bundles)
                 if pkg_bundle in bundles and template_name in bundles[pkg_bundle]:
                     filtered_files.append(file)
             # manifest.json changes: JSON sha -> json; media sha -> bundle package

--- a/scripts/sync/sync_bundles.py
+++ b/scripts/sync/sync_bundles.py
@@ -40,6 +40,15 @@ CORE_MANIFEST = (
 )
 SAMPLE_MANIFEST = ROOT / "prd" / "phase1-manifest-sample.json"
 
+JSON_TARGET = (
+    ROOT
+    / "packages"
+    / "json"
+    / "src"
+    / "comfyui_workflow_templates_json"
+    / "templates"
+)
+
 BUNDLE_TARGETS = {
     "media-api": ROOT
     / "packages"
@@ -64,6 +73,12 @@ BUNDLE_TARGETS = {
     / "media_other"
     / "src"
     / "comfyui_workflow_templates_media_other"
+    / "templates",
+    "media-assets-01": ROOT
+    / "packages"
+    / "media_assets_01"
+    / "src"
+    / "comfyui_workflow_templates_media_assets_01"
     / "templates",
 }
 BUNDLES_CONFIG = ROOT / "bundles.json"
@@ -259,6 +274,7 @@ def build_manifest(filter_pip: bool = True, excluded_names: Optional[frozenset] 
             "media-video": {"version": "0.0.0"},
             "media-image": {"version": "0.0.0"},
             "media-other": {"version": "0.0.0"},
+            "media-assets-01": {"version": "0.0.0"},
         },
         "templates": templates,
     }
@@ -292,6 +308,10 @@ def sync_bundle_directories(
         if p.name != "index.schema.json":
             index_data_filenames.add(p.name)
 
+    if JSON_TARGET.exists():
+        shutil.rmtree(JSON_TARGET)
+    JSON_TARGET.mkdir(parents=True, exist_ok=True)
+
     for target in BUNDLE_TARGETS.values():
         if target.exists():
             shutil.rmtree(target)
@@ -307,15 +327,19 @@ def sync_bundle_directories(
                 # Some optional assets (e.g., preview) may not exist; skip silently.
                 continue
 
-            dest = target_root / asset["filename"]
-            dest.parent.mkdir(parents=True, exist_ok=True)
+            filename = asset["filename"]
+            if filename.endswith(".json"):
+                dest = JSON_TARGET / Path(filename).name
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                if Path(filename).name in index_data_filenames:
+                    dest.write_bytes(filter_index_for_pip(src.read_bytes(), excluded_names))
+                else:
+                    shutil.copy2(src, dest)
+                continue
 
-            # Index data JSON files are filtered rather than copied verbatim so that
-            # cloud-only template entries are removed from the distributed package.
-            if Path(asset["filename"]).name in index_data_filenames:
-                dest.write_bytes(filter_index_for_pip(src.read_bytes(), excluded_names))
-            else:
-                shutil.copy2(src, dest)
+            dest = target_root / filename
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
 
 
 def write_manifest(manifest: dict, dry_run: bool = False) -> None:
@@ -357,7 +381,7 @@ def main():
     target = CORE_MANIFEST if not args.dry_run else SAMPLE_MANIFEST
     print(f"Wrote manifest to {target}")
     if not args.dry_run:
-        print("Synced media assets into package directories.")
+        print("Synced JSON into json package and media assets into bundle directories.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `comfyui-workflow-templates-json` (all workflow/index JSON) and `comfyui-workflow-templates-media-assets-01` (new template media) PyPI packages.
- Route all `.json` assets to the json package in `sync_bundles.py` and `loader.py`; legacy `media-*` packages now ship assets only (JSON stripped on this release).
- Extend `bundles.json` with `media-assets-01` for new templates; legacy `media-api/image/video/other` bundles are frozen.
- Update CI publish/build, version bump logic, and meta pins (meta `0.11.0`).

## Design rationale

Workflow JSON and template media have very different change patterns:

| Asset type | Change frequency | Typical size | Package |
|------------|------------------|--------------|---------|
| Workflow + index JSON | High (bug fixes, node updates, metadata) | ~20 MB total | `comfyui-workflow-templates-json` |
| Thumbnails / preview media | Low (mostly archived after publish) | 85–93 MB per legacy bundle | Legacy `media-*` (frozen) + `media-assets-01` for new templates |

**Before:** a one-line JSON fix forced republishing an 85–93 MB `media-*` wheel because JSON and images lived in the same package.

**After:** JSON-only changes bump only the `json` package (~20 MB download). Legacy media bundles are frozen — existing thumbnails stay put and those wheels stop growing. New templates assign media via `bundles.json` → `media-assets-01` (and `media-assets-02`, etc. when needed).

### First release vs. steady state

This PR is a **one-time structural migration**. The first publish must be a **full release** (all sub-packages + meta `0.11.0` with the `release` label) because legacy `media-*` wheels are being stripped of JSON and two new packages are introduced.

After that, day-to-day template maintenance looks like:

- **JSON-only edits** → bump `json` only (~20 MB for users)
- **New template with thumbnails** → bump `json` + `media-assets-01`
- **Legacy frozen bundles** → no version bump unless a rare media fix is needed

ComfyUI should pin `comfyui-workflow-templates==0.11.0` (or later) so installs always pull `json` alongside the legacy media wheels.

## Test plan

- [x] `python scripts/sync/sync_bundles.py` — 471 JSON files in json package, 0 JSON in legacy media packages
- [x] `pytest packages/core/tests` — 9 passed
- [x] `python scripts/validate/validate_manifests.py` — no errors
- [ ] Merge with **`release` label** for first PyPI publish of json + media-assets-01 + stripped legacy media wheels