### PR TITLE
feat(site): hub locale-page rendering (GTM-291, gated off) [WIP]

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 import os from 'node:os';
 
 import vue from '@astrojs/vue';
+import { INDEXABLE_LOCALES } from './src/lib/i18n/locales.ts';
 import { deriveModelGroups } from './src/lib/workflow-pages/model-groups.ts';
 import { SEO_PAGES } from './src/lib/workflow-pages/use-cases.ts';
 import { resolveUseCasePageTemplates } from './src/lib/workflow-pages/use-case-resolver.ts';
@@ -66,11 +67,19 @@ const indexableUseCaseSlugs = new Set(
 
 // Variant → canonical 301s (real, via the Vercel adapter). Skip a variant that is
 // itself a canonical slug, so a redirect can never shadow a real page.
+// Key BOTH slash forms: canonical model URLs carry a trailing slash
+// (`modelPath` → `/workflows/model/<slug>/`), so a no-slash-only redirect key let
+// the canonicalized `/workflows/model/<variant>/` fall through to a 404. The
+// locale route redirects variants in code regardless of trailing slash, so both
+// forms here restore parity (the wan2-5 bug).
 const modelSlugRedirects = Object.fromEntries(
   modelGroups.flatMap((group) =>
     group.redirectFrom
       .filter((variant) => !canonicalModelSlugs.has(variant))
-      .map((variant) => [`/workflows/model/${variant}`, `/workflows/model/${group.slug}/`])
+      .flatMap((variant) => [
+        [`/workflows/model/${variant}`, `/workflows/model/${group.slug}/`],
+        [`/workflows/model/${variant}/`, `/workflows/model/${group.slug}/`],
+      ])
   )
 );
 
@@ -80,6 +89,15 @@ const buildDate = new Date().toISOString();
 // Supported locales (matches src/i18n/config.ts)
 const locales = ['en', 'zh', 'zh-TW', 'ja', 'ko', 'es', 'fr', 'ru', 'tr', 'ar', 'pt-BR'];
 const nonDefaultLocales = locales.filter((l) => l !== 'en');
+
+// Locales flipped to indexable — the single source of truth is INDEXABLE_LOCALES
+// in src/lib/i18n/locales.ts (imported above), so a go-live flip is one edit there
+// and the sitemap gate follows automatically. While empty, no prerendered locale
+// detail page enters the sitemap, so its Google-facing content is unchanged; a
+// locale detail URL would leak in otherwise, since those pages are now static and
+// match the generic detail rule below.
+/** @type {Set<string>} */
+const indexableLocales = new Set(INDEXABLE_LOCALES);
 
 const siteOrigin = (process.env.PUBLIC_SITE_ORIGIN || 'https://comfy.org').replace(/\/$/, '');
 
@@ -215,7 +233,15 @@ export default defineConfig({
           const lastHyphen = segment.lastIndexOf('-');
           if (lastHyphen === -1) return false;
           const candidate = segment.slice(lastHyphen + 1);
-          if (candidate.length === 12 && /^[0-9a-f]+$/.test(candidate)) return true;
+          if (candidate.length === 12 && /^[0-9a-f]+$/.test(candidate)) {
+            // Locale detail pages are prerendered now; only list them once their
+            // locale is flipped indexable. English detail pages have no prefix.
+            const localeMatch = page.match(/\/([a-z]{2}(?:-[A-Z]{2})?)\/workflows\//);
+            if (localeMatch && localeMatch[1] !== 'en' && !indexableLocales.has(localeMatch[1])) {
+              return false;
+            }
+            return true;
+          }
           return false;
         }
         return true;

--- a/site/src/components/HreflangTags.astro
+++ b/site/src/components/HreflangTags.astro
@@ -18,21 +18,27 @@ interface Props {
    * never advertise per-locale URLs that would 404. Defaults to true.
    */
   localized?: boolean;
+  /**
+   * Explicit alternate locales for per-page gating (GTM-291). When provided it
+   * overrides `localized`: ONLY these locales get `<link alternate>` tags, so a
+   * detail page advertises exactly the locales for which it is indexable (Google
+   * discards a cluster that references noindexed alternates). An empty array emits
+   * just x-default — used while a locale detail page is gated non-indexable.
+   */
+  locales?: readonly Locale[];
 }
 
-const { basePath, localized = true } = Astro.props;
+const { basePath, localized = true, locales } = Astro.props;
+
+// Per-page list wins; otherwise fall back to "all locales / none" by the boolean.
+const alternateLocales: readonly Locale[] =
+  locales ?? (localized ? (Object.keys(LANGUAGES) as Locale[]) : []);
 
 // hreflang values must be lowercase (e.g. 'zh-tw' not 'zh-TW').
-const hreflangEntries = localized
-  ? Object.keys(LANGUAGES).map((locale) => {
-      const href = absoluteUrl(localizeUrl(basePath, locale as Locale));
-
-      return {
-        hreflang: locale.toLowerCase(),
-        href,
-      };
-    })
-  : [];
+const hreflangEntries = alternateLocales.map((locale) => ({
+  hreflang: locale.toLowerCase(),
+  href: absoluteUrl(localizeUrl(basePath, locale)),
+}));
 
 // Add x-default pointing to the English version
 const xDefaultHref = absoluteUrl(basePath);

--- a/site/src/components/SEOHead.astro
+++ b/site/src/components/SEOHead.astro
@@ -1,6 +1,6 @@
 ---
 import HreflangTags from './HreflangTags.astro';
-import { LANGUAGES, DEFAULT_LOCALE } from '../i18n/config';
+import { LANGUAGES, DEFAULT_LOCALE, type Locale } from '../i18n/config';
 import { absoluteUrl, SITE_NAME } from '../config/site';
 import { serializeJsonLdForScript } from '../lib/structured-data';
 
@@ -17,6 +17,8 @@ interface Props {
   hreflangBasePath?: string;
   /** Whether localized variants exist; false emits x-default only (no per-locale alternates). */
   hreflangLocalized?: boolean;
+  /** Explicit per-page alternate locales (GTM-291); overrides hreflangLocalized. */
+  hreflangLocales?: readonly Locale[];
   /** Emit robots noindex (keeps follow) for thin/unverified pages. */
   noindex?: boolean;
 }
@@ -31,6 +33,7 @@ const {
   structuredData,
   hreflangBasePath,
   hreflangLocalized = true,
+  hreflangLocales,
   noindex = false,
 } = Astro.props;
 
@@ -79,7 +82,11 @@ if (!computedHreflangBasePath) {
 <link rel="canonical" href={fullCanonicalUrl} />
 
 {/* Hreflang tags for international SEO */}
-<HreflangTags basePath={computedHreflangBasePath} localized={hreflangLocalized} />
+<HreflangTags
+  basePath={computedHreflangBasePath}
+  localized={hreflangLocalized}
+  locales={hreflangLocales}
+/>
 
 <!-- Open Graph -->
 <meta property="og:type" content={ogType} />

--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -3,6 +3,39 @@
  * SiteFooter - Blue footer matching the Figma design
  * Blue background, Comfy logo, social icons, 4-column link grid
  */
+import { LANGUAGES, DEFAULT_LOCALE, type Locale } from '../../i18n/config';
+import { getLocaleFromPath, localizeUrl } from '../../i18n/utils';
+import { INDEXABLE_LOCALES } from '../../lib/i18n/locales';
+
+// Language switcher (GTM-291). Self-derives from the current URL so no caller
+// has to thread props: the current locale is the path's locale prefix, and the
+// un-prefixed base path is what every alternate URL is rebuilt from.
+const currentLocale = getLocaleFromPath(Astro.url.pathname);
+const strippedPath =
+  currentLocale === DEFAULT_LOCALE
+    ? Astro.url.pathname
+    : Astro.url.pathname.replace(new RegExp(`^/${currentLocale}`), '') || '/';
+const basePath = strippedPath.startsWith('/') ? strippedPath : `/${strippedPath}`;
+
+// Predicate-gated links (design v3 §13 PR 3): only offer languages whose pages
+// are actually live. INDEXABLE_LOCALES is the language-level rollout gate and is
+// empty until a language passes native review, so today this renders nothing and
+// the footer stays byte-identical. English is always offered as the return path.
+// Per-page refinement (a workflow untranslated in an otherwise-live locale) lands
+// with the indexability predicate in a later PR.
+const offeredLocales: Locale[] = [
+  DEFAULT_LOCALE,
+  ...INDEXABLE_LOCALES.filter((l) => l !== DEFAULT_LOCALE),
+];
+const languageLinks =
+  offeredLocales.length > 1
+    ? offeredLocales.map((locale) => ({
+        locale,
+        nativeName: LANGUAGES[locale].nativeName,
+        url: localizeUrl(basePath, locale),
+        isCurrent: locale === currentLocale,
+      }))
+    : [];
 ---
 
 <footer class="bg-page text-content">
@@ -362,6 +395,32 @@
 
     <!-- Bottom bar -->
     <div class="mt-14 pt-6 border-t border-white/10">
+      <!-- Language switcher: only rendered once a locale is live (gated off today) -->
+      {
+        languageLinks.length > 0 && (
+          <nav
+            aria-label="Language"
+            class="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm"
+          >
+            {languageLinks.map((link) =>
+              link.isCurrent ? (
+                <span class="text-content font-medium" lang={link.locale} aria-current="true">
+                  {link.nativeName}
+                </span>
+              ) : (
+                <a
+                  href={link.url}
+                  hreflang={link.locale}
+                  lang={link.locale}
+                  class="text-content-muted hover:text-content transition-colors"
+                >
+                  {link.nativeName}
+                </a>
+              )
+            )}
+          </nav>
+        )
+      }
       <div
         class="flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-content-muted"
       >

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -123,6 +123,7 @@
   "useCase.bannerCta": "See pricing plans",
   "useCase.tryWorkflow": "Try workflow",
   "useCase.metaDescription": "Browse {count} ready-to-use ComfyUI workflow templates for {keyword}. No setup required on Comfy Cloud.",
+  "tag.metaDescription": "Browse {count} ComfyUI workflow templates tagged with \"{tag}\". Free, ready-to-use AI generation workflows on Comfy Cloud.",
   "useCase.subheading": "Ready-to-run ComfyUI workflows for {keyword}, fully editable and runnable on Comfy Cloud with no setup.",
   "model.about": "About the model",
   "model.capabilities": "Key capabilities",

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -20,6 +20,8 @@ interface Props {
   hreflangBasePath?: string;
   /** Whether localized variants of this route exist (controls hreflang alternates). */
   hreflangLocalized?: boolean;
+  /** Explicit per-page alternate locales (GTM-291); overrides hreflangLocalized. */
+  hreflangLocales?: readonly Locale[];
   theme?: 'light' | 'dark';
   hideDefaultFooter?: boolean;
   noindex?: boolean;
@@ -36,6 +38,7 @@ const {
   locale: propLocale,
   hreflangBasePath,
   hreflangLocalized = true,
+  hreflangLocales,
   theme = 'light',
   hideDefaultFooter = false,
   noindex = false,
@@ -85,6 +88,7 @@ const bodyClasses = isDark
       structuredData={structuredData}
       hreflangBasePath={hreflangBasePath}
       hreflangLocalized={hreflangLocalized}
+      hreflangLocales={hreflangLocales}
       noindex={noindex}
     />
     <slot name="head" />

--- a/site/src/lib/hub-api.ts
+++ b/site/src/lib/hub-api.ts
@@ -191,6 +191,21 @@ export interface ListWorkflowsParams {
 // API functions
 // ---------------------------------------------------------------------------
 
+/**
+ * Hub API failure carrying the HTTP status, so callers branch on `err.status`
+ * (e.g. 404 vs a transient 5xx) instead of string-matching the message.
+ */
+export class HubApiError extends Error {
+  constructor(
+    readonly status: number,
+    statusText: string,
+    url: string
+  ) {
+    super(`Hub API error: ${status} ${statusText} — ${url}`);
+    this.name = 'HubApiError';
+  }
+}
+
 async function hubFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const url = `${HUB_API_BASE}${path}`;
   const res = await fetch(url, {
@@ -202,7 +217,7 @@ async function hubFetch<T>(path: string, init?: RequestInit): Promise<T> {
   });
 
   if (!res.ok) {
-    throw new Error(`Hub API error: ${res.status} ${res.statusText} — ${url}`);
+    throw new HubApiError(res.status, res.statusText, url);
   }
 
   return res.json() as Promise<T>;

--- a/site/src/lib/i18n/resolver.ts
+++ b/site/src/lib/i18n/resolver.ts
@@ -17,6 +17,7 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { DEFAULT_LOCALE } from '../../i18n/config';
 import { isLocalePageIndexable } from './predicate';
 import { SUPPORTED_HUB_LOCALES, INDEXABLE_LOCALES } from './locales';
 import {
@@ -173,4 +174,23 @@ export function resolveLocalizedWorkflow(
   });
 
   return { data, provenance, indexable, reason };
+}
+
+/**
+ * The non-English locales for which THIS workflow's detail page is indexable — the
+ * per-page hreflang cluster (Google discards a cluster that points at noindexed
+ * alternates). Cheap while gated: `INDEXABLE_LOCALES` empty short-circuits to `[]`
+ * before any resolve, so English detail pages pay nothing until a locale flips.
+ */
+export function indexableAlternateLocales(
+  shareId: string,
+  options: ResolverOptions = {}
+): Locale[] {
+  const indexableLocales = options.indexableLocales ?? INDEXABLE_LOCALES;
+  if (indexableLocales.length === 0) return [];
+  const supported = options.supportedLocales ?? SUPPORTED_HUB_LOCALES;
+  return supported.filter(
+    (locale) =>
+      locale !== DEFAULT_LOCALE && resolveLocalizedWorkflow(shareId, locale, options).indexable
+  );
 }

--- a/site/src/lib/workflow-pages/seo-page.ts
+++ b/site/src/lib/workflow-pages/seo-page.ts
@@ -6,7 +6,7 @@
  * thin typed wrapper over the shared primitive below.
  */
 import { t } from '../../i18n/ui';
-import type { Locale } from '../../i18n/config';
+import { DEFAULT_LOCALE, type Locale } from '../../i18n/config';
 import type { ModelGroup } from './model-groups';
 import type { SeoPageDef } from './use-cases';
 import type { GeneratedSeoContent } from './schema';
@@ -15,6 +15,17 @@ import { isIndexable } from './governance';
 /** Indexable only when the page has shippable content and real templates. */
 function pageIndexable(hasQualityContent: boolean, templateCount: number): boolean {
   return isIndexable({ clusterSize: templateCount, qualityPassed: hasQualityContent });
+}
+
+/**
+ * English keeps the richer AI-generated copy; localized routes prefer the
+ * translated templated copy. The generated `content.*` is English-only, so on a
+ * non-English (already self-canonical, indexable) page it would show an English
+ * meta description — ranking well but tanking CTR. Quick win: swap the precedence
+ * per locale so these pages read in-language without waiting on any locale flip.
+ */
+function localizedFirst(locale: Locale, english: string | undefined, localized: string): string {
+  return (locale === DEFAULT_LOCALE ? english : undefined) || localized;
 }
 
 export interface SeoPageMeta {
@@ -62,12 +73,18 @@ export function buildModelPageMeta({
     hasQualityContent: hasModelQualityContent(group, content),
     h1: t('model.metaH1', locale).replace('{label}', label),
     title: t('model.metaTitle', locale).replace('{label}', label),
-    description:
-      content?.metaDescription ||
+    description: localizedFirst(
+      locale,
+      content?.metaDescription,
       t('model.metaDescription', locale)
         .replace('{count}', String(templateCount))
-        .replace('{label}', label),
-    subheading: content?.subheading || t('model.subheading', locale).replace('{label}', label),
+        .replace('{label}', label)
+    ),
+    subheading: localizedFirst(
+      locale,
+      content?.subheading,
+      t('model.subheading', locale).replace('{label}', label)
+    ),
   };
 }
 
@@ -103,12 +120,17 @@ export function buildUseCasePageMeta({
     hasQualityContent: hasUseCaseQualityContent(content),
     h1: def.h1,
     title: def.title,
-    description:
-      content?.metaDescription ||
+    description: localizedFirst(
+      locale,
+      content?.metaDescription,
       t('useCase.metaDescription', locale)
         .replace('{count}', String(templateCount))
-        .replace('{keyword}', keyword),
-    subheading:
-      content?.subheading || t('useCase.subheading', locale).replace('{keyword}', keyword),
+        .replace('{keyword}', keyword)
+    ),
+    subheading: localizedFirst(
+      locale,
+      content?.subheading,
+      t('useCase.subheading', locale).replace('{keyword}', keyword)
+    ),
   };
 }

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -1,362 +1,254 @@
 ---
 /**
- * Localized creator profile page OR workflow detail redirect (on-demand rendered)
- * Serves /{locale}/workflows/{username}/ for creator profiles.
- * URL segments with a share_id suffix redirect to the detail page.
- * Template name slugs redirect to the new URL format.
- * Data source: Hub API (listWorkflowIndex + getProfile).
+ * Localized workflow detail page — pre-rendered at build time (GTM-291).
+ * URL: /{locale}/workflows/{name}-{share_id}/
+ *
+ * Mirrors the English `workflows/[slug].astro`, but joins translated content via
+ * `resolveLocalizedWorkflow` and gates SEO by the per-page indexability predicate:
+ *
+ *  - canonical points at the localized URL only when the page is indexable
+ *    (translated + current + reviewed + locale flipped); otherwise it canonicals
+ *    to the English URL, so humans see the translation while Google keeps
+ *    indexing English. This is the "safety by canonical" the whole design rests on.
+ *  - for a locale in INDEXABLE_LOCALES, a non-indexable page fails the build
+ *    (fail-closed, section 8.4) rather than shipping a half-English indexable URL.
+ *
+ * With INDEXABLE_LOCALES empty, every page is non-indexable, so canonicals all
+ * point at English and the Google-facing output is unchanged.
+ *
+ * The SSR `[locale]/workflows/[username].astro` catches everything not generated
+ * here (creator profiles, and detail slugs for workflows added since the build).
  */
-export const prerender = false;
-
-import { getCollection } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import HubNavbar from '../../../components/hub/HubNavbar.astro';
 import SiteFooter from '../../../components/hub/SiteFooter.astro';
-import SidebarSection from '../../../components/template-detail/SidebarSection.astro';
 import TemplateDetailPage from '../../../components/template-detail/TemplateDetailPage.astro';
-import BackButton from '../../../components/BackButton.astro';
 import WorkflowGrid from '../../../components/hub/WorkflowGrid.vue';
-import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
+import { DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
 import { absoluteUrl } from '../../../config/site';
 import {
   listWorkflowIndex,
   listRelatedWorkflows,
-  getProfile,
-  getWorkflow,
-  toTemplateData,
-  extractShareId,
-  getProfileCache,
-  serializeIndexEntry,
   byUsageDesc,
+  type HubWorkflowTemplateEntry,
   type SerializedTemplate,
 } from '../../../lib/hub-api';
-import { fetchRankingMap } from '../../../lib/ranking';
-import { workflowOgUrl, creatorOgUrl } from '../../../lib/og-url';
+import { workflowOgUrl } from '../../../lib/og-url';
 import {
   buildFaqJsonLd,
   serializeJsonLdForScript,
   buildWorkflowBreadcrumb,
+  buildSoftwareApplicationJsonLd,
 } from '../../../lib/structured-data';
 import { buildToolbarLabels } from '../../../lib/toolbar';
-import { getSocialDisplay } from '../../../lib/social-links';
 import { localizeUrl } from '../../../i18n/utils';
 import { t } from '../../../i18n/ui';
+import { resolveLocalizedWorkflow, indexableAlternateLocales } from '../../../lib/i18n/resolver';
+import { SUPPORTED_HUB_LOCALES, INDEXABLE_LOCALES } from '../../../lib/i18n/locales';
 
-// ISR: cache for 60s, serve stale for up to 10 min while revalidating
-Astro.response.headers.set('CDN-Cache-Control', 'public, max-age=60, stale-while-revalidate=600');
+export async function getStaticPaths() {
+  // Every supported hub locale except English (English has its own route). Each
+  // gets prerendered pages; indexability is gated separately by the predicate, so
+  // non-flipped locales still render (English-fallback) for humans.
+  const locales = SUPPORTED_HUB_LOCALES.filter((l) => l !== DEFAULT_LOCALE) as Locale[];
 
-const { locale, slug } = Astro.params;
-
-if (Astro.url.pathname.endsWith('.json') || Astro.url.pathname.endsWith('.json/')) {
-  return new Response(null, {
-    status: 404,
-    statusText: 'Not Found',
-  });
-}
-
-// Validate locale
-if (!locale || !LOCALES.includes(locale as Locale) || locale === DEFAULT_LOCALE) {
-  return Astro.redirect('/workflows/');
-}
-
-const typedLocale = locale as Locale;
-
-if (!slug) {
-  return Astro.redirect(`/${locale}/workflows/`);
-}
-
-// If URL contains a share_id suffix, this is a workflow detail page — not a creator profile.
-const detailShareId = extractShareId(slug);
-let isDetailPage = false;
-let detailData: ReturnType<typeof toTemplateData> | null = null;
-
-if (detailShareId) {
+  let entries: HubWorkflowTemplateEntry[] = [];
   try {
-    const workflow = await getWorkflow(detailShareId);
-    detailData = toTemplateData(workflow);
-    isDetailPage = true;
-  } catch (err) {
-    const is404 = err instanceof Error && err.message.includes('404');
-    if (!is404) {
-      console.error('Hub API error on ISR detail:', err);
-      return new Response(null, {
-        status: 502,
-        statusText: 'Bad Gateway',
-        headers: {
-          'CDN-Cache-Control': 'no-store',
-        },
-      });
-    }
-    return new Response(null, {
-      status: 404,
-      statusText: 'Not Found',
-    });
-  }
-}
-
-// Check if this is a template slug — redirect to new URL format
-if (!isDetailPage) {
-  let redirectUrl: string | undefined;
-  try {
-    const entries = await listWorkflowIndex();
-    const entry = entries.find((e) => e.name === slug);
-    if (entry && entry.shareId) {
-      redirectUrl = `/${locale}/workflows/${entry.name}-${entry.shareId}/`;
-    }
+    entries = await listWorkflowIndex();
   } catch {
-    const templates = await getCollection('templates');
-    const template = templates.find((t) => !t.id.includes('/') && t.data.name === slug);
-    if (template) {
-      // Content collection doesn't have shareId, redirect to English canonical
-      redirectUrl = `/workflows/`;
+    // Hub index unavailable at build: emit no prerendered locale detail pages and
+    // let the SSR [username] catch-all serve them live (with real status codes),
+    // rather than shipping a build's worth of dead-end redirects to the index.
+    return [];
+  }
+
+  const paths = [];
+  for (const locale of locales) {
+    for (const entry of entries) {
+      const shareId = entry.shareId || '';
+      const name = entry.name || shareId;
+      if (!name) continue;
+
+      if (shareId) {
+        const resolved = resolveLocalizedWorkflow(shareId, locale);
+        // Fail-closed: a flipped (indexable) locale must never ship a page that
+        // the predicate rejects (missing/stale/unreviewed translation).
+        if (INDEXABLE_LOCALES.includes(locale) && !resolved.indexable) {
+          throw new Error(
+            `[i18n] indexable locale "${locale}" page ${name}-${shareId} is not ` +
+              `translation-complete and cannot be prerendered: ${resolved.reason}`
+          );
+        }
+        paths.push({
+          params: { locale, slug: `${name}-${shareId}` },
+          props: { entry, resolved },
+        });
+        // Legacy /{locale}/workflows/{name}/ (no shareId) is intentionally NOT
+        // prerendered: the SSR [username] catch-all 301s it to the canonical slug
+        // as a real server redirect, not a prerendered browser shim.
+      } else {
+        // No shareId — render directly. Nothing to resolve by shareId.
+        paths.push({
+          params: { locale, slug: name },
+          props: { entry, resolved: null },
+        });
+      }
     }
   }
-  if (redirectUrl) {
-    return Astro.redirect(redirectUrl, 301);
-  }
+
+  return paths;
 }
 
-// Fetch profile — try dedicated endpoint first, fall back to index-embedded profiles
-let profileFound = false;
-let displayName = slug;
-let avatarUrl: string | null = null;
-let description = '';
-let websiteUrls: string[] = [];
-try {
-  const profile = await getProfile(slug);
-  profileFound = true;
-  displayName = profile.display_name || slug;
-  avatarUrl = profile.avatar_url || null;
-  description = profile.description || '';
-  websiteUrls = profile.website_urls || [];
-} catch {
-  // Profile endpoint unavailable — fall back to cached profile from index
-  const cachedProfiles = await getProfileCache();
-  const cached = cachedProfiles.get(slug);
-  if (cached) {
-    profileFound = true;
-    displayName = cached.display_name || slug;
-    avatarUrl = cached.avatar_url || null;
-    description = cached.description || '';
-    websiteUrls = cached.website_urls || [];
-  }
+type ResolvedWorkflow = ReturnType<typeof resolveLocalizedWorkflow>;
+
+interface Props {
+  entry: HubWorkflowTemplateEntry;
+  resolved: ResolvedWorkflow | null;
 }
 
-// Fetch workflows for this creator from index
-const [profiles, rankingMap] = await Promise.all([getProfileCache(), fetchRankingMap()]);
-let serialized: SerializedTemplate[] = [];
-let indexFetchFailed = false;
+const { entry, resolved } = Astro.props;
+const locale = Astro.params.locale as Locale;
 
-try {
-  const entries = await listWorkflowIndex();
-  const filtered = entries.filter((e) => (e.profile?.username || e.username) === slug);
-  serialized = filtered.map((e) => serializeIndexEntry(e, profiles, rankingMap));
-} catch (err) {
-  indexFetchFailed = true;
-  console.error('Hub API failed for creator grid:', err);
-}
+// Structural fields come from the English index entry (not translated); the seven
+// translatable fields come from the resolver (localized, or English-fallback when
+// untranslated — which the predicate then marks non-indexable).
+const loc = resolved?.data;
+const data = {
+  name: entry.name,
+  shareId: entry.shareId || '',
+  title: loc?.title || entry.title || entry.name,
+  description: loc?.description || entry.description || '',
+  mediaType: entry.mediaType || 'image',
+  mediaSubtype: entry.mediaSubtype,
+  thumbnailVariant: entry.thumbnailVariant,
+  thumbnails: [entry.thumbnailUrl, entry.thumbnailComparisonUrl].filter(Boolean) as string[],
+  tags: entry.tags || [],
+  models: entry.models || [],
+  username: entry.profile?.username || entry.username || '',
+  date: entry.date || '',
+  tutorialUrl: entry.tutorialUrl,
+  extendedDescription: loc?.extendedDescription || entry.extendedDescription || '',
+  metaDescription: loc?.metaDescription || entry.metaDescription || entry.description || '',
+  howToUse: loc?.howToUse ?? entry.howToUse ?? [],
+  suggestedUseCases: loc?.suggestedUseCases ?? entry.suggestedUseCases ?? [],
+  faqItems: loc?.faqItems ?? entry.faqItems ?? [],
+  contentTemplate: entry.contentTemplate,
+};
 
-// Slug is bogus (e.g. "undefined" or a malformed "<name>-" suffix from a broken
-// link): no profile and no workflows — redirect instead of rendering a page
-// that would title itself "<slug> (@<slug>)" and get indexed by Google.
-if (!isDetailPage) {
-  // A failed grid-index fetch is a transient error, not a missing page: 502 (no-store)
-  // regardless of profileFound, so an empty grid from an API glitch is never cached.
-  if (indexFetchFailed) {
-    return new Response(null, {
-      status: 502,
-      statusText: 'Bad Gateway',
-      headers: {
-        'CDN-Cache-Control': 'no-store',
-      },
-    });
-  }
-  // 404 only for a successfully queried, genuinely empty result.
-  if (!profileFound && serialized.length === 0) {
-    return new Response(null, {
-      status: 404,
-      statusText: 'Not Found',
-    });
-  }
-}
+const isIndexable = resolved?.indexable ?? false;
+const title = `${data.title} - ComfyUI Workflow`;
+// Shareless workflows carry no `-shareId` suffix; guard against a dangling hyphen
+// that would canonicalize to a nonexistent /workflows/name-/ URL.
+const urlSlug = data.shareId ? `${data.name}-${data.shareId}` : data.name;
+// Safety by canonical: self-canonical only when the page is indexable; otherwise
+// point at the English URL so Google keeps indexing English until the flip.
+const canonicalUrl = isIndexable
+  ? absoluteUrl(`/${locale}/workflows/${urlSlug}/`)
+  : absoluteUrl(`/workflows/${urlSlug}/`);
 
-const canonicalUrl = absoluteUrl(`/workflows/${slug}/`);
+// One predicate drives four surfaces: canonical (above), robots noindex, the
+// hreflang cluster, and sitemap membership. Emit noindex until this page is
+// indexable, and advertise only the locales for which THIS workflow is indexable
+// (empty while gated → x-default→English only). The English detail route uses the
+// same per-page set so the cluster stays reciprocal.
+const hreflangLocales = data.shareId
+  ? ([DEFAULT_LOCALE, ...indexableAlternateLocales(data.shareId)] as Locale[])
+  : ([DEFAULT_LOCALE] as Locale[]);
 
-const socialLinks = websiteUrls.map(getSocialDisplay);
+const thumbnails = data.thumbnails;
+const primaryThumbnail = thumbnails[0] || null;
+const ogImage = workflowOgUrl(
+  data.title || data.name,
+  primaryThumbnail ? primaryThumbnail : undefined,
+  data.username || undefined
+);
 
-// Detail page variables (only used when isDetailPage is true)
-const detailTitle = detailData ? `${detailData.title || detailData.name} - ComfyUI Workflow` : '';
-const detailCanonicalUrl = detailData ? absoluteUrl(`/workflows/${slug}/`) : '';
-const detailThumbnails = detailData?.thumbnails || [];
-const detailPrimaryThumbnail = detailThumbnails[0] || null;
-const detailOgImage = detailData
-  ? workflowOgUrl(
-      detailData.title || detailData.name,
-      detailPrimaryThumbnail || undefined,
-      detailData.username || undefined
-    )
-  : '';
-const detailStructuredData = detailData
-  ? {
-      '@context': 'https://schema.org',
-      '@type': 'TechArticle',
-      headline: detailData.title || detailData.name,
-      description: detailData.description,
-      image: detailPrimaryThumbnail || undefined,
-      datePublished: detailData.date,
-      inLanguage: locale,
-    }
-  : null;
-const detailBreadcrumb = detailData
-  ? buildWorkflowBreadcrumb(typedLocale, {
-      name: detailData.title || detailData.name,
-      item: detailCanonicalUrl,
-    })
-  : null;
-const detailFaq = buildFaqJsonLd(detailData?.faqItems);
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: data.title,
+  description: data.description,
+  image: primaryThumbnail || undefined,
+  datePublished: data.date,
+  inLanguage: locale,
+};
 
-const structuredData = !isDetailPage
-  ? {
-      '@context': 'https://schema.org',
-      '@type': 'ProfilePage',
-      name: displayName,
-      description: description || `Workflows by ${displayName}`,
-      url: canonicalUrl,
-      inLanguage: locale,
-    }
-  : null;
+const faqStructuredData = buildFaqJsonLd(data.faqItems);
 
-// "View all workflows" grid for the detail page — full index minus current.
-const detailRelated: SerializedTemplate[] =
-  isDetailPage && detailData ? await listRelatedWorkflows(detailData.name, profiles) : [];
+const breadcrumbStructuredData = buildWorkflowBreadcrumb(locale, {
+  name: data.title,
+  item: canonicalUrl,
+});
+
+const softwareAppStructuredData = buildSoftwareApplicationJsonLd({
+  name: data.title,
+  description: data.metaDescription || data.description,
+});
+
+const relatedTemplates: SerializedTemplate[] = await listRelatedWorkflows(data.name);
 // Embed only the top-30 by usage; the grid lazy-loads the full catalog (grid.json).
-const detailRelatedPreview = [...detailRelated].sort(byUsageDesc).slice(0, 30);
+const relatedPreview = [...relatedTemplates].sort(byUsageDesc).slice(0, 30);
+const toolbarLabels = buildToolbarLabels(locale);
 ---
 
-{
-  isDetailPage && detailData ? (
-    <BaseLayout
-      title={detailTitle}
-      description={detailData.metaDescription || detailData.description}
-      canonicalUrl={detailCanonicalUrl}
-      ogImage={detailOgImage}
-      ogType="article"
-      structuredData={detailStructuredData ?? undefined}
-      hreflangBasePath={`/workflows/${slug}/`}
-      locale={typedLocale}
-      theme="dark"
-      hideDefaultFooter
-    >
-      <HubNavbar />
-      <TemplateDetailPage template={{ data: detailData }} locale={typedLocale}>
-        {detailRelated.length > 0 && (
-          <section slot="related" class="mt-16 lg:mt-24">
-            <a
-              href={localizeUrl('/workflows/', typedLocale)}
-              class="inline-block text-2xl lg:text-3xl font-semibold text-content hover:opacity-80 transition-opacity mb-6 lg:mb-8"
-            >
-              {t('template.viewAllWorkflows', typedLocale)}
-            </a>
-            <WorkflowGrid
-              client:visible
-              templates={detailRelatedPreview}
-              lazyFull
-              excludeName={detailData.name}
-              locale={typedLocale}
-              toolbarLabels={buildToolbarLabels(typedLocale)}
-              gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-            />
-          </section>
-        )}
-      </TemplateDetailPage>
+<BaseLayout
+  title={title}
+  description={data.metaDescription || data.description}
+  canonicalUrl={canonicalUrl}
+  ogImage={ogImage}
+  ogType="article"
+  structuredData={structuredData}
+  hreflangBasePath={`/workflows/${urlSlug}/`}
+  hreflangLocales={hreflangLocales}
+  noindex={!isIndexable}
+  locale={locale}
+  theme="dark"
+  hideDefaultFooter
+>
+  <HubNavbar />
+  <TemplateDetailPage template={{ data }} locale={locale}>
+    {
+      relatedTemplates.length > 0 && (
+        <section slot="related" class="mt-16 lg:mt-24">
+          <a
+            href={localizeUrl('/workflows/', locale)}
+            class="inline-block text-2xl lg:text-3xl font-semibold text-content hover:opacity-80 transition-opacity mb-6 lg:mb-8"
+          >
+            {t('template.viewAllWorkflows', locale)}
+          </a>
+          <WorkflowGrid
+            client:visible
+            templates={relatedPreview}
+            lazyFull
+            excludeName={data.name}
+            locale={locale}
+            toolbarLabels={toolbarLabels}
+            gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+          />
+        </section>
+      )
+    }
+  </TemplateDetailPage>
+  <script
+    is:inline
+    type="application/ld+json"
+    set:html={serializeJsonLdForScript(breadcrumbStructuredData)}
+  />
+  <script
+    is:inline
+    type="application/ld+json"
+    set:html={serializeJsonLdForScript(softwareAppStructuredData)}
+  />
+  {
+    faqStructuredData && (
       <script
         is:inline
         type="application/ld+json"
-        set:html={serializeJsonLdForScript(detailBreadcrumb)}
+        set:html={serializeJsonLdForScript(faqStructuredData)}
       />
-      {detailFaq && (
-        <script
-          is:inline
-          type="application/ld+json"
-          set:html={serializeJsonLdForScript(detailFaq)}
-        />
-      )}
-      <Fragment slot="footer">
-        <SiteFooter />
-      </Fragment>
-    </BaseLayout>
-  ) : (
-    <BaseLayout
-      title={`${displayName} (@${slug}) - ComfyUI Workflow Templates`}
-      description={description || `Workflows by ${displayName}`}
-      canonicalUrl={canonicalUrl}
-      ogImage={creatorOgUrl(displayName, slug!, avatarUrl || undefined)}
-      structuredData={structuredData ?? undefined}
-      locale={typedLocale}
-      theme="dark"
-      hideDefaultFooter
-    >
-      <HubNavbar />
-
-      <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pb-20">
-        <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 pt-8">
-          <aside class="w-full lg:w-[328px] shrink-0">
-            <div class="lg:sticky lg:top-16 flex flex-col gap-8 pt-8">
-              <BackButton locale={typedLocale} class="self-start" />
-              <SidebarSection contentClass="p-8 gap-6">
-                <div class="flex flex-col gap-4">
-                  {avatarUrl ? (
-                    <img
-                      src={avatarUrl}
-                      alt={displayName}
-                      class="size-16 rounded-full object-cover"
-                    />
-                  ) : (
-                    <div class="size-16 rounded-full bg-brand flex items-center justify-center">
-                      <span class="text-black text-2xl font-bold">
-                        {displayName.charAt(0).toUpperCase()}
-                      </span>
-                    </div>
-                  )}
-                  <div class="flex flex-col">
-                    <p class="text-content text-base font-bold">{displayName}</p>
-                    <p class="text-hub-muted text-sm">@{slug}</p>
-                  </div>
-                </div>
-
-                {description && <p class="text-hub-muted text-sm leading-normal">{description}</p>}
-
-                {socialLinks.length > 0 && (
-                  <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-hub-muted">
-                    {socialLinks.map((link) => (
-                      <a
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="underline hover:text-content transition-colors"
-                      >
-                        {link.label}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </SidebarSection>
-            </div>
-          </aside>
-
-          <WorkflowGrid
-            client:load
-            templates={serialized}
-            locale={typedLocale}
-            toolbarLabels={buildToolbarLabels(typedLocale)}
-            gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
-          />
-        </div>
-      </div>
-
-      <Fragment slot="footer">
-        <SiteFooter />
-      </Fragment>
-    </BaseLayout>
-  )
-}
+    )
+  }
+  <Fragment slot="footer">
+    <SiteFooter />
+  </Fragment>
+</BaseLayout>

--- a/site/src/pages/[locale]/workflows/[username].astro
+++ b/site/src/pages/[locale]/workflows/[username].astro
@@ -1,0 +1,244 @@
+---
+/**
+ * Localized SSR catch-all for /{locale}/workflows/{segment}/ (on-demand rendered).
+ * The prerendered `[locale]/workflows/[slug].astro` serves known workflow detail
+ * pages statically; this route catches creator profiles, redirects legacy slugs
+ * and not-yet-built workflow details to their canonical URLs, and 404s the rest.
+ */
+export const prerender = false;
+
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import HubNavbar from '../../../components/hub/HubNavbar.astro';
+import SiteFooter from '../../../components/hub/SiteFooter.astro';
+import SidebarSection from '../../../components/template-detail/SidebarSection.astro';
+import BackButton from '../../../components/BackButton.astro';
+import WorkflowGrid from '../../../components/hub/WorkflowGrid.vue';
+import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
+import { absoluteUrl } from '../../../config/site';
+import {
+  listWorkflowIndex,
+  getProfile,
+  getWorkflow,
+  extractShareId,
+  getProfileCache,
+  serializeIndexEntry,
+  HubApiError,
+  type SerializedTemplate,
+} from '../../../lib/hub-api';
+import { fetchRankingMap } from '../../../lib/ranking';
+import { creatorOgUrl } from '../../../lib/og-url';
+import { buildToolbarLabels } from '../../../lib/toolbar';
+import { getSocialDisplay } from '../../../lib/social-links';
+
+// ISR: cache for 60s, serve stale for up to 10 min while revalidating
+Astro.response.headers.set('CDN-Cache-Control', 'public, max-age=60, stale-while-revalidate=600');
+
+// The [username] segment is the SSR catch-all: a creator username, or a detail
+// slug (name-shareId) for a workflow not prerendered yet.
+const { locale, username: slug } = Astro.params;
+
+if (Astro.url.pathname.endsWith('.json') || Astro.url.pathname.endsWith('.json/')) {
+  return new Response(null, {
+    status: 404,
+    statusText: 'Not Found',
+  });
+}
+
+// Validate locale
+if (!locale || !LOCALES.includes(locale as Locale) || locale === DEFAULT_LOCALE) {
+  return Astro.redirect('/workflows/');
+}
+
+const typedLocale = locale as Locale;
+
+if (!slug) {
+  return Astro.redirect(`/${locale}/workflows/`);
+}
+
+// A `name-shareId` slug is a workflow detail request. The prerendered [slug] route
+// serves these (gated, English-canonical); anything reaching this SSR route is a
+// workflow added since the last build. Rather than render an un-gated localized
+// detail (wrong inLanguage/hreflang, no noindex), confirm it exists and redirect
+// to the English detail — the next build prerenders the gated localized page.
+const detailShareId = extractShareId(slug);
+if (detailShareId) {
+  try {
+    await getWorkflow(detailShareId);
+  } catch (err) {
+    if (err instanceof HubApiError && err.status === 404) {
+      return new Response(null, { status: 404, statusText: 'Not Found' });
+    }
+    console.error('Hub API error on ISR detail:', err);
+    return new Response(null, {
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: { 'CDN-Cache-Control': 'no-store' },
+    });
+  }
+  return Astro.redirect(`/workflows/${slug}/`, 302);
+}
+
+// Not a detail slug → a creator username, or a legacy template slug. A legacy slug
+// 301s to its canonical detail URL. A transient index outage must not bake in a
+// permanent redirect, so its content-collection fallback is a 302, not a 301.
+let redirectUrl: string | undefined;
+let redirectPermanent = true;
+try {
+  const entries = await listWorkflowIndex();
+  const entry = entries.find((e) => e.name === slug);
+  if (entry && entry.shareId) {
+    redirectUrl = `/${locale}/workflows/${entry.name}-${entry.shareId}/`;
+  }
+} catch {
+  const templates = await getCollection('templates');
+  const template = templates.find((tmpl) => !tmpl.id.includes('/') && tmpl.data.name === slug);
+  if (template) {
+    redirectUrl = `/workflows/`;
+    redirectPermanent = false; // transient — the index will recover
+  }
+}
+if (redirectUrl) {
+  return Astro.redirect(redirectUrl, redirectPermanent ? 301 : 302);
+}
+
+// Creator profile — try the dedicated endpoint, fall back to index-embedded profiles.
+let profileFound = false;
+let displayName = slug;
+let avatarUrl: string | null = null;
+let description = '';
+let websiteUrls: string[] = [];
+try {
+  const profile = await getProfile(slug);
+  profileFound = true;
+  displayName = profile.display_name || slug;
+  avatarUrl = profile.avatar_url || null;
+  description = profile.description || '';
+  websiteUrls = profile.website_urls || [];
+} catch {
+  const cachedProfiles = await getProfileCache();
+  const cached = cachedProfiles.get(slug);
+  if (cached) {
+    profileFound = true;
+    displayName = cached.display_name || slug;
+    avatarUrl = cached.avatar_url || null;
+    description = cached.description || '';
+    websiteUrls = cached.website_urls || [];
+  }
+}
+
+// Workflows for this creator, from the index.
+const [profiles, rankingMap] = await Promise.all([getProfileCache(), fetchRankingMap()]);
+let serialized: SerializedTemplate[] = [];
+let indexFetchFailed = false;
+try {
+  const entries = await listWorkflowIndex();
+  const filtered = entries.filter((e) => (e.profile?.username || e.username) === slug);
+  serialized = filtered.map((e) => serializeIndexEntry(e, profiles, rankingMap));
+} catch (err) {
+  indexFetchFailed = true;
+  console.error('Hub API failed for creator grid:', err);
+}
+
+// Bogus slug (no profile, no workflows): 404/502 rather than an indexable
+// "<slug> (@<slug>)" shell. A failed grid fetch is transient → 502 (no-store),
+// never cached; a genuinely empty result → 404.
+if (indexFetchFailed) {
+  return new Response(null, {
+    status: 502,
+    statusText: 'Bad Gateway',
+    headers: { 'CDN-Cache-Control': 'no-store' },
+  });
+}
+if (!profileFound && serialized.length === 0) {
+  return new Response(null, { status: 404, statusText: 'Not Found' });
+}
+
+const canonicalUrl = absoluteUrl(`/workflows/${slug}/`);
+const socialLinks = websiteUrls.map(getSocialDisplay);
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'ProfilePage',
+  name: displayName,
+  description: description || `Workflows by ${displayName}`,
+  url: canonicalUrl,
+};
+---
+
+<BaseLayout
+  title={`${displayName} (@${slug}) - ComfyUI Workflow Templates`}
+  description={description || `Workflows by ${displayName}`}
+  canonicalUrl={canonicalUrl}
+  ogImage={creatorOgUrl(displayName, slug!, avatarUrl || undefined)}
+  structuredData={structuredData}
+  locale={typedLocale}
+  theme="dark"
+  hideDefaultFooter
+>
+  <HubNavbar />
+
+  <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 pb-20">
+    <div class="flex flex-col lg:flex-row gap-8 lg:gap-16 pt-8">
+      <aside class="w-full lg:w-[328px] shrink-0">
+        <div class="lg:sticky lg:top-16 flex flex-col gap-8 pt-8">
+          <BackButton locale={typedLocale} class="self-start" />
+          <SidebarSection contentClass="p-8 gap-6">
+            <div class="flex flex-col gap-4">
+              {
+                avatarUrl ? (
+                  <img
+                    src={avatarUrl}
+                    alt={displayName}
+                    class="size-16 rounded-full object-cover"
+                  />
+                ) : (
+                  <div class="size-16 rounded-full bg-brand flex items-center justify-center">
+                    <span class="text-black text-2xl font-bold">
+                      {displayName.charAt(0).toUpperCase()}
+                    </span>
+                  </div>
+                )
+              }
+              <div class="flex flex-col">
+                <p class="text-content text-base font-bold">{displayName}</p>
+                <p class="text-hub-muted text-sm">@{slug}</p>
+              </div>
+            </div>
+
+            {description && <p class="text-hub-muted text-sm leading-normal">{description}</p>}
+
+            {
+              socialLinks.length > 0 && (
+                <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-hub-muted">
+                  {socialLinks.map((link) => (
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="underline hover:text-content transition-colors"
+                    >
+                      {link.label}
+                    </a>
+                  ))}
+                </div>
+              )
+            }
+          </SidebarSection>
+        </div>
+      </aside>
+
+      <WorkflowGrid
+        client:load
+        templates={serialized}
+        locale={typedLocale}
+        toolbarLabels={buildToolbarLabels(typedLocale)}
+        gridClass="grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+      />
+    </div>
+  </div>
+
+  <Fragment slot="footer">
+    <SiteFooter />
+  </Fragment>
+</BaseLayout>

--- a/site/src/pages/[locale]/workflows/tag/[tag].astro
+++ b/site/src/pages/[locale]/workflows/tag/[tag].astro
@@ -22,7 +22,6 @@ import { loadSerializedTemplates } from '../../../../lib/hub-api';
 import { buildToolbarLabels } from '../../../../lib/toolbar';
 import { serializeJsonLdForScript, buildWorkflowBreadcrumb } from '../../../../lib/structured-data';
 
-
 const { locale, tag } = Astro.params;
 
 if (Astro.url.pathname.endsWith('.json') || Astro.url.pathname.endsWith('.json/')) {
@@ -62,7 +61,11 @@ const basePath = `/workflows/tag/${tag}/`;
 const canonicalUrl = absoluteUrl(localizeUrl(basePath, typedLocale));
 
 const title = `${tagName} ${SITE_NAME} - ${t('nav.templates', typedLocale)}`;
-const description = `Browse ${matchingTemplates.length} ComfyUI workflow templates tagged with "${tagName}". Free, ready-to-use AI generation workflows.`;
+// Localized (falls back to English until the CI locale step translates the new
+// key). These tag pages are already self-canonical, so this is a quick CTR win.
+const description = t('tag.metaDescription', typedLocale)
+  .replace('{count}', String(matchingTemplates.length))
+  .replace('{tag}', tagName);
 
 const structuredData = {
   '@context': 'https://schema.org',

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -11,7 +11,8 @@ import HubNavbar from '../../components/hub/HubNavbar.astro';
 import SiteFooter from '../../components/hub/SiteFooter.astro';
 import TemplateDetailPage from '../../components/template-detail/TemplateDetailPage.astro';
 import WorkflowGrid from '../../components/hub/WorkflowGrid.vue';
-import { DEFAULT_LOCALE } from '../../i18n/config';
+import { DEFAULT_LOCALE, type Locale } from '../../i18n/config';
+import { indexableAlternateLocales } from '../../lib/i18n/resolver';
 import { getTemplatesForLocale } from '../../lib/templates';
 import { absoluteUrl } from '../../config/site';
 import {
@@ -120,8 +121,15 @@ const data = {
 };
 
 const title = `${data.title} - ComfyUI Workflow`;
-const urlSlug = `${data.name}-${data.shareId}`;
+// Guard against a dangling hyphen for shareless workflows (no `-shareId` suffix).
+const urlSlug = data.shareId ? `${data.name}-${data.shareId}` : data.name;
 const canonicalUrl = absoluteUrl(`/workflows/${urlSlug}/`);
+// Reciprocal hreflang: advertise only the locales for which this workflow is
+// indexable (empty while gated → x-default→English only), matching the localized
+// detail route so the cluster never points at a noindexed alternate.
+const hreflangLocales = data.shareId
+  ? ([DEFAULT_LOCALE, ...indexableAlternateLocales(data.shareId)] as Locale[])
+  : ([DEFAULT_LOCALE] as Locale[]);
 
 const thumbnails = data.thumbnails;
 const primaryThumbnail = thumbnails[0] || null;
@@ -168,6 +176,7 @@ const toolbarLabels = buildToolbarLabels(locale);
   ogType="article"
   structuredData={structuredData}
   hreflangBasePath={`/workflows/${urlSlug}/`}
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >


### PR DESCRIPTION
**Draft / WIP.** Stacked on #1044 (the translation pipeline). This PR renders the actual localized hub pages. It ships with \`INDEXABLE_LOCALES\` **empty**, so Google-facing output stays byte-identical until each language is flipped on after native review.

## Depends on
- **#1044** (base branch here) — the resolver/predicate/schema + pipeline.
- **#940** (GrowthNatives' hard-404 fix) must land first — it rewrites the same \`[locale]/workflows/*\` routes. This PR will rebase onto #940 and preserve its semantics (\`.json/\`-suffix hard-404, 404-on-missing-data, 502-not-redirect on API failure).

## Scope (per design v3)
- Route split of \`src/pages/[locale]/workflows/[slug].astro\`: prerendered detail route via \`resolveLocalizedWorkflow\`; creator-profile branch stays SSR.
- Localized head/body: title patterns, translated meta, \`og:locale\`(+alternates), JSON-LD with \`inLanguage\`, localized dates.
- Fail-closed build asserts for indexable locales.
- Sitemap locale gate wired to the per-page indexability predicate (canonical / hreflang / sitemap membership all from one decision).
- Quick win: translated titles/metas on the already-indexable locale model/tag/category/index pages.
- Language switcher (server-rendered) + wan2-5 model-variant 404 parity.
- 50-URL/locale language-check crawler + extend \`verify:sitemap-indexability\`.

Ships \`INDEXABLE_LOCALES = []\` → no page is indexable yet; per-language go-live is a later one-line change after native review.