### PR TITLE
feat(site): pin Kling Avatar 2.0 as AI Avatar Generator hero + add Use Cases footer link

### DIFF
--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -3,6 +3,11 @@
  * SiteFooter - Blue footer matching the Figma design
  * Blue background, Comfy logo, social icons, 4-column link grid
  */
+import { getLocaleFromPath } from '../../i18n/utils';
+import { useCasesIndexPath } from '../../lib/routes';
+
+const locale = getLocaleFromPath(Astro.url.pathname);
+const useCasesHref = useCasesIndexPath(locale);
 ---
 
 <footer class="bg-page text-content">
@@ -151,6 +156,14 @@
         <div>
           <h4 class="text-brand font-semibold text-sm mb-4">Resources</h4>
           <ul class="space-y-3">
+            <li>
+              <a
+                href={useCasesHref}
+                class="text-content-secondary text-sm hover:text-content transition-colors"
+              >
+                Use Cases
+              </a>
+            </li>
             <li>
               <a
                 href="https://blog.comfy.org"

--- a/site/src/components/workflow-pages/LandingHero.astro
+++ b/site/src/components/workflow-pages/LandingHero.astro
@@ -1,6 +1,6 @@
 ---
 import type { Locale } from '../../i18n/config';
-import { firstStillThumbnail, firstTemplateWithStill } from '../../lib/media-utils';
+import { firstStillThumbnail, pickHeroTemplate } from '../../lib/media-utils';
 import { thumbnailPath, workflowDetailPath } from '../../lib/routes';
 import type { SerializedTemplate } from '../../lib/hub-api';
 import { resolveTemplateLogos } from '../../lib/model-logos';
@@ -19,11 +19,23 @@ interface Props {
   analytics?: { location: string; template?: string };
   /** Templates the page resolves to; the first still image becomes the hero visual. */
   templates: SerializedTemplate[];
+  /** Optional `template.name` to pin as the hero, overriding the still-image auto-pick. */
+  heroTemplateName?: string;
   locale: Locale;
 }
 
-const { eyebrow, title, description, meta, primaryCta, secondaryCta, analytics, templates, locale } =
-  Astro.props;
+const {
+  eyebrow,
+  title,
+  description,
+  meta,
+  primaryCta,
+  secondaryCta,
+  analytics,
+  templates,
+  heroTemplateName,
+  locale,
+} = Astro.props;
 
 // Shared brand-solid / brand-outline buttons. Only external links open a new
 // tab; same-page anchors (e.g. "#workflows") must scroll in place.
@@ -42,7 +54,7 @@ const ctaButtons = [
   };
 });
 
-const heroTemplate = firstTemplateWithStill(templates);
+const heroTemplate = pickHeroTemplate(templates, heroTemplateName);
 const heroImage = firstStillThumbnail(heroTemplate?.thumbnails);
 const heroSrc = heroImage ? thumbnailPath(heroImage) : null;
 const heroLogos = heroTemplate ? resolveTemplateLogos(heroTemplate) : [];

--- a/site/src/lib/media-utils.ts
+++ b/site/src/lib/media-utils.ts
@@ -54,3 +54,23 @@ export function firstTemplateWithStill<T extends { thumbnails?: string[] }>(
 ): T | undefined {
   return templates.find((template) => hasStillThumbnail(template.thumbnails));
 }
+
+/**
+ * Hero pick that honors an optional pinned template name: a SEO page can force
+ * a specific workflow as its featured hero, overriding the usage-sorted default.
+ * Falls back to `firstTemplateWithStill` when the preferred name is absent from
+ * the grid or has no still thumbnail yet, so a preference never leaves the
+ * page heroless.
+ */
+export function pickHeroTemplate<T extends { name?: string; thumbnails?: string[] }>(
+  templates: T[],
+  preferredName?: string
+): T | undefined {
+  if (preferredName) {
+    const preferred = templates.find(
+      (template) => template.name === preferredName && hasStillThumbnail(template.thumbnails)
+    );
+    if (preferred) return preferred;
+  }
+  return firstTemplateWithStill(templates);
+}

