### PR TITLE
Fix manifest prefix collision for int8 template thumbnails.

### DIFF
--- a/packages/core/src/comfyui_workflow_templates_core/manifest.json
+++ b/packages/core/src/comfyui_workflow_templates_core/manifest.json
@@ -342,26 +342,6 @@
         {
           "filename": "api_google_gemini-1.webp",
           "sha256": "fd041e9b20b9e41e85b1c68acc091c7431711adb2de086ffdba68cc43f826728"
-        },
-        {
-          "filename": "api_google_gemini_image-1.webp",
-          "sha256": "b301922b1fdf58d8922d22149f9364e7e53535e8953f967325fa7e05f63208c1"
-        },
-        {
-          "filename": "api_google_gemini_omni_flash_i2v-1.webp",
-          "sha256": "e7cd862bba0a443045ba5d303a6dbd2fdbda523863baada6e0410183805993a8"
-        },
-        {
-          "filename": "api_google_gemini_omni_flash_t2v-1.webp",
-          "sha256": "8cb3f06af2bb53cbe751507a5de4ce202f2045a8e0f56c662d696989091dec67"
-        },
-        {
-          "filename": "api_google_gemini_omni_flash_video_edit-1.webp",
-          "sha256": "c7a12ecbc6a82782ac190e5f6d655cb1b87faa341d2a69f13436f54c6206915d"
-        },
-        {
-          "filename": "api_google_gemini_omni_flash_video_edit-2.webp",
-          "sha256": "aa232a71b2893f9be1f92f6803e800b7fecaa18a9242e03c46edb9cc209b018e"
         }
       ],
       "cdn": {
@@ -618,14 +598,6 @@
         {
           "filename": "api_kling_motion_control-1.webp",
           "sha256": "eaa34606a8485f5884595b626b325751bd7341406cbe8072439c00d8d46223d8"
-        },
-        {
-          "filename": "api_kling_motion_control3-1.webp",
-          "sha256": "03b6fc2cb37597c0d044322aeb006763db91318945e84558d3c2104e46683678"
-        },
-        {
-          "filename": "api_kling_motion_control3-2.webp",
-          "sha256": "bc0ed49244c970ee578e50a23ded4e5d1cd64d1cbb033fa787a2d212bb80faea"
         }
       ],
       "cdn": {
@@ -1848,14 +1820,6 @@
         {
           "filename": "image_qwen_Image_2512-1.webp",
           "sha256": "a8e3a4a28992b199a17674a96f3d5884dd5c7b5d593d970cc191229c963e4dea"
-        },
-        {
-          "filename": "image_qwen_Image_2512_controlnet-1.webp",
-          "sha256": "d18ef9c314a567a4170c898affde4338a48a6c3007006b68d1af70a5fc6ee2d0"
-        },
-        {
-          "filename": "image_qwen_Image_2512_controlnet-2.webp",
-          "sha256": "464c48f98efbf28d1d0ea538b5635f14ebf8749819fb9c5c308cad757110c859"
         }
       ],
       "cdn": {
@@ -2142,14 +2106,6 @@
         {
           "filename": "3d_hunyuan3d_multiview_to_model-2.webp",
           "sha256": "323bf2112cc91dcbaa1aa7b8cfdc67c3054280ad63994c98e9efdbf0d2b5e327"
-        },
-        {
-          "filename": "3d_hunyuan3d_multiview_to_model_turbo-1.webp",
-          "sha256": "cd7662b2dd6df82ba35a45caec578fb7bbdbc6a8ec35a31f87a20260ab4c4cf3"
-        },
-        {
-          "filename": "3d_hunyuan3d_multiview_to_model_turbo-2.webp",
-          "sha256": "648aa51605b4fad11b8c5257cb72a08abc70975a7588febaea388fd26f80f086"
         }
       ],
       "cdn": {
@@ -3154,14 +3110,6 @@
         {
           "filename": "audio_ace_step_1_5_split-1.mp3",
           "sha256": "05c6cd1bbc054f75304311a8d60ad8e112504805a633c68ad89e624dc3215f92"
-        },
-        {
-          "filename": "audio_ace_step_1_5_split_4b-1.mp3",
-          "sha256": "71c0491f8742afb55d92197e140f03bad2ef9d3f6a9c85d3dac7df4a98315d63"
-        },
-        {
-          "filename": "audio_ace_step_1_5_split_llm-1.mp3",
-          "sha256": "8fba41b1469ba831a112f9a302146a5824dd15a5c86683fd0214972c755ddb70"
         }
       ],
       "cdn": {
@@ -3514,10 +3462,6 @@
         {
           "filename": "flux_schnell-1.webp",
           "sha256": "7d0ee3729029efc052bb9b74c2099df5ba4928e72642b2691c3c3af52775a11c"
-        },
-        {
-          "filename": "flux_schnell_full_text_to_image-1.webp",
-          "sha256": "7f4d43a62183753980325541c585348965e0b5fe39e4c67a30986af2885f88e5"
         }
       ],
       "cdn": {
@@ -3826,10 +3770,6 @@
         {
           "filename": "image_ernie_image-1.webp",
           "sha256": "3edb358993695a997e668d9f315a14fa0a7570b09b198f7fc5f189076616eaff"
-        },
-        {
-          "filename": "image_ernie_image_turbo-1.webp",
-          "sha256": "10c7de8b75ac2001dbc081856c16962b98084558034ff8c9db78b53ad08de5d9"
         }
       ],
       "cdn": {
@@ -3914,50 +3854,6 @@
         {
           "filename": "image_flux2-2.webp",
           "sha256": "ff3a255c16ab846d456ff1065028ffe5b46f2f28263d2854c31d307cf1c4299d"
-        },
-        {
-          "filename": "image_flux2_fp8-1.webp",
-          "sha256": "0aadfee787ab4700fc639cad3bf5fd031f6a1b31868beef66baac13b030c4d65"
-        },
-        {
-          "filename": "image_flux2_klein_9b_kv_image_edit-1.webp",
-          "sha256": "caefb2f14d2215295109c3d9cc6f407b68265de40cc842be0a3f26cc630afe82"
-        },
-        {
-          "filename": "image_flux2_klein_9b_kv_image_edit-2.webp",
-          "sha256": "33ca074f8082bdb218e7ec428b8a01f384ef0a7b3d88e0c3ce43bff52d50e957"
-        },
-        {
-          "filename": "image_flux2_klein_image_edit_4b_base-1.webp",
-          "sha256": "df909cea53d886015a84d351373c01587b6d45c8601a44a4174751fffc84544f"
-        },
-        {
-          "filename": "image_flux2_klein_image_edit_4b_distilled-1.webp",
-          "sha256": "a2d51779480a3859bdc7b0242cccaff1e06cf6bb76385389f05bd96142c9490a"
-        },
-        {
-          "filename": "image_flux2_klein_image_edit_9b_base-1.webp",
-          "sha256": "1c893d333137ac4238bde0a8c6b3d4afab1e7b04849f43cad7d1370030e6af23"
-        },
-        {
-          "filename": "image_flux2_klein_image_edit_9b_distilled-1.webp",
-          "sha256": "6420cc35a26d811267880ef4f0d683a0328d66b03134fd8acf61b506f39a40ca"
-        },
-        {
-          "filename": "image_flux2_klein_image_edit_9b_distilled-2.webp",
-          "sha256": "ef33e9d91b5cefa107b571e15ec260931c652ab6f73984040bf212957ca737c7"
-        },
-        {
-          "filename": "image_flux2_klein_text_to_image-1.webp",
-          "sha256": "dc061b092390279bcd71e3121aead0e816f8bb22d5ff9b866b5ef2112157ccc0"
-        },
-        {
-          "filename": "image_flux2_text_to_image-1.webp",
-          "sha256": "77473b8d2488fcd7d6d1adec18de450220fa61c3a8a16878a3308fc4a11dcf52"
-        },
-        {
-          "filename": "image_flux2_text_to_image_9b-1.webp",
-          "sha256": "2fc23983516bfd3cbad9fcaaf2d891a3baec20d5c9040332194bc6bbb68a0d31"
         }
       ],
       "cdn": {
@@ -4110,10 +4006,6 @@
         {
           "filename": "image_flux2_text_to_image-1.webp",
           "sha256": "77473b8d2488fcd7d6d1adec18de450220fa61c3a8a16878a3308fc4a11dcf52"
-        },
-        {
-          "filename": "image_flux2_text_to_image_9b-1.webp",
-          "sha256": "2fc23983516bfd3cbad9fcaaf2d891a3baec20d5c9040332194bc6bbb68a0d31"
         }
       ],
       "cdn": {
@@ -4150,14 +4042,6 @@
         {
           "filename": "image_hidream_o1-1.webp",
           "sha256": "8c3ead0eedec0502e3f2ae825e77d0a3fb9d39a371935ed86ab3b1bbe7dcc060"
-        },
-        {
-          "filename": "image_hidream_o1_dev-1.webp",
-          "sha256": "42389755a4a92907f4caf5a37a244b926e4dcacb3f6f3f68c49563861ba3a773"
-        },
-        {
-          "filename": "image_hidream_o1_dev-2.webp",
-          "sha256": "9670b4fa6af7f462eb50542b4648c326439ff74953f8d5dc99298514a4583eca"
         }
       ],
       "cdn": {
@@ -4234,10 +4118,6 @@
         {
           "filename": "image_krea2_turbo_t2i-1.webp",
           "sha256": "ba214942f8b71a1cc70abb13ea7ffd337ff7a7c2b95cf4f4f1a18413143070f8"
-        },
-        {
-          "filename": "image_krea2_turbo_t2i_int8-1.webp",
-          "sha256": "0b27a18d226a94de2aa81cca79677c0c0a73c2acbd5f13be77d4307569cc45f6"
         }
       ],
       "cdn": {
@@ -4488,82 +4368,6 @@
         {
           "filename": "image_qwen_image-1.webp",
           "sha256": "9b61fc1058f6ddc310347eca0902777617b10bae962ea5fb303f7eddbf6ec5f4"
-        },
-        {
-          "filename": "image_qwen_image_2512_with_2steps_lora-1.webp",
-          "sha256": "a2e8ca661a24762df93b93fd28dac7556f718c1efe305c93e32a98ce5be23ff4"
-        },
-        {
-          "filename": "image_qwen_image_controlnet_patch-1.webp",
-          "sha256": "233bdd99c862da7ee038142625374a13238bf766996ad42edde806257e918407"
-        },
-        {
-          "filename": "image_qwen_image_controlnet_patch-2.webp",
-          "sha256": "748f1edad66133a7c2edd63052220955fea9568f53fd9cd9e2d904090922a588"
-        },
-        {
-          "filename": "image_qwen_image_edit-1.webp",
-          "sha256": "8308e3589732a4f36e3df85292a36ae4eb96e528c932fc24dc985296307f1e51"
-        },
-        {
-          "filename": "image_qwen_image_edit-2.webp",
-          "sha256": "52861e9846b68b4c36f36732d9d337f6885c136c78e7631f2b43b2cb6b09a0c2"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509-1.webp",
-          "sha256": "a9f52fb9b2d8933bb2c118698a875910c7f672fbd0b61e2189fcb5c745967d84"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509-2.webp",
-          "sha256": "0f14e8b7fa50e29229b8a512dc33c96ec8d52704f6e656df046af928a64eeafa"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509_relight-1.webp",
-          "sha256": "d8c30a50fd96c96ca2e4594a9f87e0d8871537c0dd1be51d1d12cda3226ac7fc"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509_relight-2.webp",
-          "sha256": "d96b23a1a67436767bbd3bb56ac6558e41e5464d4d2445e969742802f4593823"
-        },
-        {
-          "filename": "image_qwen_image_edit_2511-1.webp",
-          "sha256": "91c5da5b47f2e72022f16d6ba0619d91d248c4c31d77f46727df171c8ec0d1f7"
-        },
-        {
-          "filename": "image_qwen_image_edit_2511-2.webp",
-          "sha256": "ee6150b36db8d0771e7a7a3aa1a2b1ba81d86a7576b477e4b19035f3b0c80c34"
-        },
-        {
-          "filename": "image_qwen_image_instantx_controlnet-1.webp",
-          "sha256": "866333d22baa19e85b1dcb75556790de02032fdb8b58f75e6a71aec7379f362c"
-        },
-        {
-          "filename": "image_qwen_image_instantx_controlnet-2.webp",
-          "sha256": "1ee0c1381a79cf67b20fa388a1d5b1ff248d3aceeda2110bcf37d9aeea665b3e"
-        },
-        {
-          "filename": "image_qwen_image_instantx_inpainting_controlnet-1.webp",
-          "sha256": "66fde18de64f512905d1b93753f6b8fa3d00e2e79a05ff2916a0d7aaefc146bd"
-        },
-        {
-          "filename": "image_qwen_image_instantx_inpainting_controlnet-2.webp",
-          "sha256": "9187dd7414eb950cf38d1c2b54bf68fa8b3d8f3bd709de2d4abcd346f79b30ec"
-        },
-        {
-          "filename": "image_qwen_image_layered-1.webp",
-          "sha256": "e07a002d235a9902eabf254346621fd9b0739b4b3a18d785161e08b4a2900583"
-        },
-        {
-          "filename": "image_qwen_image_layered_control-1.webp",
-          "sha256": "6b6f707d336cf0155146b4df49f61801810543a1a2a19c251c5a6390136a0137"
-        },
-        {
-          "filename": "image_qwen_image_union_control_lora-1.webp",
-          "sha256": "c2310000870f19774b8f8323f90001bfdc909f41cc2bec41bc01c15c1771457b"
-        },
-        {
-          "filename": "image_qwen_image_union_control_lora-2.webp",
-          "sha256": "0541d8698edd40e7eefd563f22313371defb16807db08e5c13a3541e7f142cdf"
         }
       ],
       "cdn": {
@@ -4626,30 +4430,6 @@
         {
           "filename": "image_qwen_image_edit-2.webp",
           "sha256": "52861e9846b68b4c36f36732d9d337f6885c136c78e7631f2b43b2cb6b09a0c2"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509-1.webp",
-          "sha256": "a9f52fb9b2d8933bb2c118698a875910c7f672fbd0b61e2189fcb5c745967d84"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509-2.webp",
-          "sha256": "0f14e8b7fa50e29229b8a512dc33c96ec8d52704f6e656df046af928a64eeafa"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509_relight-1.webp",
-          "sha256": "d8c30a50fd96c96ca2e4594a9f87e0d8871537c0dd1be51d1d12cda3226ac7fc"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509_relight-2.webp",
-          "sha256": "d96b23a1a67436767bbd3bb56ac6558e41e5464d4d2445e969742802f4593823"
-        },
-        {
-          "filename": "image_qwen_image_edit_2511-1.webp",
-          "sha256": "91c5da5b47f2e72022f16d6ba0619d91d248c4c31d77f46727df171c8ec0d1f7"
-        },
-        {
-          "filename": "image_qwen_image_edit_2511-2.webp",
-          "sha256": "ee6150b36db8d0771e7a7a3aa1a2b1ba81d86a7576b477e4b19035f3b0c80c34"
         }
       ],
       "cdn": {
@@ -4672,14 +4452,6 @@
         {
           "filename": "image_qwen_image_edit_2509-2.webp",
           "sha256": "0f14e8b7fa50e29229b8a512dc33c96ec8d52704f6e656df046af928a64eeafa"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509_relight-1.webp",
-          "sha256": "d8c30a50fd96c96ca2e4594a9f87e0d8871537c0dd1be51d1d12cda3226ac7fc"
-        },
-        {
-          "filename": "image_qwen_image_edit_2509_relight-2.webp",
-          "sha256": "d96b23a1a67436767bbd3bb56ac6558e41e5464d4d2445e969742802f4593823"
         }
       ],
       "cdn": {
@@ -4786,10 +4558,6 @@
         {
           "filename": "image_qwen_image_layered-1.webp",
           "sha256": "e07a002d235a9902eabf254346621fd9b0739b4b3a18d785161e08b4a2900583"
-        },
-        {
-          "filename": "image_qwen_image_layered_control-1.webp",
-          "sha256": "6b6f707d336cf0155146b4df49f61801810543a1a2a19c251c5a6390136a0137"
         }
       ],
       "cdn": {
@@ -4848,22 +4616,6 @@
         {
           "filename": "image_z_image-1.webp",
           "sha256": "9f52ff8cacd08bb7f0eb304e397bb8b064f0b27b77a153688ed30801f6daa9a9"
-        },
-        {
-          "filename": "image_z_image_turbo-1.webp",
-          "sha256": "2e55bb579c40bdfa785eece644a78431bba4eac60f567835142a58aa41d548dd"
-        },
-        {
-          "filename": "image_z_image_turbo_fun_union_controlnet-1.webp",
-          "sha256": "80c81d5ec402de7dfb4283c1c6ccdddc64fee0e592d8f0b477d160d0b28e663b"
-        },
-        {
-          "filename": "image_z_image_turbo_fun_union_controlnet-2.webp",
-          "sha256": "ecc36e5a9f52ce3b31510320bba3347139155e1147cd7032b8e6b0804b5eda10"
-        },
-        {
-          "filename": "image_z_image_turbo_int8-1.webp",
-          "sha256": "6d27bd92bd03088307d689362baae5d40f430daa12a1fe5319ba7b9e4a006dec"
         }
       ],
       "cdn": {
@@ -4882,18 +4634,6 @@
         {
           "filename": "image_z_image_turbo-1.webp",
           "sha256": "2e55bb579c40bdfa785eece644a78431bba4eac60f567835142a58aa41d548dd"
-        },
-        {
-          "filename": "image_z_image_turbo_fun_union_controlnet-1.webp",
-          "sha256": "80c81d5ec402de7dfb4283c1c6ccdddc64fee0e592d8f0b477d160d0b28e663b"
-        },
-        {
-          "filename": "image_z_image_turbo_fun_union_controlnet-2.webp",
-          "sha256": "ecc36e5a9f52ce3b31510320bba3347139155e1147cd7032b8e6b0804b5eda10"
-        },
-        {
-          "filename": "image_z_image_turbo_int8-1.webp",
-          "sha256": "6d27bd92bd03088307d689362baae5d40f430daa12a1fe5319ba7b9e4a006dec"
         }
       ],
       "cdn": {
@@ -5894,14 +5634,6 @@
         {
           "filename": "video_ltx2_i2v-1.webp",
           "sha256": "36cf8b8b6891d5281c4b2f8fcf9c07873a09c2588f30a2083078a601925101fe"
-        },
-        {
-          "filename": "video_ltx2_i2v_distilled-1.webp",
-          "sha256": "89ca0b8c0eb5c23f1a50c08d30429c9f7124ca0ecb247c5f100a2d1ea1a0c135"
-        },
-        {
-          "filename": "video_ltx2_i2v_lora-1.webp",
-          "sha256": "1d3d366534d85557ac68cc9aaa98ef3dba5f97c2dedd983efe02283c52fd561d"
         }
       ],
       "cdn": {
@@ -5938,10 +5670,6 @@
         {
           "filename": "video_ltx2_t2v-1.webp",
           "sha256": "1cd0fd528e816a6450123b50d3a936428dc5a80679c9e388a3a63e579e6a5276"
-        },
-        {
-          "filename": "video_ltx2_t2v_distilled-1.webp",
-          "sha256": "83eff570eeb7e1f181fe67a0af3c37ba6f4a30f84caf60ec0fe083a1d2b794f0"
         }
       ],
       "cdn": {
@@ -5978,10 +5706,6 @@
         {
           "filename": "video_wanmove_480p-1.webp",
           "sha256": "0c9d4a2431f64803b91770a0cdb2c3e9b8b36f0fc1d03601cb5bdd5c4af23848"
-        },
-        {
-          "filename": "video_wanmove_480p_hallucination-1.webp",
-          "sha256": "5b282672e7610664e602dda0f297c21568b3c562f5a1a3c56126b14a56651c20"
         }
       ],
       "cdn": {
@@ -6174,14 +5898,6 @@
         {
           "filename": "api_bria_remove_video_background-2.webp",
           "sha256": "cff7f3ab21c356b4401120fd7d82ee406802e4aa6731b543aed59948215a3a90"
-        },
-        {
-          "filename": "api_bria_remove_video_background_transparent-1.webp",
-          "sha256": "cb641b6507c413c0aad621c6dd21362151616f422ba2e9ca00fe0c4a9dee9d1c"
-        },
-        {
-          "filename": "api_bria_remove_video_background_transparent-2.webp",
-          "sha256": "60da910d071dc9e71b1dd768dae45d25042b500ac4d8b572b05c51012fcee1db"
         }
       ],
       "cdn": {
@@ -6266,58 +5982,6 @@
         {
           "filename": "api_bytedance_seed-1.webp",
           "sha256": "915c9edc01ff5c1124c6d6aa2af708c389fd8dce35ca7bcab0593cb83d3a64c8"
-        },
-        {
-          "filename": "api_bytedance_seed_audio1_0_t2a-1.webp",
-          "sha256": "1663d7b20857758cb40561b559483d347b22f5c5085d305bb1c29f175f6bfcf0"
-        },
-        {
-          "filename": "api_bytedance_seed_audio1_0_ta2a-1.webp",
-          "sha256": "f8bcb4564f30d0723eed45d16252b299b5a06e83694dda428e81a9f0272c8eca"
-        },
-        {
-          "filename": "api_bytedance_seed_audio1_0_ti2a-1.webp",
-          "sha256": "624c1c0402dc32be82beb0db5b7208661252c082e27a9c6f57dd6c9ece0d78e6"
-        },
-        {
-          "filename": "api_bytedance_seedance1_5_flf2v-1.webp",
-          "sha256": "92f83ce660103da36074332541338b11bf82eb0e0caee112adec6da3146b2f36"
-        },
-        {
-          "filename": "api_bytedance_seedance1_5_image_to_video-1.webp",
-          "sha256": "befa582e9ab033429b1bf5a015bd74cd7b2c7593729cbcb1dff165baecd1337e"
-        },
-        {
-          "filename": "api_bytedance_seedance1_5_text_to_video-1.webp",
-          "sha256": "9e91273489cdfbb779bdf9f69412de202cd13803708f453676f5c86598922ce5"
-        },
-        {
-          "filename": "api_bytedance_seedream4-1.webp",
-          "sha256": "b1d554f1b2c63c80109b0cd6deea0e55b0862c5e9a1c402b16783ac3966e13c6"
-        },
-        {
-          "filename": "api_bytedance_seedream_5_0_lite_image_edit-1.webp",
-          "sha256": "41839bb4f82ebef5895792420d776f68fc55ae71283ba52fbc3baf9954d2e66f"
-        },
-        {
-          "filename": "api_bytedance_seedream_5_0_lite_image_edit-2.webp",
-          "sha256": "0a9725277c920901e245af7715948cab395975caa8b9ffbef5658959fabaf770"
-        },
-        {
-          "filename": "api_bytedance_seedream_5_0_lite_t2i-1.webp",
-          "sha256": "c18b024da89ee14ffe2fa460a0fe36893542afe064105f04adc68b889cefe5c3"
-        },
-        {
-          "filename": "api_bytedance_seedream_5_0_pro_image_edit-1.webp",
-          "sha256": "78dcc49f1715d7fff422e9a6d40d72402ea5d0f31ca713628e097ee283852188"
-        },
-        {
-          "filename": "api_bytedance_seedream_5_0_pro_image_edit-2.webp",
-          "sha256": "41415e375f1f9bc5347e054189d65591ac86bf2368ed5c0186c4a2931b5f05b6"
-        },
-        {
-          "filename": "api_bytedance_seedream_5_0_pro_t2i-1.webp",
-          "sha256": "3df3f5a9e9c5d34f28cfe1198505d0b182441c86625f9a1bb97274555962830f"
         }
       ],
       "cdn": {
@@ -6522,10 +6186,6 @@
         {
           "filename": "api_seedance2_0_flf2v-1.webp",
           "sha256": "6157f3f53089f845e9b15f18909653fc25c32a2aeb5d9e4b7d8856a590197156"
-        },
-        {
-          "filename": "api_seedance2_0_flf2v_real_human-1.webp",
-          "sha256": "3b101b16a5b85e800a8366700dcdc29cb9341ae0fbdc89e2b8986257f71ee3ea"
         }
       ],
       "cdn": {
@@ -6580,14 +6240,6 @@
         {
           "filename": "api_seedance2_0_r2v-1.webp",
           "sha256": "a5376a854fe8206d2adfa013bbfde93e1a76f7461c20de5238a76878961a949c"
-        },
-        {
-          "filename": "api_seedance2_0_r2v_4k-1.webp",
-          "sha256": "ebe93bcfb5cbbcaeeac8af2b575106a3340d4da3fb5477c095ae1c258bf50d47"
-        },
-        {
-          "filename": "api_seedance2_0_r2v_real_human-1.webp",
-          "sha256": "36425e6dd42e095697a825a10d14369dfd339edd1e00287957830080c8eb3694"
         }
       ],
       "cdn": {
@@ -6898,10 +6550,6 @@
         {
           "filename": "audio_stable_audio_3_medium-1.webp",
           "sha256": "5ce318ce8c0facc61ba33787ea1bc72ac0cada41b4d7a8179a81812181786cbf"
-        },
-        {
-          "filename": "audio_stable_audio_3_medium_base-1.webp",
-          "sha256": "a133debab9c06b1a42d8eb7ac4ddede1c737671f76be319f687531bda796b6d1"
         }
       ],
       "cdn": {
@@ -8056,10 +7704,6 @@
         {
           "filename": "utility_sdpose_multi_person-1.webp",
           "sha256": "9bc5bebc56dc55c5ff3052df8348285e75e725464b5474be7c62f876fe258c79"
-        },
-        {
-          "filename": "utility_sdpose_multi_person_video-1.webp",
-          "sha256": "4821f7c2681860e18c592b12fb1f2d99b1011230e6db0e17972aea0b6d4b4eef"
         }
       ],
       "cdn": {
@@ -8296,18 +7940,6 @@
         {
           "filename": "api_grok_video-1.webp",
           "sha256": "26274dd41ce414a1ea85ed7fc2518130488330c6706812803c5cd251ef9fd206"
-        },
-        {
-          "filename": "api_grok_video_edit-1.webp",
-          "sha256": "b68e2c2d21f62ea4d3c927a5436f55318b6a09a949d26ed8aef6daa1d56ce317"
-        },
-        {
-          "filename": "api_grok_video_edit-2.webp",
-          "sha256": "7e6dca4640ca3766cef5741db1ac86839539c0057c004f7a7f4aea209899a409"
-        },
-        {
-          "filename": "api_grok_video_extend-1.webp",
-          "sha256": "62a20627d273a092aa8f2c56c4727ac7d75bafb0e2474e706cd3519f723a4ea2"
         }
       ],
       "cdn": {

--- a/scripts/sync/sync_bundles.py
+++ b/scripts/sync/sync_bundles.py
@@ -83,6 +83,19 @@ BUNDLE_TARGETS = {
 }
 BUNDLES_CONFIG = ROOT / "bundles.json"
 
+
+def media_file_belongs_to_template(filename: str, template_id: str) -> bool:
+    """Return True when a media asset filename belongs to exactly this template.
+
+    Prevents prefix collisions such as assigning ``image_krea2_turbo_t2i_int8-1.webp``
+    to template ``image_krea2_turbo_t2i`` (``{template_id}*.webp`` glob is too broad).
+    """
+    stem = Path(filename).stem
+    if stem == template_id:
+        return True
+    return stem.startswith(f"{template_id}-")
+
+
 def get_pip_excluded_template_names() -> frozenset[str]:
     """Return the set of template names that must be excluded from pip packages.
 
@@ -237,6 +250,8 @@ def build_manifest(filter_pip: bool = True, excluded_names: Optional[frozenset] 
             for pattern in media_patterns:
                 for asset_path in sorted(TEMPLATES_DIR.glob(pattern)):
                     if asset_path.name in seen:
+                        continue
+                    if not media_file_belongs_to_template(asset_path.name, template_id):
                         continue
                     seen.add(asset_path.name)
                     assets.append(


### PR DESCRIPTION
The `{template_id}*.webp` glob in sync_bundles.py incorrectly assigned files like image_krea2_turbo_t2i_int8-1.webp to image_krea2_turbo_t2i (media-image), causing ComfyUI to fail resolving assets at startup. Match media filenames by exact template id or `{id}-` prefix only.