### PR TITLE
fix(sync): install jsonschema in the run-click refresh workflow

### DIFF
--- a/.github/workflows/refresh-run-click-usage.yml
+++ b/.github/workflows/refresh-run-click-usage.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Fetch run_clicks and fold into index.json
         run: |
+          pip install jsonschema # sync_data.py imports validate_templates, which needs it
           python scripts/sync/fetch_algolia_usage.py --templates-dir templates
           python scripts/sync/sync_data.py --templates-dir templates
 


### PR DESCRIPTION
## Summary

Fixes the "Refresh Run-Click Usage" workflow, which failed on its first CI run at the fold step.

## Changes

**What:**
- The refresh job crashed with `jsonschema package not installed`. The fetch succeeded (439 run_clicks written), but the fold step runs `sync_data.py`, which imports `validate_templates` and exits when `jsonschema` isn't present. The step now installs it first, matching what the validate workflows already do.

**Breaking:** None.

## Review Focus

One-line fix, scoped to the new workflow. Mirrors the `pip install jsonschema` step in `validate-templates.yml` rather than declaring a new dependency, since the repo installs it ad-hoc per workflow.

## Testing

Reproduced the exact CI error locally by running the fold with `jsonschema` blocked (exit 1), then confirmed the full fetch → fold flow runs clean with it installed (coverage 413/549, Seedance usage updated). Verify: re-run the workflow via `workflow_dispatch` and confirm it proceeds past the fold to "Open PR".
