### PR TITLE
Add Use Cases link to site footer Product column

### DIFF
--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -144,6 +144,14 @@
                 Template
               </a>
             </li>
+            <li>
+              <a
+                href="/workflows/use-cases/"
+                class="text-content-secondary text-sm hover:text-content transition-colors"
+              >
+                Use Cases
+              </a>
+            </li>
           </ul>
         </div>
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## What

Adds a **Use Cases** link to the `Product` column of the site footer, pointing at `/workflows/use-cases/` (i.e. https://comfy.org/workflows/use-cases/).

The use-cases index page has existed for a while (`site/src/pages/workflows/use-cases/index.astro`) but was not reachable from the footer, so it was missing from site navigation entirely.

## Where

`site/src/components/hub/SiteFooter.astro` — the footer rendered on every `/workflows/*` page (hub index, template detail, category, tag, model, creators, use-case pages, and their localized variants via `SeoIndexPage`), so the link appears site-wide on the workflows hub.

Placed directly after the existing `Template` entry, matching that entry's markup exactly: root-relative internal href (no `target="_blank"`, no external-link icon) and the same `text-content-secondary text-sm hover:text-content transition-colors` classes.

Note: the link is intentionally **not** locale-prefixed. Every other footer link is unlocalized, and `/{locale}/workflows/use-cases/` routes do not exist (only `[locale]/workflows/{index,[slug],category,model,tag,creators}`), so a localized href would 404.

## Verification

- `pnpm exec eslint src/components/hub/SiteFooter.astro` → clean
- `pnpm exec prettier --check src/components/hub/SiteFooter.astro` → clean
- `pnpm run check` (astro check) → 0 errors, 0 warnings
- `pnpm test` → 27 files / 303 tests passing
- Repo-wide `pnpm run lint` / `format:check` failures (`BaseLayout.astro` `prefer-rest-params`, `[username].astro` prettier parse error, unformatted `creators.astro` / test files) are pre-existing on `main` — confirmed by re-running on the base commit — and untouched here.
- Manual QA against `astro dev`: footer renders the new link under `Product` on desktop (1280px) and mobile (390px, 2-column layout) with no layout shift or clipping; clicking it navigates to `/workflows/use-cases/` (Use Cases index renders, 0 console errors). Live `https://comfy.org/workflows/use-cases/` also returns 200, so the target is valid in production.
- Visual regression snapshots not updated: the `Visual Regression (Site)` workflow is currently disabled (`if: false`), and this change adds one row to the tallest footer column.


## Screenshots

![Site footer at 1280px: Use Cases link added under the Product column after Template](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/02b13b044810b646df83e39675d2f5ba02873416e03272906354f99936eaa4e1/pr-images/1785172989520-8a893570-7d86-484d-ad8b-13bf0c493270.png)

![Site footer at 390px: Use Cases link renders under Product in the 2-column mobile layout](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/02b13b044810b646df83e39675d2f5ba02873416e03272906354f99936eaa4e1/pr-images/1785172989861-628f6d32-5a6e-42da-b469-5eebaa536d47.png)

![Destination page after clicking the footer link: /workflows/use-cases/ Use Cases index](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/02b13b044810b646df83e39675d2f5ba02873416e03272906354f99936eaa4e1/pr-images/1785172990256-1fdceb14-19f8-4ecb-bd1e-ee6697350c42.png)