### PR TITLE
refactor(sync): refresh template usage on template PRs

### DIFF
--- a/.github/workflows/refresh-run-click-usage.yml
+++ b/.github/workflows/refresh-run-click-usage.yml
@@ -2,37 +2,37 @@ name: Refresh Run-Click Usage
 
 # Fetches fresh per-template run_clicks from the Algolia templates_index and folds
 # them into templates/index*.json (the `usage` field the cloud/desktop pickers rank
-# on). Opens a PR rather than committing to main, so the existing version-check +
-# publish flow ships it with a human merge. Runs biweekly (1st & 15th) and on demand.
+# on), committing the result back to the PR branch.
 #
 # The website (templates.comfy.org) refreshes its own ranking separately via
 # cron-rebuild-site.yml — this workflow is only for the published package.
 
 on:
-  schedule:
-    - cron: '0 0 1,15 * *' # biweekly: 1st and 15th, 00:00 UTC
-  workflow_dispatch: # manual/immediate refresh
-
-concurrency:
-  group: refresh-run-click-usage
-  cancel-in-progress: false
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'templates/**.json'
 
 permissions:
-  contents: write # push the refresh branch
-  pull-requests: write # open the refresh PR
+  contents: write
 
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    # Only run on same-repo PRs (fork PRs can't auto-commit)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    concurrency:
+      group: refresh-run-click-usage-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     env:
       ALGOLIA_APP_ID: 4E0RO38HS8
       ALGOLIA_API_KEY: 684d998c36b67a9a9fce8fc2d8860579
-      GH_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
-      - name: Checkout
+      - name: Checkout PR
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -46,24 +46,34 @@ jobs:
           python scripts/sync/fetch_algolia_usage.py --templates-dir templates
           python scripts/sync/sync_data.py --templates-dir templates
 
-      - name: Open PR if usage changed
+      - name: Commit usage updates to PR
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add templates/index*.json
           if git diff --cached --quiet; then
-            echo "No run-click usage changes — nothing to open."
+            echo "✅ No run-click usage changes needed"
             exit 0
           fi
-          # Supersede any prior open refresh PR so they don't pile up.
-          gh pr list --search "head:chore/refresh-run-click-usage" --state open \
-            --json number -q '.[].number' | xargs -r -n1 gh pr close --delete-branch
-          BRANCH="chore/refresh-run-click-usage-${{ github.run_id }}"
-          git checkout -b "$BRANCH"
-          git commit -m "chore: refresh template usage from Algolia run_clicks"
-          git push origin "$BRANCH"
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore: refresh template usage from Algolia run_clicks" \
-            --body "Automated biweekly refresh of \`usage\` from the Algolia \`templates_index\` (real PostHog run-clicks). Merging triggers the normal version bump + PyPI publish."
+
+          if ! git commit -m "Auto-sync template usage from Algolia run_clicks"; then
+            echo "⚠️ Commit failed, retrying after rebase..."
+            if ! git pull origin "${{ github.head_ref }}" --rebase; then
+              echo "❌ Rebase failed due to conflicts. Manual intervention required."
+              git status
+              exit 1
+            fi
+            git commit -m "Auto-sync template usage from Algolia run_clicks"
+          fi
+
+          if ! git push origin HEAD; then
+            echo "⚠️ Push failed, retrying after pull..."
+            if ! git pull origin "${{ github.head_ref }}" --rebase; then
+              echo "❌ Rebase failed due to conflicts. Manual intervention required."
+              git status
+              exit 1
+            fi
+            git push origin HEAD
+          fi
+
+          echo "✅ Template usage updates committed to PR"


### PR DESCRIPTION
## Summary

The usage refresh now runs on template PRs and commits the updated numbers to the PR branch, instead of trying to write to main on a schedule.

## Changes

**What:**
- The scheduled version couldn't land its changes: main requires a pull request (repository ruleset), and Actions isn't permitted to open one, so both the direct push and the PR attempt failed in CI. It now triggers on PRs that touch template JSON and commits the refreshed usage onto that branch — the same shape as `sync-custom-nodes` and the version bump.

**Breaking:** None. The fetch and fold steps are unchanged.

## Review Focus

Uses the built-in token, so no new secrets. Worth knowing: usage now refreshes as a side effect of template PRs rather than on a clock — a standalone scheduled refresh would need the Cloud Code Bot credentials (`APP_ID` + `CLOUD_CODE_BOT_PRIVATE_KEY`), which this repo doesn't have.

## Testing

Ran the workflow's steps locally against the live index: fetch pulled 439 run_clicks, the fold reported 413/571 coverage, staging picked up only the 12 index files, and a second run produced no further changes. Two earlier CI runs confirmed the failure modes this replaces.