--- a/site/src/lib/workflow-pages/use-cases.ts
+++ b/site/src/lib/workflow-pages/use-cases.ts
@@ -31,6 +31,13 @@ export interface SeoPageDef {
   keywords: KeywordModel;
   /** Catalog filters that select the page's template grid (usage-sorted, OR semantics). */
   filters: SeoPageFilters;
+  /**
+   * Optional `template.name` to pin as the hero card, overriding the default
+   * "first template with a still thumbnail" auto-pick. Silently falls back to
+   * the auto-pick when the named template is absent from the grid or lacks a
+   * still thumbnail — safe to set ahead of a pending hub thumbnail upload.
+   */
+  heroTemplateName?: string;
 }
 
 export const SEO_PAGES: SeoPageDef[] = [
@@ -140,6 +147,11 @@ export const SEO_PAGES: SeoPageDef[] = [
     filters: {
       tags: ['Character Reference', 'Lip Sync', 'Character Replacement', 'Character', 'Face Swap'],
     },
+    // Feature Kling: Avatar 2.0 as the hero — the current auto-pick (Kling O3:
+    // Reference to Video) has a broken hub thumbnail. Falls back to auto-pick
+    // until the hub thumbnail for `api_kling_avatar2` is re-uploaded as a still
+    // (animated .webp), so this line is safe to land ahead of that upstream fix.
+    heroTemplateName: 'api_kling_avatar2',
   },
   {
     slug: 'ai-image-to-video',

--- a/site/src/pages/workflows/use-cases/[slug].astro
+++ b/site/src/pages/workflows/use-cases/[slug].astro
@@ -13,7 +13,7 @@ import { inner, eyebrow, heading } from '../../../components/workflow-pages/land
 import { getLocaleFromPath, localizeUrl } from '../../../i18n/utils';
 import { t } from '../../../i18n/ui';
 import { resolveTemplateLogos } from '../../../lib/model-logos';
-import { firstStillThumbnail, firstTemplateWithStill } from '../../../lib/media-utils';
+import { firstStillThumbnail, pickHeroTemplate } from '../../../lib/media-utils';
 import { absoluteUrl } from '../../../config/site';
 import { useCasePath, useCasesIndexPath, modelPath } from '../../../lib/routes';
 import { getCloudCtaUrl, getCloudLandingUrl, getPricingUrl } from '../../../lib/urls';
@@ -102,7 +102,9 @@ const qualityContent = hasQualityContent ? content : null;
 const noindex = !isUseCasePageIndexable(templates.length, content);
 
 // The template whose still becomes the hero image — reserved so no section reuses it.
-const heroTemplate = firstTemplateWithStill(templates);
+// Honors `def.heroTemplateName` when set (with fallback), so the reserved-hero
+// exclusion downstream stays in sync with what LandingHero actually renders.
+const heroTemplate = pickHeroTemplate(templates, def.heroTemplateName);
 const heroTemplateName = heroTemplate?.name;
 const heroImage = firstStillThumbnail(heroTemplate?.thumbnails);
 
@@ -217,6 +219,7 @@ const relatedCards = resolveRailImages(
       secondaryCta={{ label: t('template.viewAllWorkflows', locale), href: '#workflows' }}
       analytics={{ location: `usecase_${def.slug}_hero`, template: leadShareId }}
       templates={templates}
+      heroTemplateName={def.heroTemplateName}
       locale={locale}
     />
 

--- a/site/tests/unit/media-utils.test.ts
+++ b/site/tests/unit/media-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isAudioFile, isMediaFile, isVideoFile } from '../../src/lib/media-utils';
+import { isAudioFile, isMediaFile, isVideoFile, pickHeroTemplate } from '../../src/lib/media-utils';
 
 describe('isVideoFile', () => {
   it.for([
@@ -37,5 +37,40 @@ describe('isMediaFile', () => {
     ['thumb.png', false],
   ] as [string, boolean][])('isMediaFile(%s) → %s', ([filename, expected]) => {
     expect(isMediaFile(filename)).toBe(expected);
+  });
+});
+
+describe('pickHeroTemplate', () => {
+  const stillA = { name: 'a', thumbnails: ['a.webp'] };
+  const videoOnly = { name: 'v', thumbnails: ['v.mp4'] };
+  const stillB = { name: 'b', thumbnails: ['b.png'] };
+  const noThumbs = { name: 'n' };
+
+  it('returns the first template with a still thumbnail when no preference is set', () => {
+    expect(pickHeroTemplate([videoOnly, stillA, stillB])).toBe(stillA);
+  });
+
+  it('honors preferredName when the named template has a still thumbnail', () => {
+    expect(pickHeroTemplate([videoOnly, stillA, stillB], 'b')).toBe(stillB);
+  });
+
+  it('falls back to the auto-pick when preferredName is unknown', () => {
+    expect(pickHeroTemplate([videoOnly, stillA, stillB], 'ghost')).toBe(stillA);
+  });
+
+  it('falls back to the auto-pick when the preferred template lacks a still thumbnail', () => {
+    expect(pickHeroTemplate([videoOnly, stillA], 'v')).toBe(stillA);
+  });
+
+  it('falls back to the auto-pick when the preferred template has no thumbnails at all', () => {
+    expect(pickHeroTemplate([noThumbs, stillA], 'n')).toBe(stillA);
+  });
+
+  it('returns undefined when no template has a still thumbnail', () => {
+    expect(pickHeroTemplate([videoOnly, noThumbs], 'v')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty grid', () => {
+    expect(pickHeroTemplate([], 'anything')).toBeUndefined();
   });
 });


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Summary

Two site changes:

1. **Fix the broken featured hero on [`/workflows/use-cases/ai-avatar-generator/`](https://comfy.org/workflows/use-cases/ai-avatar-generator/)** by pinning **Kling: Avatar 2.0** as the hero. Adds an optional `heroTemplateName` escape hatch on `SeoPageDef` so any use-case page can override the default usage-sorted `firstTemplateWithStill` auto-pick.
2. **Add "Use Cases"** as the top link in the **Resources** section of the site footer, pointing to `/workflows/use-cases/` (locale-aware).

## Root cause of the broken hero

The current hero on `/workflows/use-cases/ai-avatar-generator/` is `api_kling_o3_i2v` (Kling O3: Reference to Video) because it's the highest-usage template in the tag-filtered grid with a still (non-video) thumbnail. Its hub thumbnail URL:

```
https://comfy-hub-assets.comfy.org/templates/53d8d088-6078-4d12-98ae-a8e898cf6c06.webp
```

returns **HTTP 404**. That's the broken image users see.

Simply removing O3 from the grid isn't sufficient: `Kling: Avatar 2.0` (`api_kling_avatar2`) is what users expect featured, but its hub thumbnail is currently an `.mp4` only, so `firstTemplateWithStill` skips it. The site's `LandingHero` renders `<img>`, not `<video>`, so video-only thumbnails cannot be heroes today. (Note: the "video-looking" hero on `/workflows/use-cases/ai-image-upscaler/` is actually an **animated `.webp`**, not an mp4 — rendered in a plain `<img>`.)

## What this PR does

- **`SeoPageDef.heroTemplateName?: string`** — an optional pinned template name that wins over the usage-sorted `firstTemplateWithStill` auto-pick. Falls back to the auto-pick when the pinned template is missing from the grid or has no still thumbnail yet, so this is safe to land ahead of the hub-side upload.
- **`pickHeroTemplate(templates, preferredName?)`** — a shared helper (`site/src/lib/media-utils.ts`) so `[slug].astro`'s reserved-hero exclusion and `LandingHero.astro`'s rendering pick the same template. Unit-tested for pin-hit, pin-miss (unknown name / no still), and empty-grid cases (7 new tests).
- **Set `heroTemplateName: 'api_kling_avatar2'`** on the `ai-avatar-generator` entry.
- **Add "Use Cases" to the footer Resources section** as the top item, styled as an internal link (no external arrow). Uses `useCasesIndexPath(getLocaleFromPath(Astro.url.pathname))` so `/zh/...` pages get `/zh/workflows/use-cases/`, etc.

## Coordination with the hub side (Moubeen)

This PR ships the pin mechanism, but the hero on the live page will only visibly change **after the hub thumbnail for `api_kling_avatar2` is re-uploaded as a still image** — either an animated `.webp` (matches how the image-upscaler hero works today) or a plain still frame. Until then, `pickHeroTemplate` gracefully falls back to the current auto-pick, so the page is not made worse by merging this.

- **Ready-to-upload asset**: [`templates/api_kling_avatar2-1.webp`](/Comfy-Org/workflow_templates/blob/main/templates/api_kling_avatar2-1.webp) in this repo is already a **1.5 MB animated `.webp` with 56 frames** — exactly the file to upload as the hub thumbnail for `api_kling_avatar2`.
- **Also worth fixing on the hub side**: the current broken URL `templates/53d8d088-6078-4d12-98ae-a8e898cf6c06.webp` for `api_kling_o3_i2v` — the local repo file [`templates/api_kling_o3_i2v-1.webp`](/Comfy-Org/workflow_templates/blob/main/templates/api_kling_o3_i2v-1.webp) (animated `.webp`, 45 frames) is available.

## Verification

### Preview URL
Vercel will attach a preview URL when this PR is opened (see the "Vercel" bot comment below). The live change on that preview:
- `/workflows/use-cases/ai-avatar-generator/` — hero **falls back to the current broken O3 image until the hub upload lands** (documented behavior — the graceful fallback is the whole point of the escape hatch design).
- `/workflows/**` on all locales — Resources footer now includes "Use Cases" as the top link.

### Local simulation of the post-hub-upload state
I built the site with a locally-patched `hub-api.ts` that swaps in a still thumbnail for `api_kling_avatar2` (simulating Moubeen's future upload), then screenshot-verified the hero renders correctly. **This simulation patch was reverted before commit** — see the diff — the branch only contains the intentional changes.

**Before Moubeen's upload** (current fallback behavior on the preview URL — auto-pick returns the broken O3 image, exactly as documented in the code comment):

![Current state: broken auto-picked hero](https://placeholder-broken-hero.png)

**After Moubeen's upload** (simulated locally by injecting a still into `api_kling_avatar2`'s hub thumbnail — proves the pin works end-to-end):

![Simulated post-upload state: Kling Avatar 2.0 hero](https://placeholder-post-upload.png)

**Footer "Use Cases" link in Resources section**:

![Footer Use Cases link](https://placeholder-footer.png)

**Footer link navigates correctly to `/workflows/use-cases/`**:

![Footer link target page](https://placeholder-footer-target.png)

### Automated checks
- `pnpm run test` → **281 tests pass** (25 files, includes 7 new unit tests for `pickHeroTemplate`)
- `npx astro check` → 0 errors, 0 warnings on my changed files
- `npx eslint <changed files> --max-warnings 0` → clean
- `npx prettier --check <changed files>` → clean
- `pnpm run build` (with `PUBLIC_HUB_API_URL=https://cloud.comfy.org`) → 83s, complete, no errors

Pre-existing lint issue in `BaseLayout.astro:64` (`prefer-rest-params` on the GA gtag snippet — deliberate per PR #751 to preserve GA4 tracking) is unrelated to this PR.

## Files changed

- `site/src/lib/media-utils.ts` — new `pickHeroTemplate` helper (14 lines including jsdoc)
- `site/src/lib/workflow-pages/use-cases.ts` — new optional `SeoPageDef.heroTemplateName` field; set on ai-avatar-generator entry
- `site/src/pages/workflows/use-cases/[slug].astro` — use `pickHeroTemplate(templates, def.heroTemplateName)`; pass `heroTemplateName` down to `LandingHero`
- `site/src/components/workflow-pages/LandingHero.astro` — accept `heroTemplateName` prop; use `pickHeroTemplate`
- `site/src/components/hub/SiteFooter.astro` — add locale-aware "Use Cases" link at the top of Resources
- `site/tests/unit/media-utils.test.ts` — 7 new unit tests for `pickHeroTemplate`

## Follow-ups for whoever is doing the hub-side work

1. Upload `templates/api_kling_avatar2-1.webp` (from this repo) as the hub thumbnail for the `api_kling_avatar2` workflow.
2. Re-upload `templates/api_kling_o3_i2v-1.webp` as the hub thumbnail for `api_kling_o3_i2v` to fix that separate broken thumbnail.

Once (1) lands, the hero on `/workflows/use-cases/ai-avatar-generator/` will automatically switch to Kling: Avatar 2.0 without any further code changes.

## Screenshots

![Current state: broken auto-picked hero on /workflows/use-cases/ai-avatar-generator/ - the small broken-image icon inside an empty dark panel](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ce851841504a63e0b88f108d5348217f6789b850f91338afb411a728a2882cd9/pr-images/1784002583822-15bfc399-b1a3-4c93-9ce4-154684f83c64.png)

![Simulated post-upload state: Kling: Avatar 2.0 rendered as the hero after locally patching the hub API to serve a still thumbnail - proves the heroTemplateName pin works end-to-end](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ce851841504a63e0b88f108d5348217f6789b850f91338afb411a728a2882cd9/pr-images/1784002584145-eabbe085-fd20-44f0-acf1-b2e519237904.png)

![Footer with 'Use Cases' as the top link in the Resources section, alongside Blog, Discord, Github, Docs, YouTube](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ce851841504a63e0b88f108d5348217f6789b850f91338afb411a728a2882cd9/pr-images/1784002584491-ab5bb056-c491-408d-aa7c-08ef5f3c1ef2.png)

![Clicking the footer 'Use Cases' link navigates to /workflows/use-cases/ - the Use Cases index page](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ce851841504a63e0b88f108d5348217f6789b850f91338afb411a728a2882cd9/pr-images/1784002584828-1b06e24d-1a5f-4f1a-bdbe-0f5c91f45b7f.png)