### PR TITLE
chore: refresh template usage from Algolia run_clicks

### DIFF
--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "نموذج خفيف الوزن 2B يولد صورًا عالية الجودة البصرية من التلميحات الإنجليزية والروسية.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["صوت","استنساخ الصوت"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["صوت","تحويل النص إلى كلام","استنساخ الصوت"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Un modelo ligero de 2B que genera imágenes de alta calidad visual a partir de indicaciones en inglés y ruso.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["Audio","Clonación de Voz"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["Audio","Texto a voz","Clonación de Voz"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "یک مدل سبک ۲ میلیارد پارامتری که از پرامپت‌های انگلیسی و روسی با کیفیت بصری بالا تصویر تولید می‌کند.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["صدا","همانندسازی صدا"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["صدا","متن به گفتار","همانندسازی صدا"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Un modèle léger de 2B qui génère des images de haute qualité visuelle à partir de prompts en anglais et russe.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["Audio","Clonage Vocal"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["Audio","Synthèse vocale","Clonage Vocal"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "英語とロシア語のプロンプトから高視覚品質の画像を生成する軽量2Bモデル。",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["オーディオ","音声クローニング"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["オーディオ","テキスト読み上げ","音声クローニング"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.json
+++ b/templates/index.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "A lightweight 2B model that generates images from English and Russian prompts with high visual quality.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["Audio","Voice Cloning"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["Audio","Text to Speech","Voice Cloning"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "영어와 러시아어 프롬프트에서 고품질 시각 이미지를 생성하는 경량 2B 모델。",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["오디오","음성 복제"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["오디오","텍스트 음성 변환","음성 복제"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Um modelo leve de 2B que gera imagens de alta qualidade visual a partir de prompts em inglês e russo.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["Áudio","Clonagem de Voz"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["Áudio","Texto para Fala","Clonagem de Voz"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Легковесная 2B-модель, создающая качественные изображения по текстовым подсказкам на английском и русском языках.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["Аудио","Клонирование Голоса"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["Аудио","Преобразование текста в речь","Клонирование Голоса"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "İngilizce ve Rusça istemlerden yüksek görsel kalitesinde görüntüler üreten hafif 2B model.",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["Ses","Ses Klonlama"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["Ses","Metinden Sese","Ses Klonlama"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "輕量級 2B 模型，從英文和俄文提示生成高視覺品質影像。",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["音頻","語音克隆"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["音頻","文字轉語音","語音克隆"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 7258,
+        "usage": 15075,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2068,
+        "usage": 262,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 7571,
+        "usage": 389,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1115,
+        "usage": 686,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2345,
+        "usage": 2054,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -298,7 +298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7318,
+        "usage": 1051,
         "io": {
           "inputs": [
             {
@@ -409,7 +409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2334,
+        "usage": 310,
         "io": {
           "inputs": [
             {
@@ -496,7 +496,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2564,
+        "usage": 706,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -715,7 +715,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2597,
+        "usage": 1229,
         "io": {
           "inputs": [
             {
@@ -782,7 +782,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1164,
+        "usage": 476,
         "io": {
           "inputs": [
             {
@@ -870,7 +870,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 681,
+        "usage": 448,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -957,7 +957,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1279,
+        "usage": 134,
         "io": {
           "outputs": [
             {
@@ -1089,7 +1089,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 1065,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1172,7 +1172,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 601,
+        "usage": 461,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1227,7 +1227,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 587,
+        "usage": 287,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1260,7 +1260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 288,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1492,7 +1492,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 285,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1576,7 +1576,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 964,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1595,7 +1595,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 6,
+        "usage": 162,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1637,7 +1637,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 565,
+        "usage": 256,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1703,7 +1703,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1732,7 +1732,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 131,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1766,7 +1766,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1795,7 +1795,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 242,
+        "usage": 104,
         "io": {
           "inputs": [
             {
@@ -1851,7 +1851,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1877,7 +1877,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1249,
+        "usage": 556,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -1913,7 +1913,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 553,
+        "usage": 122,
         "io": {
           "inputs": [
             {
@@ -1941,7 +1941,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 90,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1981,7 +1981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2039,7 +2039,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2054,7 +2054,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 175,
+        "usage": 82,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2084,7 +2084,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 747,
+        "usage": 108,
         "io": {
           "inputs": [
             {
@@ -2118,7 +2118,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 155,
+        "usage": 35,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2147,7 +2147,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 622,
+        "usage": 110,
         "io": {
           "inputs": [
             {
@@ -2190,7 +2190,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1200,
+        "usage": 129,
         "io": {
           "inputs": [
             {
@@ -2233,7 +2233,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 607,
+        "usage": 162,
         "io": {
           "inputs": [
             {
@@ -2270,7 +2270,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 254,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -2310,7 +2310,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2343,7 +2343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2378,7 +2378,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 49,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2406,7 +2406,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 411,
+        "usage": 139,
         "io": {
           "inputs": [
             {
@@ -2443,7 +2443,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 129,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2479,7 +2479,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 4,
+        "usage": 39,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2520,7 +2520,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2569,7 +2569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -2599,7 +2599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 20,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2621,7 +2621,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 55,
+        "usage": 33,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2646,7 +2646,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 55,
+        "usage": 11,
         "io": {
           "outputs": [
             {
@@ -2732,7 +2732,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 133,
+        "usage": 53,
         "io": {
           "outputs": [
             {
@@ -2760,7 +2760,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 469,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -2788,7 +2788,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 434,
+        "usage": 172,
         "io": {
           "outputs": [
             {
@@ -2815,7 +2815,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 228,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -2856,7 +2856,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 550,
+        "usage": 152,
         "username": "ComfyUI"
       },
       {
@@ -2872,7 +2872,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 166,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -2898,7 +2898,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 428,
+        "usage": 136,
         "io": {
           "outputs": [
             {
@@ -2926,7 +2926,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 86,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -2951,7 +2951,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 108,
+        "usage": 109,
         "io": {
           "outputs": [
             {
@@ -2977,7 +2977,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "轻量级 2B 模型，从英语和俄语提示生成高质量视觉图像。",
         "date": "2026-02-03",
-        "usage": 10,
+        "usage": 11,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3006,7 +3006,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 72,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3035,7 +3035,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 229,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3061,7 +3061,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 162,
+        "usage": 82,
         "io": {
           "inputs": [
             {
@@ -3086,7 +3086,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -3110,7 +3110,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 31,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3151,7 +3151,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 94,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3186,7 +3186,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 63,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -3211,7 +3211,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 77,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3248,7 +3248,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 88,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3283,7 +3283,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 173,
+        "usage": 44,
         "username": "ComfyUI"
       },
       {
@@ -3298,7 +3298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 26,
         "username": "ComfyUI"
       },
       {
@@ -3314,7 +3314,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3338,7 +3338,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 285,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3368,7 +3368,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3394,7 +3394,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 106,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -3421,7 +3421,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3447,7 +3447,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 125,
+        "usage": 106,
         "username": "ComfyUI"
       },
       {
@@ -3463,7 +3463,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 60,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3499,7 +3499,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 77,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -3526,7 +3526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 290,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -3566,7 +3566,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 62,
+        "usage": 176,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3594,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3620,7 +3620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3644,7 +3644,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 57,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3693,7 +3693,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 33,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -3720,7 +3720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 108,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -3757,7 +3757,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 138,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3788,7 +3788,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 111,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3803,7 +3803,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 56,
+        "usage": 26,
         "io": {
           "outputs": [
             {
@@ -3832,7 +3832,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3899,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 31,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3936,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 115,
+        "usage": 83,
         "io": {
           "inputs": [
             {
@@ -3963,7 +3963,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 18,
+        "usage": 6,
         "io": {
           "outputs": [
             {
@@ -3991,7 +3991,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 39,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -4019,7 +4019,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "outputs": [
             {
@@ -4049,7 +4049,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4075,7 +4075,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 51,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4111,7 +4111,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 101,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4144,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -4170,7 +4170,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4211,7 +4211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 4,
         "io": {
           "outputs": [
             {
@@ -4244,7 +4244,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 16,
         "io": {
           "outputs": [
             {
@@ -4276,7 +4276,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4291,7 +4291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4306,7 +4306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 29,
         "username": "ComfyUI"
       },
       {
@@ -4321,7 +4321,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -4336,7 +4336,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 140,
+        "usage": 32,
         "username": "ComfyUI"
       },
       {
@@ -4353,7 +4353,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 104,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -4380,7 +4380,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 124,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4411,7 +4411,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 4,
+        "usage": 8,
         "io": {
           "outputs": [
             {
@@ -4440,7 +4440,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 3,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4466,7 +4466,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -4521,7 +4521,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6400,
+        "usage": 1346,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4547,7 +4547,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1504,
+        "usage": 1572,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4593,7 +4593,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2971,
+        "usage": 38951,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4722,7 +4722,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1955,
+        "usage": 10877,
         "io": {
           "inputs": [
             {
@@ -4761,7 +4761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 1004,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -4974,7 +4974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 988,
+        "usage": 973,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5014,7 +5014,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 484,
+        "usage": 1266,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5087,7 +5087,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 1068,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5209,7 +5209,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3989,
+        "usage": 1243,
         "io": {
           "inputs": [
             {
@@ -5312,7 +5312,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 744,
+        "usage": 401,
         "io": {
           "inputs": [
             {
@@ -5343,7 +5343,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 401,
+        "usage": 133,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5576,7 +5576,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 133,
+        "usage": 83,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5618,7 +5618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 97,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5664,7 +5664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 69,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5699,7 +5699,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1398,
+        "usage": 1105,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5726,7 +5726,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 293,
+        "usage": 1191,
         "username": "ComfyUI"
       },
       {
@@ -5775,7 +5775,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 78,
+        "usage": 96,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -5808,7 +5808,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 601,
+        "usage": 158,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5848,7 +5848,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 432,
+        "usage": 1004,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6168,7 +6168,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6214,7 +6214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 77,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6240,7 +6240,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 22,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6285,7 +6285,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 103,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6327,7 +6327,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 215,
+        "usage": 153,
         "io": {
           "inputs": [
             {
@@ -6367,7 +6367,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 111,
+        "usage": 76,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6409,7 +6409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 207,
         "io": {
           "inputs": [
             {
@@ -6440,7 +6440,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 383,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6513,7 +6513,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 61,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6550,7 +6550,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 161,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6599,7 +6599,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6625,7 +6625,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 132,
+        "usage": 59,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6659,7 +6659,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 399,
+        "usage": 215,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6693,7 +6693,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 29,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6733,7 +6733,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6801,7 +6801,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 210,
+        "usage": 160,
         "io": {
           "inputs": [
             {
@@ -6832,7 +6832,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 108,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6863,7 +6863,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -6877,7 +6877,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 19,
+        "usage": 101,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -6911,7 +6911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 369,
+        "usage": 317,
         "io": {
           "inputs": [
             {
@@ -6934,7 +6934,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 241,
+        "usage": 697,
         "io": {
           "inputs": [
             {
@@ -6965,7 +6965,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -6988,7 +6988,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 129,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -7012,7 +7012,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 93,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7040,7 +7040,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 82,
+        "usage": 30,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7072,7 +7072,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 74,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7089,7 +7089,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7122,7 +7122,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 56,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7154,7 +7154,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 179,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7187,7 +7187,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 160,
+        "usage": 223,
         "io": {
           "inputs": [
             {
@@ -7214,7 +7214,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 181,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -7243,7 +7243,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 45,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7281,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 271,
+        "usage": 225,
         "io": {
           "inputs": [
             {
@@ -7313,7 +7313,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -7423,7 +7423,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 155,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -7446,7 +7446,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 22,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7476,7 +7476,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 254,
+        "usage": 195,
         "io": {
           "inputs": [
             {
@@ -7501,7 +7501,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 66,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -7533,7 +7533,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 175,
+        "usage": 86,
         "io": {
           "inputs": [
             {
@@ -7567,7 +7567,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -7597,7 +7597,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 28,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -7626,7 +7626,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 19,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7641,7 +7641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -7666,7 +7666,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 28,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7698,7 +7698,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7723,7 +7723,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 174,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -7749,7 +7749,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -7763,7 +7763,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 44,
+        "usage": 84,
         "io": {
           "outputs": [
             {
@@ -7792,7 +7792,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 55,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -7823,7 +7823,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 53,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -7848,7 +7848,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 45,
+        "usage": 153,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7894,7 +7894,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 28,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -7920,7 +7920,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 18,
+        "usage": 12,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -7946,7 +7946,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 10,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7978,7 +7978,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 34,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -8002,7 +8002,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 87,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -8045,7 +8045,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 18,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 45,
+        "usage": 80,
         "username": "ComfyUI"
       },
       {
@@ -8123,7 +8123,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 48,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8149,7 +8149,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8186,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 87,
+        "usage": 307,
         "io": {
           "inputs": [
             {
@@ -8211,7 +8211,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8228,7 +8228,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8260,7 +8260,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8285,7 +8285,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 28,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8315,7 +8315,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 37,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8340,7 +8340,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 6,
+        "usage": 14,
         "username": "ComfyUI"
       },
       {
@@ -8356,7 +8356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -8382,7 +8382,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8408,7 +8408,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8439,7 +8439,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 50,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -8480,7 +8480,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 11,
+        "usage": 4,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8498,7 +8498,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 41,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8533,7 +8533,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 56,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8569,7 +8569,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 10,
         "username": "ComfyUI"
       },
       {
@@ -8598,7 +8598,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 20,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -8614,7 +8614,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -8666,7 +8666,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 5,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8691,7 +8691,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8707,7 +8707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "username": "ComfyUI"
       },
       {
@@ -8723,7 +8723,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8739,7 +8739,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8769,7 +8769,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8825,7 +8825,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 16,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -8857,7 +8857,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 1,
         "io": {
           "inputs": [
             {
@@ -8883,7 +8883,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -8923,7 +8923,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 38,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -8939,7 +8939,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -8955,7 +8955,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8981,7 +8981,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9006,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 13,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9031,7 +9031,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 19,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9046,7 +9046,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 3,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9071,7 +9071,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9102,7 +9102,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 17,
+        "usage": 53,
         "username": "ComfyUI"
       }
     ]
@@ -9161,7 +9161,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2432,
+        "usage": 946,
         "io": {
           "inputs": [
             {
@@ -9514,7 +9514,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 636,
+        "usage": 497,
         "io": {
           "inputs": [
             {
@@ -9655,7 +9655,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 353,
+        "usage": 297,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9703,7 +9703,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 92,
+        "usage": 279,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9782,7 +9782,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 10,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9809,7 +9809,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 81,
+        "usage": 51,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9904,7 +9904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 138,
+        "usage": 57,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9949,7 +9949,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 77,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9987,7 +9987,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10055,7 +10055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 32,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10169,7 +10169,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 76,
+        "usage": 142,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10210,7 +10210,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 43,
+        "usage": 712,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10237,7 +10237,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 5,
         "searchRank": 0,
         "username": "PurzBeats",
         "requiresCustomNodes": ["comfyui_fill-nodes"],
@@ -10278,7 +10278,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 54,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10358,7 +10358,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 105,
+        "usage": 99,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10385,7 +10385,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 17,
+        "usage": 15,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10458,7 +10458,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 43,
+        "usage": 131,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -10480,7 +10480,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 86,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10522,7 +10522,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10561,7 +10561,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 51,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10613,7 +10613,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 77,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10639,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 222,
+        "usage": 102,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10674,7 +10674,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 113,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10720,7 +10720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10763,7 +10763,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 399,
+        "usage": 469,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10805,7 +10805,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 49,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10839,7 +10839,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 89,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10887,7 +10887,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 15,
+        "usage": 64,
         "searchRank": 0,
         "username": "shane"
       },
@@ -10976,7 +10976,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 35,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11017,7 +11017,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11050,7 +11050,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 174,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11082,7 +11082,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 92,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -11117,7 +11117,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -11160,7 +11160,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 23,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11188,7 +11188,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 100,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11226,7 +11226,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 18,
+        "usage": 59,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11268,7 +11268,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11296,7 +11296,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11337,7 +11337,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 25,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11430,7 +11430,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 79,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11470,7 +11470,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 124,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11511,7 +11511,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 17,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11543,7 +11543,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11622,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 142,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11681,7 +11681,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 328,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -11740,7 +11740,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 75,
         "io": {
           "inputs": [
             {
@@ -11766,7 +11766,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 76,
         "io": {
           "inputs": [
             {
@@ -11829,7 +11829,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 198,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11855,7 +11855,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 14,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -11899,7 +11899,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 67,
+        "usage": 226,
         "logos": [
           {
             "provider": "Google"
@@ -11938,7 +11938,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 48,
         "logos": [
           {
             "provider": "ByteDance"
@@ -11989,7 +11989,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 429,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12028,7 +12028,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 45,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12060,7 +12060,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 16,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12096,7 +12096,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 42,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -12123,7 +12123,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12156,7 +12156,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 12,
+        "usage": 52,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12201,7 +12201,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -12226,7 +12226,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 7,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12259,7 +12259,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 15,
+        "usage": 6,
         "logos": [
           {
             "provider": "Google"
@@ -12291,7 +12291,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 36,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12339,7 +12339,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12383,7 +12383,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper","comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 25,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -12419,7 +12419,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 94,
         "logos": [
           {
             "provider": "Google"
@@ -12457,7 +12457,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12496,7 +12496,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 38,
         "logos": [
           {
             "provider": "Google"
@@ -12536,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12572,7 +12572,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 3,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -12604,7 +12604,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -12642,7 +12642,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12682,7 +12682,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 11,
         "logos": [
           {
             "provider": "Google"
@@ -12719,7 +12719,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 17,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12768,7 +12768,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 8,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12797,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 4,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -12859,7 +12859,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 39,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12903,7 +12903,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 6,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling","Google"]
@@ -13119,7 +13119,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 1,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13136,7 +13136,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 452,
+        "usage": 44,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13152,7 +13152,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 181,
+        "usage": 30,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13173,7 +13173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 692,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13205,7 +13205,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13237,7 +13237,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13276,7 +13276,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13308,7 +13308,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13340,7 +13340,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13367,7 +13367,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 41,
+        "usage": 18,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13399,7 +13399,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 24,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13425,7 +13425,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 14,
+        "usage": 60,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13441,7 +13441,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 27,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13457,7 +13457,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13472,7 +13472,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 103,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -13497,7 +13497,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 135,
+        "usage": 94,
         "searchRank": 0,
         "tags": ["音频","语音克隆"],
         "io": {
@@ -13524,7 +13524,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "searchRank": 0,
         "tags": ["音频","文本转语音","语音克隆"],
         "io": {
@@ -13558,7 +13558,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13590,7 +13590,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 23,
+        "usage": 14,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13607,7 +13607,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -13632,7 +13632,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 10,
+        "usage": 4,
         "username": "ComfyUI"
       },
       {
@@ -13647,7 +13647,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13669,7 +13669,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 258,
+        "usage": 169,
         "io": {
           "inputs": [
             {
@@ -13884,7 +13884,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 91,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -13930,7 +13930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13973,7 +13973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13987,7 +13987,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 18,
+        "usage": 42,
         "username": "ComfyUI"
       },
       {
@@ -14008,7 +14008,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14088,7 +14088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14131,7 +14131,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14158,7 +14158,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14174,7 +14174,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 11,
         "username": "ComfyUI"
       },
       {
@@ -14190,7 +14190,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14206,7 +14206,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14232,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14264,7 +14264,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14290,7 +14290,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14316,7 +14316,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -14353,7 +14353,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 141,
+        "usage": 113,
         "io": {
           "inputs": [
             {
@@ -14378,7 +14378,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 21,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14404,7 +14404,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 57,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -14448,7 +14448,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 59,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -14497,7 +14497,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14519,7 +14519,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png","thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14725,7 +14725,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 95,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -14753,7 +14753,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 236,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -14771,7 +14771,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -14803,7 +14803,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -14877,7 +14877,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 403,
+        "usage": 198,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14915,7 +14915,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 615,
+        "usage": 727,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14951,7 +14951,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 399,
+        "usage": 131,
         "searchRank": 0,
         "logos": [
           {
@@ -14996,7 +14996,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 166,
+        "usage": 110,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15037,7 +15037,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 306,
+        "usage": 127,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15147,7 +15147,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 211,
+        "usage": 246,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15257,7 +15257,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 145,
+        "usage": 120,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15780,7 +15780,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 28,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15908,7 +15908,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 8,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15934,7 +15934,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 11,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -15962,7 +15962,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 48,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16055,7 +16055,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 19,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16088,7 +16088,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16123,7 +16123,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 1,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16160,7 +16160,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 266,
+        "usage": 141,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16275,7 +16275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 47,
         "searchRank": 0,
         "logos": [
           {
@@ -16307,7 +16307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 31,
         "searchRank": 0,
         "logos": [
           {
@@ -16339,7 +16339,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 87,
         "searchRank": 0,
         "logos": [
           {
@@ -16427,7 +16427,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 75,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16454,7 +16454,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 91,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16486,7 +16486,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 41,
         "searchRank": 0,
         "logos": [
           {
@@ -16600,7 +16600,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 67,
         "searchRank": 0,
         "logos": [
           {
@@ -16641,7 +16641,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16721,7 +16721,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 88,
+        "usage": 62,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16754,7 +16754,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 78,
+        "usage": 44,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -16780,7 +16780,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 34,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -16808,7 +16808,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 29,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -16832,7 +16832,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -16879,7 +16879,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 154,
+        "usage": 134,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -16920,7 +16920,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -16950,7 +16950,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 77,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -17011,7 +17011,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 53,
+        "usage": 285,
         "io": {
           "inputs": [
             {
@@ -17039,7 +17039,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 20,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17068,7 +17068,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 21,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -17097,7 +17097,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 5,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -17120,7 +17120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 6,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17146,7 +17146,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 30,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -17184,7 +17184,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17229,7 +17229,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 1,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17245,7 +17245,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1187,
+        "usage": 302,
         "io": {
           "outputs": [
             {
@@ -17274,7 +17274,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 1,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17319,7 +17319,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 268,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -17363,7 +17363,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 7,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17405,7 +17405,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 104,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -17437,7 +17437,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 96,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17494,7 +17494,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 176,
+        "usage": 42,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17531,7 +17531,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 104,
+        "usage": 108,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17572,7 +17572,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 93,
+        "usage": 86,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17614,7 +17614,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 122,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17657,7 +17657,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 359,
+        "usage": 79,
         "io": {
           "outputs": [
             {
@@ -17685,7 +17685,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1579,
+        "usage": 205,
         "io": {
           "inputs": [
             {
@@ -17722,7 +17722,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1565,
+        "usage": 1920,
         "io": {
           "inputs": [
             {
@@ -17758,7 +17758,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 65,
+        "usage": 339,
         "io": {
           "inputs": [
             {
@@ -17785,7 +17785,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 31,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17802,7 +17802,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 807,
+        "usage": 383,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -17898,7 +17898,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 32,
+        "usage": 56,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17914,7 +17914,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 6,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17967,7 +17967,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 51,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -17985,7 +17985,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],


### PR DESCRIPTION
Automated biweekly refresh of `usage` from the Algolia `templates_index` (real PostHog run-clicks). Merging triggers the normal version bump + PyPI publish.

_Raised manually (same steps as the Refresh Run-Click Usage workflow) while the workflow's push token is being granted write access._