### PR TITLE
Fix/hub card try now anchor

### DIFF
--- a/site/src/components/hub/HubWorkflowCard.vue
+++ b/site/src/components/hub/HubWorkflowCard.vue
@@ -347,7 +347,10 @@ function handleCardClick() {
       <h3
         class="absolute bottom-5 left-5 right-5 z-10 font-medium text-content-bright text-base leading-[1.3] line-clamp-2 drop-shadow-md pointer-events-none sm:text-lg lg:text-xl"
       >
-        {{ title }}
+        <a v-if="templateUrl" :href="templateUrl" class="pointer-events-auto" @click.stop>
+          {{ title }}
+        </a>
+        <template v-else>{{ title }}</template>
       </h3>
 
       <!-- Glass model badges — mirrors ModelBadges.astro; keep the classes in sync. -->
@@ -386,13 +389,13 @@ function handleCardClick() {
 
         <ButtonPill
           v-if="templateUrl"
-          as="button"
-          type="button"
+          as="a"
+          :href="templateUrl"
           variant="solid"
           mode="reveal"
           class="shrink-0"
           :aria-label="title"
-          @click.stop="handleCardClick"
+          @click.stop
         >
           Try now
         </ButtonPill>

--- a/site/src/components/hub/HubWorkflowCard.vue
+++ b/site/src/components/hub/HubWorkflowCard.vue
@@ -347,7 +347,13 @@ function handleCardClick() {
       <h3
         class="absolute bottom-5 left-5 right-5 z-10 font-medium text-content-bright text-base leading-[1.3] line-clamp-2 drop-shadow-md pointer-events-none sm:text-lg lg:text-xl"
       >
-        <a v-if="templateUrl" :href="templateUrl" class="pointer-events-auto" @click.stop>
+        <a
+          v-if="templateUrl"
+          :href="templateUrl"
+          class="pointer-events-auto"
+          data-testid="workflow-card-link"
+          @click.stop
+        >
           {{ title }}
         </a>
         <template v-else>{{ title }}</template>

--- a/site/tests/e2e.spec.ts
+++ b/site/tests/e2e.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: get the first template card link from the workflow listing.
- * HubWorkflowCard renders a stretched link with aria-hidden="true"
- * pointing to /workflows/{template_name}/.
+ * Targets the card title anchor by test id — creator links share the
+ * /workflows/ prefix, so an href-only selector matches those too.
  */
 function templateCardLink(page: import('@playwright/test').Page) {
-  return page.locator('main a[aria-hidden="true"][href^="/workflows/"]').first();
+  return page.locator('main a[data-testid="workflow-card-link"]').first();
 }
 
 test.describe('Homepage', () => {


### PR DESCRIPTION
## Summary

Clicking "Try now" on a workflow card did nothing for some users on production — most often on slower connections or a cold cache. The card CTA was a JavaScript-only button, so it stayed dead until the browse island finished hydrating; anyone who clicked during that window got silence. The card title and its CTA are now real links, so they work from first paint with no JavaScript at all.

## Changes

**What**

- The "Try now" pill is now a link instead of a button. Previously the only path to the workflow page was a click handler assigning `window.location.href`, which needs Vue booted before it does anything. The pill now carries the destination in its markup, so the browser handles the click itself — and middle-click, ⌘-click and "open in new tab" start working, none of which a button ever supported.
- The card title is a link too, which gives every card a crawlable path to its workflow page in the server-rendered HTML rather than one reachable only by running JavaScript.
- Clicking anywhere else on the card still works exactly as before. That handler is untouched and remains the click-anywhere affordance; the new links stop propagation so a click on the title or pill doesn't also fire it and trigger a double navigation.

**Breaking**

None. Same destinations, same URL builder, same visual treatment and reveal animation. The button carried no analytics, so nothing was lost in the swap. The empty-URL case still degrades to plain text rather than an empty link.