### PR TITLE
chore: refresh template usage from Algolia run_clicks

### DIFF
--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "نموذج خفيف الوزن 2B يولد صورًا عالية الجودة البصرية من التلميحات الإنجليزية والروسية.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["صوت", "استنساخ الصوت"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["صوت", "تحويل النص إلى كلام", "استنساخ الصوت"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "تعمل GPT-5.6 Luna على تبسيط مرحلة ما قبل الإنتاج البصري من خلال تحليل صورة مرجعية واحدة وتوليد نص إبداعي منظم من موجه المستخدم. تأخذ صورة إدخال واحدة ولا تنتج أي مخرجات بصرية صريحة، مع التركيز بدلاً من ذلك على كتابة إعلانات سريعة وموحدة. مثالية لتوسيع أوصاف المشاهد بشكل دفعة، وتنظيم قوائم اللقطات، والتوليد الإبداعي عالي الحجم.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "توليد النص"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "قم بوصف المشهد أو عالم باستخدام GPT-5.6 Terra، وهو نموذج متعدد الوسائط متوازن يفسر صورة واحدة مرفوعة لتوجيه السرد البصري واتساق الأسلوب. مثالي لبناء العوالم، وإنشاء لوحات المزاج، والحفاظ على جماليات متماسكة عبر سلسلة من الأعمال.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "توليد النص"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5 هو نموذج رائد متعدد الوسائط مصمم للمهام الهندسية والإبداعية المعقدة، مع تحليل بصري أصلي واستدلال عالي السرعة. يأخذ الملخصات الإبداعية والصور المُنشأة كمدخلات، وينتج أوصافًا موحدة للمشاهد وتحليلاً بصريًا تكراريًا. مثالي لإنشاء القصص المصورة متعددة اللقطات، وتوليد أوصاف الصور بشكل دفعة، والتحسين الإبداعي القائم على الملاحظات.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "توليد النص"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "قم بتوليد أوصاف تفصيلية للصور وموجزات إبداعية باستخدام Kimi K3، وهو نموذج متعدد الوسائط مع نوافذ سياقية تصل إلى مليون رمز لفهم موحد للنصوص والصور. أدخل صورة واحدة وموجه نصي لإنتاج تحليلات بصرية دقيقة أو أوصاف دفعة. مثالي لتبسيط السلاسل البصرية متعددة اللقطات، وتوليد موجهات نصوص برمجية آلية لسير العمل القائمة على العقد، وتحسين المفاهيم الإبداعية بشكل متكرر من خلال ملاحظات الصور.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["توليد النص"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5، أول نموذج رائد من فئة Mythos من Anthropic، يدعم سير العمل الإبداعي من البداية إلى النهاية في ComfyUI. يأخذ موجه نصي واحد ويولد إخراج منظم واحد يتضمن تحليلات القصة المصورة، وموجهات دقيقة لنماذج SD وControlNet، ونصوص عقدة مخصصة. مثالي لفناني المفاهيم الذين يصقلون السرد البصري، وصناع الأفلام بالذكاء الاصطناعي الذين يحافظون على تناسق الأسلوب عبر السلاسل، والمبدعين الرقميين الذين يؤتمتون خط أنابيب العرض بأكمله.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "توليد النص"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "استفد من Claude Sonnet 5 لتنفيذ المهام المستقلة عالية القيمة، وسد الفجوة نحو الأداء الرائد بتكلفة أقل. أدخل أي موجه نصي أو نص برمجي لتوليد أوصاف صور دقيقة، ونصوص سير عمل آلية، وسجلات تسلسل اللقطات، أو تصحيحات منطق العقد. مثالي لمهام الإنتاج الدفعي، وتصحيح منطق عقد ComfyUI، والحفاظ على جودة إخراج متسقة عبر سير عمل التوليد المتكرر.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "توليد النص"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "توليد نص مع الفهم البصري باستخدام النماذج Qwen3-VL، ومعالجة صورة الإدخال واحدة لإنتاج استجابات نصية سياقية. مثالي لوصف الصور، الإجابة على الأسئلة البصرية، وتوليد المحتوى متعدد الوسائط.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["توليد النص"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "اختر نموذجًا من القائمة المنسقة لـ OpenRouter (Claude، GPT، Gemini، إلخ). قم بإنشاء استجابة نصية مع تحميلات وسائط اختيارية للنماذج القادرة على الرؤية.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["توليد النص", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "أدخل استفسارك أو صورتك للتحليل. قم بإنشاء استجابة باللغة الطبيعية مدعومة من Anthropic Claude، تدعم كلاً من المحادثة النصية وفهم الصور.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "توليد النص"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "أدخل موجه النص الخاص بك واختيارياً صورة أو صوت أو فيديو. قم بتوليد إخراج نصي مع دعم قابل للتكوين للاستدلال والبرمجة وتعدد اللغات.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["توليد النص"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "استخدم نموذج Qwen3.5 لتحليل صورة الإدخال وتوليد موجهات نصية وصفية. يقوم سير العمل هذا بتنفيذ التعليق على الصور وهندسة الموجه العكسي.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["توليد النص"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "أدخل موجه نصي لتوليد ردود مفصلة ومعللة باستخدام نموذج Qwen3-4B-Thinking.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["توليد النص"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "تجربة الذكاء الاصطناعي متعدد الوسائط من Google مع قدرات التفكير من Gemini.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "توليد النص"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Un modelo ligero de 2B que genera imágenes de alta calidad visual a partir de indicaciones en inglés y ruso.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["Audio", "Clonación de Voz"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["Audio", "Texto a voz", "Clonación de Voz"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna agiliza la preproducción visual analizando una sola imagen de referencia y generando texto creativo estructurado a partir de un prompt de usuario. Toma 1 imagen de entrada y no produce salidas visuales explícitas, centrándose en cambio en una redacción rápida y estandarizada. Ideal para la expansión de descripciones de escenas por lote, la organización de listas de tomas y la ideación creativa de alto volumen.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Generación de texto"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "Describe una escena o mundo usando GPT-5.6 Terra, un modelo multimodal equilibrado que interpreta una imagen subida para guiar la narración visual y la coherencia de estilo. Ideal para la construcción de mundos, la creación de paneles de inspiración y el mantenimiento de una estética cohesionada en una serie de obras.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Generación de texto"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5 es un modelo multimodal insignia diseñado para tareas complejas de ingeniería y creativas, con análisis visual nativo e inferencia de alta velocidad. Toma resúmenes creativos e imágenes generadas como entradas, produciendo descripciones de escenas estandarizadas y análisis visual iterativo. Ideal para storyboarding de múltiples tomas, generación de descripciones de imágenes por lote y refinamiento creativo impulsado por retroalimentación.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Generación de texto"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "Genere descripciones detalladas de imágenes y resúmenes creativos utilizando Kimi K3, un modelo multimodal con ventanas de contexto de un millón de tokens para la comprensión unificada de texto e imagen. Ingrese una imagen y un prompt de texto para producir análisis visuales matizados o descripciones por lote. Ideal para optimizar series visuales de múltiples tomas, generar prompts de script automatizados para flujos de trabajo basados en nodos y refinar iterativamente conceptos creativos a través de la Retroalimentación de imágenes.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Generación de texto"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5, el primer modelo público de clase Mythos de Anthropic, impulsa flujos de trabajo creativos de extremo a extremo en ComfyUI. Toma 1 prompt de texto y genera 1 salida estructurada que incluye desgloses de storyboard, prompts precisos para modelos SD y ControlNet, y scripts de nodos personalizados. Ideal para artistas conceptuales que refinan narrativas visuales, cineastas de IA que mantienen la consistencia de estilo en series y creadores digitales que automatizan todo su pipeline de renderizado.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Generación de texto"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "Aproveche Claude Sonnet 5 para la ejecución autónoma de tareas de alto valor, cerrando la brecha hacia el rendimiento insignia a un costo menor. Ingrese cualquier prompt o script de texto para generar descripciones de imágenes precisas, scripts de flujo de trabajo automatizados, registros de secuencia de tomas o correcciones de lógica de nodos. Ideal para tareas de producción por lotes, depuración de lógica de nodos de ComfyUI y mantenimiento de una calidad de salida consistente en flujos de trabajo de generación repetitivos.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Generación de texto"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "TextGenerate con comprensión visual usando modelos Qwen3-VL, procesando una imagen de entrada para producir respuestas de texto contextuales. Ideal para descripción de imágenes, respuesta a preguntas visuales y generación de contenido multimodal.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Generación de texto"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "Seleccione un modelo de la lista seleccionada de OpenRouter (Claude, GPT, Gemini, etc.). Genere una respuesta de texto con cargas de medios opcionales para modelos con capacidad de visión.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["Generación de texto", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "Ingrese su consulta o imagen para su análisis. Genere una respuesta en lenguaje natural impulsada por Anthropic Claude, que admite tanto conversación de texto como comprensión de imágenes.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Generación de texto"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "Ingrese su prompt de texto y opcionalmente una imagen, audio o vídeo. Genere una salida de texto con soporte configurable de razonamiento, codificación y multilingüe.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Generación de texto"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "Utilice el modelo Qwen3.5 para analizar una imagen de entrada y generar prompts de texto descriptivos. Este flujo de trabajo realiza captioning de imágenes e ingeniería de prompts inversa.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Generación de texto"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "Ingrese un prompt de texto para generar respuestas detalladas y razonadas utilizando el modelo Qwen3-4B-Thinking.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Generación de texto"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "Experimentar la IA multimodal de Google con las capacidades de razonamiento de Gemini.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Generación de texto"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16327,7 +16330,7 @@
         "mediaType": "image",
         "mediaSubtype": "webp",
         "thumbnailVariant": "compareSlider",
-        "tags": ["Mejora de imagen"],
+        "tags": ["Mejora de imagen", "Mejora de imagen"],
         "models": ["SUPIR"],
         "date": "2026-04-20",
         "openSource": true,
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "یک مدل سبک ۲ میلیارد پارامتری که از پرامپت‌های انگلیسی و روسی با کیفیت بصری بالا تصویر تولید می‌کند.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["صدا", "همانندسازی صدا"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["صدا", "متن به گفتار", "همانندسازی صدا"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna با تحلیل یک تصویر مرجع و تولید متن خلاقانه ساختاریافته از پرامپت کاربر، پیش‌تولید بصری را ساده‌سازی می‌کند. این ابزار 1 تصویر ورودی دریافت می‌کند و هیچ خروجی بصری آشکاری تولید نمی‌کند، در عوض بر کپی‌رایتینگ سریع و استاندارد تمرکز دارد. ایده‌آل برای گسترش توضیحات صحنه به صورت دسته‌ای، سازماندهی لیست نماها و ایده‌پردازی خلاقانه با حجم بالا.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "تولید متن"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "یک صحنه یا جهان را با استفاده از GPT-5.6 Terra توصیف کنید، یک مدل چندوجهی متعادل که یک تصویر آپلود شده را تفسیر می‌کند تا داستان‌سرایی بصری و ثبات سبک را هدایت کند. ایده‌آل برای جهان‌سازی، ایجاد تابلوی خلق و خو، و حفظ زیبایی‌شناسی منسجم در مجموعه‌ای از آثار.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "تولید متن"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5 یک مدل چندوجهی پرچمدار است که برای وظایف مهندسی و خلاقانه پیچیده طراحی شده است، با تجزیه و تحلیل بصری بومی و استنتاج با سرعت بالا. این مدل خلاصه‌های خلاقانه و تصاویر تولیدشده را به عنوان ورودی‌ها دریافت کرده و توضیحات استاندارد صحنه و تحلیل بصری تکراری تولید می‌کند. ایده‌آل برای استوری‌بورد چندنما، تولید دسته‌ای توضیحات تصویر و اصلاح خلاقانه مبتنی بر بازخورد.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "تولید متن"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "با استفاده از Kimi K3، یک مدل چندوجهی با پنجره‌های زمینه میلیون‌تاکنی برای درک یکپارچه متن و تصویر، توضیحات دقیق تصاویر و خلاصه‌های خلاقانه تولید کنید. یک تصویر و یک پرامپت متنی را ورودی دهید تا تحلیل‌های بصری دقیق یا توضیحات دسته‌ای تولید شود. ایده‌آل برای ساده‌سازی سری‌های بصری چندنما، تولید پرامپت‌های اسکریپت خودکار برای گردش‌کارهای مبتنی بر گره، و بهبود تدریجی مفاهیم خلاقانه از طریق بازخورد تصویر.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["تولید متن"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5، اولین مدل پیشرو از کلاس Mythos که توسط Anthropic به صورت عمومی منتشر شده است، گردش‌کارهای خلاقانه سرتاسری را در ComfyUI تقویت می‌کند. این مدل 1 پرامپت متنی دریافت کرده و 1 خروجی ساختاریافته شامل تفکیک استوری‌بورد، پرامپت‌های دقیق برای مدل‌های SD و ControlNet، و اسکریپت‌های گره سفارشی تولید می‌کند. ایده‌آل برای هنرمندان مفهومی که روایت‌های بصری را اصلاح می‌کنند، فیلمسازان هوش مصنوعی که ثبات سبک را در سری‌ها حفظ می‌کنند، و سازندگان دیجیتالی که کل خط لوله رندر خود را خودکار می‌کنند.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "تولید متن"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "از Claude Sonnet 5 برای اجرای وظایف خودکار با ارزش بالا استفاده کنید و شکاف تا عملکرد پرچمدار را با هزینه کمتر پر کنید. هر پرامپت یا اسکریپت متنی را وارد کنید تا توضیحات دقیق تصویر، اسکریپت‌های گردش‌کار خودکار، گزارش‌های توالی نما یا تصحیحات منطق گره را تولید کنید. ایده‌آل برای وظایف تولید دسته‌ای، اشکال‌زدایی منطق گره ComfyUI و حفظ کیفیت خروجی ثابت در گردش‌کارهای تولید تکراری.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "تولید متن"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "تولید متن با درک بصری با استفاده از مدل‌های Qwen3-VL، پردازش یک تصویر ورودی برای تولید پاسخ‌های متنی زمینه‌ای. ایده‌آل برای شرح تصویر، پاسخ به سوالات بصری و تولید محتوای چندوجهی.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["تولید متن"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "یک مدل از لیست انتخاب‌شده OpenRouter (Claude، GPT، Gemini و غیره) انتخاب کنید. با آپلود رسانه اختیاری برای مدل‌های دارای قابلیت بینایی، یک پاسخ متنی تولید کنید.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["تولید متن", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "پرسش یا تصویر خود را برای تحلیل وارد کنید. یک پاسخ به زبان طبیعی با پشتیبانی از مکالمه متنی و درک تصویر، توسط Anthropic Claude تولید کنید.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "تولید متن"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "پرامپت متنی خود را وارد کنید و به صورت اختیاری یک تصویر، صوت یا ویدیو اضافه کنید. خروجی متن را با پشتیبانی قابل تنظیم از استدلال، کدنویسی و چندزبانه تولید کنید.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["تولید متن"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "از مدل Qwen3.5 برای تحلیل تصویر ورودی و تولید پرامپت‌های متنی توصیفی استفاده کنید. این گردش‌کار، شرح‌نویسی تصویر و مهندسی پرامپت معکوس را انجام می‌دهد.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["تولید متن"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "یک پرامپت متنی وارد کنید تا با استفاده از مدل Qwen3-4B-Thinking پاسخ‌های دقیق و استدلالی تولید کنید.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["تولید متن"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "هوش مصنوعی چندوجهی Google را با قابلیت‌های استدلال Gemini تجربه کنید.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "تولید متن"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Un modèle léger de 2B qui génère des images de haute qualité visuelle à partir de prompts en anglais et russe.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["Audio", "Clonage Vocal"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["Audio", "Synthèse vocale", "Clonage Vocal"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna rationalise la préproduction visuelle en analysant une seule image de référence et en générant un texte créatif structuré à partir d'un prompt utilisateur. Il prend 1 image d'entrée et ne produit aucune sortie visuelle explicite, se concentrant plutôt sur une rédaction rapide et standardisée. Idéal pour l'expansion de descriptions de scènes par lot, l'organisation de listes de plans et l'idéation créative à haut volume.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Génération de texte"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "Décrivez une scène ou un monde à l'aide de GPT-5.6 Terra, un modèle multimodal équilibré qui interprète un Contrôle d'image téléchargé pour guider la narration visuelle et la cohérence stylistique. Idéal pour la construction de mondes, la création de mood boards et le maintien d'une esthétique cohérente dans une série d'œuvres.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Génération de texte"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5 est un modèle multimodal phare conçu pour les tâches d'ingénierie complexes et créatives, avec un parsing visuel natif et une inférence à haute vitesse. Il prend des briefs créatifs et des images générées comme entrées, produisant des descriptions de scènes standardisées et une analyse visuelle itérative. Idéal pour le storyboarding multi-prise, la génération de descriptions d'images par lot et le raffinement créatif basé sur les commentaires.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Génération de texte"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "Générez des descriptions d'images détaillées et des briefs créatifs à l'aide de Kimi K3, un modèle multimodal avec des fenêtres de contexte d'un million de tokens pour une compréhension unifiée du texte et de l'image. Entrez une image et un prompt textuel pour produire des analyses visuelles nuancées ou des descriptions par lot. Idéal pour rationaliser les séries visuelles multi-plans, générer des prompts de script automatisés pour les flux de travail basés sur des nœuds, et affiner de manière itérative les concepts créatifs grâce aux Commentaires sur les images.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Génération de texte"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5, le premier modèle public de classe Mythos d'Anthropic, alimente des flux de travail créatifs de bout en bout dans ComfyUI. Il prend 1 prompt textuel et génère 1 sortie structurée comprenant des décompositions de storyboard, des prompts précis pour les modèles SD et ControlNet, et des scripts de nœuds personnalisés. Idéal pour les artistes conceptuels affinant des récits visuels, les cinéastes IA maintenant la cohérence de style dans les séries et les créateurs numériques automatisant l'ensemble de leur pipeline de rendu.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Génération de texte"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "Tirez parti de Claude Sonnet 5 pour l'exécution autonome de tâches à haute valeur ajoutée, comblant l'écart vers des performances de premier ordre à moindre coût. Saisissez n'importe quel prompt ou script textuel pour générer des descriptions d'images précises, des scripts de flux de travail automatisés, des journaux de séquence de plans ou des corrections de logique de nœuds. Idéal pour les tâches de production par lots, le débogage de la logique des nœuds ComfyUI et le maintien d'une qualité de sortie constante dans les flux de travail de génération répétitifs.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Génération de texte"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "TextGenerate avec compréhension visuelle à l'aide des Modèles Qwen3-VL, en traitant une image d'entrée pour produire des réponses textuelles contextuelles. Idéal pour le sous-titrage d'images, la réponse à des questions visuelles et la génération de contenu multimodal.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Génération de texte"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "Sélectionnez un modèle dans la liste organisée d'OpenRouter (Claude, GPT, Gemini, etc.). Générez une réponse textuelle avec des téléchargements de médias facultatifs pour les modèles compatibles avec la vision.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["Génération de texte", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "Saisissez votre requête ou image pour analyse. Générez une réponse en langage naturel propulsée par Anthropic Claude, prenant en charge à la fois la conversation textuelle et la compréhension d'images.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Génération de texte"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "Saisissez votre prompt textuel et éventuellement une image, un audio ou une vidéo. Générez une sortie de texte avec un raisonnement, un codage et un support multilingue configurables.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Génération de texte"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "Utilisez le modèle Qwen3.5 pour analyser une image d'entrée et générer des prompts textuels descriptifs. Ce flux de travail effectue le sous-titrage d'image et l'ingénierie de prompt inversée.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Génération de texte"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "Entrez un prompt textuel pour générer des réponses détaillées et raisonnées à l'aide du modèle Qwen3-4B-Thinking.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Génération de texte"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "Découvrez l'IA multimodale de Google avec les capacités de raisonnement de Gemini.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Génération de texte"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "英語とロシア語のプロンプトから高視覚品質の画像を生成する軽量2Bモデル。",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["オーディオ", "音声クローニング"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["オーディオ", "テキスト読み上げ", "音声クローニング"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Lunaは、1枚の参照画像を分析し、ユーザープロンプトから構造化されたクリエイティブテキストを生成することで、ビジュアルプリプロダクションを効率化します。1つの入力画像を受け取り、明示的な視覚出力は生成せず、迅速で標準化されたコピーライティングに重点を置いています。バッチシーン説明の拡張、ショットリストの整理、大量のクリエイティブアイデア創出に最適です。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "テキスト生成"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "GPT-5.6 Terraを使用してシーンや世界を説明します。これは、アップロードされた1枚の画像を解釈し、ビジュアルストーリーテリングとスタイルの一貫性を導くバランスの取れたマルチモーダルモデルです。ワールドビルディング、ムードボード作成、一連の作品全体で統一感のある美学を維持するのに最適です。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "テキスト生成"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5は、複雑なエンジニアリングおよびクリエイティブタスク向けに設計されたフラッグシップマルチモーダルモデルであり、ネイティブなビジュアル解析と高速推論を備えています。クリエイティブブリーフと生成済み画像を入力として受け取り、標準化されたシーン説明と反復的なビジュアル分析を生成します。マルチショットストーリーボード、バッチ画像説明生成、フィードバック駆動のクリエイティブリファインメントに最適です。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "テキスト生成"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "Kimi K3を使用して、詳細な画像説明とクリエイティブブリーフを生成します。これは、100万トークンのコンテキストウィンドウを持つマルチモーダルモデルで、テキストと画像の統合理解を実現します。1枚の画像とテキストプロンプトを入力すると、ニュアンスのある視覚分析やバッチ説明を生成します。マルチショットのビジュアルシリーズの効率化、ノードベースのワークフロー用の自動スクリプトプロンプトの生成、画像フィードバックによるクリエイティブコンセプトの反復的な洗練に最適です。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["テキスト生成"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5は、Anthropic初の公開Mythosクラスのフロンティアモデルであり、ComfyUIにおけるエンドツーエンドのクリエイティブワークフローを強化します。1つのテキストプロンプトを受け取り、ストーリーボードの内訳、SDモデルとControlNetの正確なプロンプト、カスタムノードスクリプトを含む1つの構造化出力を生成します。ビジュアルナラティブを洗練するコンセプトアーティスト、シリーズ全体でスタイルの一貫性を維持するAI映画製作者、レンダリングパイプライン全体を自動化するデジタルクリエイターに最適です。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "テキスト生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "Claude Sonnet 5を活用して高価値な自律タスクを実行し、フラッグシップ性能へのギャップを低コストで埋めます。任意のテキストプロンプトやスクリプトを入力して、正確な画像説明、自動化ワークフロースクリプト、ショットシーケンスログ、ノードロジック修正を生成します。バッチ生産タスク、ComfyUIノードロジックのデバッグ、反復的な生成ワークフロー全体で一貫した出力品質の維持に最適です。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "テキスト生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "Qwen3-VLモデルを使用して視覚的理解でTextGenerateし、1つの入力画像を処理してコンテキストに応じたテキスト応答を生成します。画像キャプション、視覚的質問応答、マルチモーダルコンテンツ生成に最適です。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["テキスト生成"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "OpenRouterの厳選リスト（Claude、GPT、Geminiなど）からモデルを選択します。ビジョン対応モデルでは、オプションでメディアをアップロードしてテキスト応答を生成します。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["テキスト生成", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "分析のためにクエリまたは画像を入力してください。Anthropic Claudeを搭載した自然言語応答を生成し、テキスト会話と画像理解の両方をサポートします。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "テキスト生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "テキストプロンプトを入力し、必要に応じて画像、オーディオ、ビデオを追加します。設定可能な推論、コーディング、多言語サポートでテキスト出力を生成します。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["テキスト生成"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "Qwen3.5モデルを使用して入力画像を分析し、説明的なテキストプロンプトを生成します。このワークフローは画像キャプションとリバースプロンプトエンジニアリングを実行します。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["テキスト生成"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "テキストプロンプトを入力して、Qwen3-4B-Thinkingモデルを使用して詳細で推論された応答を生成します。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["テキスト生成"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "Geminiの推論機能で、GoogleのマルチモーダルAIを体験します。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "テキスト生成"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.json
+++ b/templates/index.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -334,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -445,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -532,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -751,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -818,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -906,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -993,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1233,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1316,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1371,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1404,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1441,14 +1441,6 @@
               "nodeId": 41,
               "nodeType": "LoadImage",
               "file": "perfume_bottle.png.png",
-              "mediaType": "image"
-            }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
               "mediaType": "image"
             }
           ]
@@ -1673,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1757,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1776,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1818,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1884,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1913,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1947,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1976,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2032,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2058,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2094,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2122,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2162,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2220,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2235,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2265,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2299,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2328,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2371,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2414,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2451,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2491,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2524,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2559,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2587,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2624,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2660,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2701,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2750,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2780,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2802,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2827,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2913,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2941,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2969,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2996,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3037,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3053,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3079,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3107,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3132,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3158,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "A lightweight 2B model that generates images from English and Russian prompts with high visual quality.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3187,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3216,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3242,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3267,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3291,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3332,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3367,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3392,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3429,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3464,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3479,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3495,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3519,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3549,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3575,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3602,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3628,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3644,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3680,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3707,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3775,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3801,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3825,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3874,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3901,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3938,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3969,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3984,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4013,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4080,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4117,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4144,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4172,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4230,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4256,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4292,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4325,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4351,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4392,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4425,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4457,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4472,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4487,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4517,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4534,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4561,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4621,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4647,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4702,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4712,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4729,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4775,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4886,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4925,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5138,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5178,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5291,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5445,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5548,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5579,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5791,7 +5782,14 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5845,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5887,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5933,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5968,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5995,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6044,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6077,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6117,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6437,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6483,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6509,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6554,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6596,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6636,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6678,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6709,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6782,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6819,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6868,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6894,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6928,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6962,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7002,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7070,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7132,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7146,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7180,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7203,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7234,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7257,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7281,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7309,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7326,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7342,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7359,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7376,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7393,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7425,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7458,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7485,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7514,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7552,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7659,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7689,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7714,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7746,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7780,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7810,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7839,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7854,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7879,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7911,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7936,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7962,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7976,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8005,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8036,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8061,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8107,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8133,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8159,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8191,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8215,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8258,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8289,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8336,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8362,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8399,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8424,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8440,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8470,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8495,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8511,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8537,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8563,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8594,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8635,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8653,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8688,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8724,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8738,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8753,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8769,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8795,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8821,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8846,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8862,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8878,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8894,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8920,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8934,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8966,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9006,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9038,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9089,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9114,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9129,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9154,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9185,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9244,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9597,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9696,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9738,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9786,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9865,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9892,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9987,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10032,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10070,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10138,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10252,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10293,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10361,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10441,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10468,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10541,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10563,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10605,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10644,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10696,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10722,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10757,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10803,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10846,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10888,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10922,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10970,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11059,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11100,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11133,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11165,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11200,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11243,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11271,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11309,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11351,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11379,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11420,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11513,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11553,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11594,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11626,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11705,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11764,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11823,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11849,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11912,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11982,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12021,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12072,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12111,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12143,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12179,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12206,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12239,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12284,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12309,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12374,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12422,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12466,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12502,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12540,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12579,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12619,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12687,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12725,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12765,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12802,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12851,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12880,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12908,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12942,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12986,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13224,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13241,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13257,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13278,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13310,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13342,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13381,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13413,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13445,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13472,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13504,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13530,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13546,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13562,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13577,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13602,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["Audio", "Voice Cloning"],
         "io": {
@@ -13629,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["Audio", "Text to Speech", "Voice Cloning"],
         "io": {
@@ -13663,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13695,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13712,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13752,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13774,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13989,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14035,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14078,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14092,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14113,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14193,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14236,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14279,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14295,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14311,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14337,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14369,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14395,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14421,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14458,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14483,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14509,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14553,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14602,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14624,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -15048,7 +15044,7 @@
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15076,7 +15072,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15094,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15126,7 +15122,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15200,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15238,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15274,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15319,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15360,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15506,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15580,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16103,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16231,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16257,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16285,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16378,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16411,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16483,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16598,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16630,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16662,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16750,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16777,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16809,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16923,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16964,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17044,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17077,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17103,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17131,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17155,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17202,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17243,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17273,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17308,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17334,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17362,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17391,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17420,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17443,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17469,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17507,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17552,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17568,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17597,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17642,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17686,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17728,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17760,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17817,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17854,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17895,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17937,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17980,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18008,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18045,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18081,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18108,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18125,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18221,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18290,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18308,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "영어와 러시아어 프롬프트에서 고품질 시각 이미지를 생성하는 경량 2B 모델。",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["오디오", "음성 복제"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["오디오", "텍스트 음성 변환", "음성 복제"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna는 단일 레퍼런스 이미지를 분석하고 사용자 프롬프트로부터 구조화된 창의적 텍스트를 생성하여 시각적 사전 제작을 간소화합니다. 1개의 입력 이미지를 받아 명시적인 시각적 출력을 생성하지 않으며, 신속하고 표준화된 카피라이팅에 중점을 둡니다. 배치 장면 설명 확장, 샷 목록 구성, 대량 창의적 아이디어 발상에 이상적입니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "텍스트 생성"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "GPT-5.6 Terra를 사용하여 장면이나 세계를 설명하세요. 이는 업로드된 하나의 이미지를 해석하여 시각적 스토리텔링과 스타일 일관성을 안내하는 균형 잡힌 멀티모달 모델입니다. 세계관 구축, 무드 보드 생성, 일련의 작업 전반에 걸쳐 일관된 미학을 유지하는 데 이상적입니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "텍스트 생성"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5는 복잡한 엔지니어링 및 창의적 작업을 위해 설계된 플래그십 멀티모달 모델로, 기본 시각적 파싱과 고속 추론을 갖추고 있습니다. 창의적 브리프와 생성된 이미지를 입력으로 받아 표준화된 장면 설명과 반복적 시각 분석을 생성합니다. 멀티샷 스토리보드, 배치 이미지 설명 생성, 피드백 기반 창의적 개선에 이상적입니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "텍스트 생성"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "Kimi K3를 사용하여 상세한 이미지 설명과 크리에이티브 브리프를 생성하세요. Kimi K3는 백만 토큰 컨텍스트 윈도우를 갖춘 멀티모달 모델로, 텍스트와 이미지를 통합적으로 이해합니다. 하나의 이미지와 텍스트 프롬프트를 입력하면 미묘한 시각적 분석이나 배치 설명을 생성합니다. 멀티샷 비주얼 시리즈 간소화, 노드 기반 워크플로를 위한 자동 스크립트 프롬프트 생성, 이미지 피드백을 통한 크리에이티브 개념 반복적 개선에 이상적입니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["텍스트 생성"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5는 Anthropic의 첫 공개 Mythos급 프론티어 모델로, ComfyUI에서 엔드투엔드 크리에이티브 워크플로를 지원합니다. 1개의 텍스트 프롬프트를 받아 스토리보드 분석, SD 모델 및 ControlNet용 정확한 프롬프트, 커스텀 노드 스크립트를 포함한 1개의 구조화된 출력을 생성합니다. 시각적 내러티브를 다듬는 컨셉 아티스트, 시리즈 전반에 걸쳐 스타일 일관성을 유지하는 AI 영화 제작자, 전체 렌더링 파이프라인을 자동화하는 디지털 크리에이터에게 이상적입니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "텍스트 생성"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "Claude Sonnet 5를 활용하여 고가치 자율 작업을 실행하고, 더 낮은 비용으로 플래그십 성능과의 격차를 해소합니다. 텍스트 프롬프트나 스크립트를 입력하여 정확한 이미지 설명, 자동화된 워크플로 스크립트, 샷 시퀀스 로그 또는 노드 로직 수정을 생성합니다. 배치 생산 작업, ComfyUI 노드 로직 디버깅, 반복적인 생성 워크플로 전반에서 일관된 출력 품질 유지에 이상적입니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "텍스트 생성"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "Qwen3-VL 모델을 사용하여 시각적 이해를 바탕으로 텍스트 생성하고, 하나의 입력 이미지를 처리하여 맥락에 맞는 텍스트 응답을 생성합니다. 이미지 캡셔닝, 시각적 질문 응답, 멀티모달 콘텐츠 생성에 이상적입니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["텍스트 생성"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "OpenRouter의 선별된 목록(Claude, GPT, Gemini 등)에서 모델을 선택하세요. 비전 지원 모델의 경우 선택적으로 미디어를 업로드하여 텍스트 응답을 생성합니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["텍스트 생성", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "분석을 위해 쿼리나 이미지를 입력하세요. Anthropic Claude가 지원하는 자연어 응답을 생성하며, 텍스트 대화와 이미지 이해를 모두 지원합니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "텍스트 생성"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "텍스트 프롬프트를 입력하고 선택적으로 이미지, 오디오, 비디오를 추가하세요. 구성 가능한 추론, 코딩 및 다국어 지원으로 텍스트 출력을 생성합니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["텍스트 생성"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "Qwen3.5 모델을 사용하여 입력 이미지를 분석하고 설명적인 텍스트 프롬프트를 생성합니다. 이 워크플로는 이미지 캡셔닝 및 역방향 프롬프트 엔지니어링을 수행합니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["텍스트 생성"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "텍스트 프롬프트를 입력하여 Qwen3-4B-Thinking 모델을 사용해 상세하고 추론된 응답을 생성합니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["텍스트 생성"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "Gemini의 추론 기능으로 Google의 멀티모달 AI를 경험합니다.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "텍스트 생성"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Um modelo leve de 2B que gera imagens de alta qualidade visual a partir de prompts em inglês e russo.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["Áudio", "Clonagem de Voz"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["Áudio", "Texto para Fala", "Clonagem de Voz"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "O GPT-5.6 Luna simplifica a pré-produção visual analisando uma única imagem de referência e gerando texto criativo estruturado a partir de um prompt do usuário. Ele recebe 1 imagem de entrada e não produz saídas visuais explícitas, concentrando-se em vez disso em uma redação rápida e padronizada. Ideal para expansão de descrições de cena em lote, organização de lista de tomadas e ideação criativa de alto volume.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Geração de Texto"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "Descreva uma cena ou mundo usando o GPT-5.6 Terra, um modelo multimodal equilibrado que interpreta uma Imagem enviada para guiar a narrativa visual e a consistência de estilo. Ideal para construção de mundos, criação de mood boards e manutenção de uma estética coesa em uma série de trabalhos.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Geração de Texto"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "O Grok 4.5 é um modelo multimodal de ponta projetado para tarefas complexas de engenharia e criativas, com análise visual nativa e inferência de alta velocidade. Ele recebe briefings criativos e imagens geradas como entradas, produzindo descrições de cena padronizadas e análise visual iterativa. Ideal para storyboarding de múltiplas tomadas, geração de descrições de imagens em lote e refinamento criativo orientado por feedback.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Geração de Texto"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "Gere descrições detalhadas de imagens e briefings criativos usando o Kimi K3, um modelo multimodal com janelas de contexto de um milhão de tokens para compreensão unificada de texto e imagem. Insira uma imagem e um prompt de texto para produzir análises visuais detalhadas ou descrições em lote. Ideal para simplificar séries visuais de múltiplas tomadas, gerar prompts de script automatizados para fluxos de trabalho baseados em nós e refinar iterativamente conceitos criativos por meio de feedback de imagem.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Geração de Texto"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5, o primeiro modelo público de classe Mythos da Anthropic, potencializa fluxos de trabalho criativos de ponta a ponta no ComfyUI. Ele recebe 1 prompt de texto e gera 1 saída estruturada incluindo detalhamentos de storyboard, prompts precisos para modelos SD e ControlNet, e scripts de nós personalizados. Ideal para artistas conceituais refinando narrativas visuais, cineastas de IA mantendo consistência de estilo em séries e criadores digitais automatizando todo o pipeline de renderização.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Geração de Texto"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "Aproveite o Claude Sonnet 5 para execução autônoma de tarefas de alto valor, preenchendo a lacuna para o desempenho principal a um custo menor. Insira qualquer prompt ou script de texto para gerar descrições de imagem precisas, scripts de fluxo de trabalho automatizados, logs de sequência de cenas ou correções de lógica de nós. Ideal para tarefas de produção em lote, depuração de lógica de nós do ComfyUI e manutenção de qualidade de saída consistente em fluxos de trabalho de geração repetitivos.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Geração de Texto"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "TextGenerate com compreensão visual usando Modelos Qwen3-VL, processando uma imagem de entrada para produzir respostas de texto contextuais. Ideal para legendagem de imagens, resposta a perguntas visuais e geração de conteúdo multimodal.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Geração de Texto"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "Selecione um modelo da lista selecionada do OpenRouter (Claude, GPT, Gemini, etc.). Gere uma resposta de texto com uploads opcionais de mídia para modelos com capacidade de visão.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["Geração de Texto", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "Insira sua consulta ou imagem para análise. Gere uma resposta em linguagem natural alimentada pelo Anthropic Claude, suportando tanto conversas de texto quanto compreensão de imagens.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Geração de Texto"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "Insira seu prompt de texto e, opcionalmente, uma imagem, áudio ou vídeo. Gere uma saída de texto com suporte configurável para raciocínio, codificação e multilíngue.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Geração de Texto"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "Use o modelo Qwen3.5 para analisar uma imagem de entrada e Gerar prompts de texto descritivos. Este fluxo de trabalho realiza legendagem de imagem e engenharia de prompt reversa.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Geração de Texto"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "Insira um prompt de texto para gerar respostas detalhadas e fundamentadas usando o modelo Qwen3-4B-Thinking.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Geração de Texto"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "Experimente a IA multimodal do Google com as capacidades de raciocínio do Gemini.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Geração de Texto"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "Легковесная 2B-модель, создающая качественные изображения по текстовым подсказкам на английском и русском языках.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["Аудио", "Клонирование Голоса"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["Аудио", "Преобразование текста в речь", "Клонирование Голоса"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna оптимизирует визуальную препродакшн, анализируя одно референсное изображение и генерируя структурированный креативный текст из пользовательского промпта. Он принимает 1 входное изображение и не создает явных визуальных выходов, сосредотачиваясь вместо этого на быстром, стандартизированном копирайтинге. Идеально подходит для пакетного расширения описаний сцен, организации списков кадров и высокообъемной креативной генерации идей.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Генерация текста"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "Опишите сцену или мир с помощью GPT-5.6 Terra — сбалансированной мультимодальной модели, которая интерпретирует одно загруженное Изображение для управления визуальным повествованием и согласованностью стиля. Идеально подходит для построения миров, создания досок настроения и поддержания единой эстетики в серии работ.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Генерация текста"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5 — это флагманская мультимодальная модель, предназначенная для сложных инженерных и творческих задач, с нативным визуальным парсингом и высокоскоростным выводом. Она принимает креативные брифы и сгенерированные изображения в качестве входов, создавая стандартизированные описания сцен и итеративный визуальный анализ. Идеально подходит для многокадрового раскадровки, пакетной генерации описаний изображений и творческой доработки на основе обратной связи.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Генерация текста"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "Генерируйте подробные описания изображений и креативные брифы с помощью Kimi K3, мультимодальной модели с окнами контекста в миллион токенов для унифицированного понимания текста и изображений. Введите одно изображение и текстовый промпт, чтобы получить детальный визуальный анализ или пакетные описания. Идеально подходит для оптимизации многосъемочных визуальных серий, создания автоматизированных скриптовых промптов для рабочих процессов на основе узлов и итеративного улучшения креативных концепций с помощью Обратной связи по изображениям.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Генерация текста"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5, первая публичная модель класса Mythos от Anthropic, обеспечивает сквозные творческие рабочие процессы в ComfyUI. Она принимает 1 текстовый промпт и генерирует 1 структурированный выход, включающий разбивку раскадровки, точные промпты для моделей SD и ControlNet, а также скрипты пользовательских узлов. Идеально подходит для концепт-художников, уточняющих визуальные повествования, ИИ-кинематографистов, поддерживающих единообразие стиля в сериях, и цифровых создателей, автоматизирующих весь свой конвейер рендеринга.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Генерация текста"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "Используйте Claude Sonnet 5 для выполнения высокоценных автономных задач, сокращая разрыв с флагманской производительностью при более низкой стоимости. Введите любой текстовый промпт или скрипт, чтобы генерировать точные описания изображений, автоматизированные скрипты рабочего процесса, журналы последовательности кадров или исправления логики узлов. Идеально подходит для задач пакетного производства, отладки логики узлов ComfyUI и поддержания стабильного качества вывода в повторяющихся рабочих процессах генерации.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Генерация текста"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "TextGenerate с визуальным пониманием с помощью Моделей Qwen3-VL, обрабатывая одно входное изображение для создания контекстных текстовых ответов. Идеально подходит для описания изображений, визуальных вопросов-ответов и генерации мультимодального содержимого.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Генерация текста"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "Выберите модель из подобранного списка OpenRouter (Claude, GPT, Gemini и т.д.). Сгенерируйте текстовый ответ с возможностью загрузки медиафайлов для моделей, поддерживающих зрение.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["Генерация текста", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "Введите ваш запрос или изображение для анализа. Создайте ответ на естественном языке на базе Anthropic Claude, поддерживающий как текстовое общение, так и понимание изображений.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Генерация текста"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "Введите текстовый промпт и, при желании, изображение, аудио или видео. Создайте текстовый выход с настраиваемой поддержкой рассуждений, кодирования и многоязычности.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Генерация текста"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "Используйте модель Qwen3.5 для анализа входного изображения и Генерировать описательные текстовые промпты. Этот рабочий процесс выполняет подпись изображений и обратную разработку промптов.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Генерация текста"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "Введите текстовый промпт, чтобы генерировать подробные и обоснованные ответы с помощью модели Qwen3-4B-Thinking.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Генерация текста"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "Опыт мультимодального ИИ от Google с возможностями рассуждения Gemini.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Генерация текста"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "İngilizce ve Rusça istemlerden yüksek görsel kalitesinde görüntüler üreten hafif 2B model.",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["Ses", "Ses Klonlama"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["Ses", "Metinden Sese", "Ses Klonlama"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna, tek bir referans görüntüyü analiz ederek ve bir kullanıcı isteminden yapılandırılmış yaratıcı metin üreterek görsel ön prodüksiyonu kolaylaştırır. 1 giriş görüntüsü alır ve hiçbir açık görsel çıktı üretmez, bunun yerine hızlı, standartlaştırılmış metin yazarlığına odaklanır. Toplu sahne açıklaması genişletme, çekim listesi düzenleme ve yüksek hacimli yaratıcı fikir üretimi için idealdir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Metin Üretimi"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "GPT-5.6 Terra'yı kullanarak bir sahneyi veya dünyayı tanımlayın; bu, yüklenen bir Görsel'i yorumlayarak görsel hikaye anlatımını ve stil tutarlılığını yönlendiren dengeli bir multimodal modeldir. Dünya inşası, ruh hali panosu oluşturma ve bir dizi çalışma boyunca uyumlu bir estetik sürdürmek için idealdir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Metin Üretimi"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5, karmaşık mühendislik ve yaratıcı görevler için tasarlanmış, yerel görsel ayrıştırma ve yüksek hızlı çıkarım sunan amiral gemisi çok modlu bir modeldir. Yaratıcı brifingleri ve oluşturulan görselleri girdi olarak alır, standartlaştırılmış sahne açıklamaları ve yinelemeli görsel analiz üretir. Çoklu çekim storyboard'ları, toplu görsel açıklaması oluşturma ve geri bildirim odaklı yaratıcı iyileştirme için idealdir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Metin Üretimi"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "Kimi K3'ü kullanarak ayrıntılı görsel açıklamaları ve yaratıcı brifingler oluşturun; bu, birleşik metin ve görsel anlama için milyon token bağlam pencerelerine sahip çok modlu bir modeldir. Bir görsel ve bir metin istemi girin; nüanslı görsel analizler veya toplu açıklamalar üretin. Çoklu çekim görsel serilerini kolaylaştırmak, düğüm tabanlı iş akışları için otomatik komut dosyası istemleri oluşturmak ve görsel Geri Bildirimi aracılığıyla yaratıcı konseptleri yinelemeli olarak iyileştirmek için idealdir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Metin Üretimi"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5, Anthropic'in ilk halka açık Mythos sınıfı öncü modeli, ComfyUI'de uçtan uca yaratıcı iş akışlarını güçlendirir. 1 metin istemi alır ve storyboard dökümleri, SD modelleri ve ControlNet için hassas istemler ve özel düğüm komut dosyaları dahil olmak üzere 1 yapılandırılmış çıktı üretir. Görsel anlatıları iyileştiren konsept sanatçıları, seriler boyunca stil tutarlılığını koruyan AI film yapımcıları ve tüm render hattını otomatikleştiren dijital yaratıcılar için idealdir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Metin Üretimi"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "Claude Sonnet 5'i yüksek değerli otonom görev yürütme için kullanın, daha düşük maliyetle amiral gemisi performansına olan boşluğu kapatın. Hassas görsel açıklamaları, otomatik iş akışı betikleri, çekim sırası kayıtları veya düğüm mantığı düzeltmeleri oluşturmak için herhangi bir metin istemi veya betik girin. Toplu üretim görevleri, ComfyUI düğüm mantığını hata ayıklama ve tekrarlayan oluşturma iş akışlarında tutarlı çıktı kalitesini koruma için idealdir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Metin Üretimi"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "Qwen3-VL Modelleri kullanarak görsel anlama ile TextGenerate yapın, bir giriş görüntüsünü işleyerek bağlamsal metin yanıtları üretin. Görsel altyazılama, görsel soru yanıtlama ve çok modlu içerik oluşturma için idealdir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Metin Üretimi"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "OpenRouter'ın seçilmiş listesinden (Claude, GPT, Gemini vb.) bir model seçin. Görüntü destekli modeller için isteğe bağlı medya yüklemeleriyle bir metin yanıtı oluşturun.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["Metin Üretimi", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "Analiz için sorgunuzu veya görselinizi girin. Anthropic Claude tarafından desteklenen, hem metin sohbetini hem de görüntü anlamayı destekleyen doğal dil yanıtı oluşturun.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Metin Üretimi"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "Metin isteminizi ve isteğe bağlı olarak bir görsel, ses veya video girin. Yapılandırılabilir akıl yürütme, kodlama ve çok dilli destek ile metin çıktısı oluşturun.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Metin Üretimi"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "Bir giriş görüntüsünü analiz etmek ve açıklayıcı metin istemleri Oluştur için Qwen3.5 modelini kullanın. Bu iş akışı, görsel altyazılama ve ters istem mühendisliği gerçekleştirir.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Metin Üretimi"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "Qwen3-4B-Thinking modelini kullanarak ayrıntılı, mantıklı yanıtlar oluşturmak için bir metin istemi girin.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["Metin Üretimi"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "Gemini'nin akıl yürütme yetenekleri ile Google'ın çoklu modlu yapay zekasını deneyimleyin.",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "Metin Üretimi"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "輕量級 2B 模型，從英文和俄文提示生成高視覺品質影像。",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["音頻", "語音克隆"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["音頻", "文字轉語音", "語音克隆"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna 通過分析單張參考圖並根據使用者提示詞生成結構化創意文字，簡化了視覺前期製作。它接收1張輸入圖像，不產生顯式視覺輸出，專注於快速、標準化的文案撰寫。非常適合批次場景描述擴展、鏡頭列表整理以及高容量創意構思。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文字生成"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "使用GPT-5.6 Terra描述一個場景或世界，這是一個平衡的多模態模型，可解讀一張上傳的圖片，以引導視覺敘事和風格一致性。適用於世界構建、情緒板創建以及在一系列作品中保持統一的審美風格。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文字生成"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5 是一款旗艦多模態模型，專為複雜工程和創意任務而設計，具備原生視覺解析和高速推論能力。它以創意簡報和已生成圖像作為輸入，產生標準化場景描述和迭代視覺分析。非常適合多鏡頭故事板、批次圖片描述生成以及意見回饋驅動的創意優化。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文字生成"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "使用Kimi K3產生詳細的圖片描述和創意簡報，這是一個具有百萬token上下文視窗的多模態模型，用於統一的文字和圖片理解。輸入一張圖片和一個文字提示詞，即可產生細緻的視覺分析或批次描述。非常適合簡化多鏡頭視覺系列、為基於節點的工作流程產生自動化腳本提示詞，以及透過圖片意見回饋迭代優化創意概念。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文字生成"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5，Anthropic 首個公開的 Mythos 級前沿模型，為 ComfyUI 中的端到端創意工作流程提供支援。它接收 1 個文字提示詞，生成 1 個結構化輸出，包括故事板分解、SD 模型和 ControlNet 的精確提示詞，以及自訂節點腳本。非常適合用於細化視覺敘事的概念藝術家、保持系列風格一致的 AI 電影製作人，以及自動化整個渲染管線的數位創作者。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文字生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "利用Claude Sonnet 5執行高價值自主任務，以較低成本彌合與旗艦性能的差距。輸入任何文字提示詞或指令碼，即可產生精確的圖片描述、自動化工作流程指令碼、鏡頭序列日誌或節點邏輯修正。適用於批次生產任務、除錯ComfyUI節點邏輯以及在重複性產生工作流程中保持一致的輸出品質。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文字生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "使用Qwen3-VL模型，透過視覺理解生成文本，處理一張輸入圖像以產生上下文相關的文本回應。適用於圖片描述、視覺問答和多模態內容生成。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文字生成"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "從OpenRouter精選列表中選擇一個模型（Claude、GPT、Gemini等）。生成文字回應，並可選擇上傳媒體檔案以用於支援視覺的模型。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["文字生成", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "輸入您的查詢或圖像進行分析。生成由Anthropic Claude驅動的自然語言回應，支援文字對話和圖像理解。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文字生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "輸入您的文字提示詞，並可選擇圖片、音訊或影片。透過可配置的推理、編碼和多語言支援生成文字輸出。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文字生成"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "使用Qwen3.5模型分析輸入圖像並產生描述性文字提示詞。此工作流程執行圖片描述和反向提示詞工程。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文字生成"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "輸入文字提示詞，使用Qwen3-4B-Thinking模型產生詳細、有推理的回應。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文字生成"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "體驗 Google 的多模態 AI 與 Gemini 的推理能力。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文字生成"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -18,7 +18,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 8330,
+        "usage": 15041,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -74,7 +74,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2310,
+        "usage": 244,
         "io": {
           "inputs": [
             {
@@ -117,7 +117,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 6467,
+        "usage": 343,
         "io": {
           "inputs": [
             {
@@ -146,7 +146,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 1156,
+        "usage": 618,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -230,7 +230,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2927,
+        "usage": 1964,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -285,6 +285,7 @@
             }
           ]
         },
+        "thumbnail": ["thumbnail/image_krea2_turbo_int8_image_style_reference.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -333,7 +334,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6941,
+        "usage": 991,
         "io": {
           "inputs": [
             {
@@ -444,7 +445,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2559,
+        "usage": 295,
         "io": {
           "inputs": [
             {
@@ -531,7 +532,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2078,
+        "usage": 664,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -750,7 +751,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 2832,
+        "usage": 1209,
         "io": {
           "inputs": [
             {
@@ -817,7 +818,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 816,
+        "usage": 451,
         "io": {
           "inputs": [
             {
@@ -905,7 +906,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 950,
+        "usage": 426,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -992,7 +993,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 1142,
+        "usage": 127,
         "io": {
           "outputs": [
             {
@@ -1232,7 +1233,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 581,
+        "usage": 800,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -1315,7 +1316,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 606,
+        "usage": 465,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -1370,7 +1371,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 723,
+        "usage": 272,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1403,7 +1404,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 227,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1442,16 +1443,9 @@
               "file": "perfume_bottle.png.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 182,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Joy_Image_Edit.png",
-              "mediaType": "image"
-            }
           ]
         },
+        "thumbnail": ["input/perfume_bottle.png.png", "output/Joy_Image_Edit.png"],
         "includeOnDistributions": ["local"]
       },
       {
@@ -1671,7 +1665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 426,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1755,7 +1749,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 636,
+        "usage": 161,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -1774,7 +1768,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 16,
+        "usage": 161,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1816,7 +1810,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 754,
+        "usage": 247,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -1882,7 +1876,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1911,7 +1905,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 186,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1945,7 +1939,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1974,7 +1968,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 314,
+        "usage": 102,
         "io": {
           "inputs": [
             {
@@ -2030,7 +2024,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2056,7 +2050,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 1444,
+        "usage": 552,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -2092,7 +2086,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 929,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -2120,7 +2114,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 72,
+        "usage": 32,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2160,7 +2154,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 22,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2218,7 +2212,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2233,7 +2227,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 259,
+        "usage": 75,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -2263,7 +2257,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 857,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2297,7 +2291,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 196,
+        "usage": 38,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -2326,7 +2320,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 633,
+        "usage": 106,
         "io": {
           "inputs": [
             {
@@ -2369,7 +2363,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 1240,
+        "usage": 123,
         "io": {
           "inputs": [
             {
@@ -2412,7 +2406,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 812,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2443,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 292,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -2489,7 +2483,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2522,7 +2516,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 19,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2557,7 +2551,7 @@
         "openSource": true,
         "size": 36185099469,
         "vram": 36185099469,
-        "usage": 69,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2585,7 +2579,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 434,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -2622,7 +2616,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 127,
+        "usage": 27,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2658,7 +2652,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2699,7 +2693,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 13,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2748,7 +2742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -2778,7 +2772,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -2800,7 +2794,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2825,7 +2819,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 49,
+        "usage": 12,
         "io": {
           "outputs": [
             {
@@ -2911,7 +2905,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 156,
+        "usage": 56,
         "io": {
           "outputs": [
             {
@@ -2939,7 +2933,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 355,
+        "usage": 111,
         "io": {
           "outputs": [
             {
@@ -2967,7 +2961,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 447,
+        "usage": 179,
         "io": {
           "outputs": [
             {
@@ -2994,7 +2988,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 202,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -3035,7 +3029,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 610,
+        "usage": 159,
         "username": "ComfyUI"
       },
       {
@@ -3051,7 +3045,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 219,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -3077,7 +3071,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 524,
+        "usage": 137,
         "io": {
           "outputs": [
             {
@@ -3105,7 +3099,7 @@
         "date": "2025-08-23",
         "size": 35304631173,
         "vram": 35304631173,
-        "usage": 113,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3130,7 +3124,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 92,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -3156,7 +3150,7 @@
         "thumbnailVariant": "hoverZoom",
         "description": "轻量级 2B 模型，从英语和俄语提示生成高质量视觉图像。",
         "date": "2026-02-03",
-        "usage": 14,
+        "usage": 10,
         "size": 21689584845,
         "vram": 21689584845,
         "searchRank": 0,
@@ -3185,7 +3179,7 @@
         "date": "2025-09-18",
         "size": 24159191040,
         "vram": 24159191040,
-        "usage": 43,
+        "usage": 35,
         "io": {
           "outputs": [
             {
@@ -3214,7 +3208,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 148,
+        "usage": 56,
         "io": {
           "inputs": [
             {
@@ -3240,7 +3234,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 195,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -3265,7 +3259,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 91,
         "io": {
           "inputs": [
             {
@@ -3289,7 +3283,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 49,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3330,7 +3324,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 65,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -3365,7 +3359,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 41,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -3390,7 +3384,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 60,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -3427,7 +3421,7 @@
         "date": "2025-09-21",
         "size": 22333829939,
         "vram": 22333829939,
-        "usage": 121,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3462,7 +3456,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 302,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -3477,7 +3471,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -3493,7 +3487,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 44,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -3517,7 +3511,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 211,
+        "usage": 273,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -3547,7 +3541,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3573,7 +3567,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 114,
+        "usage": 51,
         "io": {
           "inputs": [
             {
@@ -3600,7 +3594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -3626,7 +3620,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 118,
+        "usage": 102,
         "username": "ComfyUI"
       },
       {
@@ -3642,7 +3636,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 32,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3678,7 +3672,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 93,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -3705,7 +3699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 312,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3745,7 +3739,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 102,
+        "usage": 178,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -3773,7 +3767,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -3799,7 +3793,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -3823,7 +3817,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 84,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3872,7 +3866,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 139,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -3899,7 +3893,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 110,
+        "usage": 60,
         "io": {
           "inputs": [
             {
@@ -3936,7 +3930,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 64,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -3967,7 +3961,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 77,
+        "usage": 51,
         "username": "ComfyUI"
       },
       {
@@ -3982,7 +3976,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 57,
+        "usage": 27,
         "io": {
           "outputs": [
             {
@@ -4011,7 +4005,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -4078,7 +4072,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 27,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -4115,7 +4109,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 133,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -4142,7 +4136,7 @@
         "date": "2025-04-17",
         "size": 33285996544,
         "vram": 33285996544,
-        "usage": 21,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4170,7 +4164,7 @@
         "date": "2025-04-17",
         "size": 24266565222,
         "vram": 24266565222,
-        "usage": 25,
+        "usage": 13,
         "io": {
           "outputs": [
             {
@@ -4228,7 +4222,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -4254,7 +4248,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 53,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -4290,7 +4284,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 96,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4323,7 +4317,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -4349,7 +4343,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4390,7 +4384,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "outputs": [
             {
@@ -4423,7 +4417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 21,
         "io": {
           "outputs": [
             {
@@ -4455,7 +4449,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 12,
+        "usage": 40,
         "username": "ComfyUI"
       },
       {
@@ -4470,7 +4464,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "username": "ComfyUI"
       },
       {
@@ -4485,7 +4479,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -4515,7 +4509,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 115,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -4532,7 +4526,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 118,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -4559,7 +4553,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -4619,7 +4613,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -4645,7 +4639,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 4,
         "io": {
           "inputs": [
             {
@@ -4700,7 +4694,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 6731,
+        "usage": 1235,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4710,8 +4704,7 @@
               "file": "egyptian_queen.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -4727,7 +4720,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1257,
+        "usage": 1502,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4773,7 +4766,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2923,
+        "usage": 40939,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -4884,7 +4877,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 1713,
+        "usage": 11123,
         "io": {
           "inputs": [
             {
@@ -4923,7 +4916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1143,
+        "usage": 884,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -5136,7 +5129,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 973,
+        "usage": 914,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5176,7 +5169,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 402,
+        "usage": 1014,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -5274,7 +5267,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_talking_photo.mp4"]
       },
       {
         "name": "video_ltx2_3_flf2v",
@@ -5288,7 +5282,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 965,
+        "usage": 134,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5426,7 +5420,8 @@
               "mediaType": "video"
             }
           ]
-        }
+        },
+        "thumbnail": ["output/api_heygen_avatar_video.mp4"]
       },
       {
         "name": "video_wan2_2_14B_i2v",
@@ -5441,7 +5436,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 3682,
+        "usage": 1142,
         "io": {
           "inputs": [
             {
@@ -5544,7 +5539,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1142,
+        "usage": 334,
         "io": {
           "inputs": [
             {
@@ -5575,7 +5570,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 321,
+        "usage": 126,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5785,8 +5780,16 @@
         "usage": 0,
         "searchRank": 0,
         "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_video_translate.png"],
         "io": {
-          "inputs": [],
+          "inputs": [
+            {
+              "nodeId": 5,
+              "nodeType": "LoadVideo",
+              "file": "heygen_input.mp4",
+              "mediaType": "video"
+            }
+          ],
           "outputs": [
             {
               "nodeId": 6,
@@ -5840,7 +5843,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 156,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5882,7 +5885,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5928,7 +5931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 66,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -5963,7 +5966,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1374,
+        "usage": 1054,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -5990,7 +5993,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 317,
+        "usage": 1148,
         "username": "ComfyUI"
       },
       {
@@ -6039,7 +6042,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 74,
+        "usage": 93,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6072,7 +6075,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 584,
+        "usage": 152,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6112,7 +6115,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 356,
+        "usage": 861,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6432,7 +6435,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6478,7 +6481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 78,
+        "usage": 71,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -6504,7 +6507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 83,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -6549,7 +6552,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 113,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6591,7 +6594,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 196,
+        "usage": 156,
         "io": {
           "inputs": [
             {
@@ -6631,7 +6634,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 101,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6673,7 +6676,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 202,
         "io": {
           "inputs": [
             {
@@ -6704,7 +6707,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 363,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6777,7 +6780,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 289,
+        "usage": 56,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6814,7 +6817,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 274,
+        "usage": 3,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6863,7 +6866,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 92,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6889,7 +6892,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 113,
+        "usage": 54,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -6923,7 +6926,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 372,
+        "usage": 212,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2", "comfyui-kjnodes", "comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -6957,7 +6960,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 33,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6997,7 +7000,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 62,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7065,7 +7068,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 203,
+        "usage": 159,
         "io": {
           "inputs": [
             {
@@ -7096,7 +7099,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 111,
+        "usage": 68,
         "io": {
           "inputs": [
             {
@@ -7127,7 +7130,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -7141,7 +7144,7 @@
         "models": ["Vidu", "Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 14,
+        "usage": 89,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -7175,7 +7178,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 321,
+        "usage": 284,
         "io": {
           "inputs": [
             {
@@ -7198,7 +7201,7 @@
         "models": ["Kling 2.6", "Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 144,
+        "usage": 658,
         "io": {
           "inputs": [
             {
@@ -7229,7 +7232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -7252,7 +7255,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 96,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -7276,7 +7279,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 113,
+        "usage": 74,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7304,7 +7307,7 @@
         "size": 38010460570,
         "vram": 38010460570,
         "requiresCustomNodes": ["comfyui_controlnet_aux"],
-        "usage": 79,
+        "usage": 28,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7321,8 +7324,7 @@
               "file": "woman_with_paper.mp4",
               "mediaType": "video"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7337,7 +7339,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 48,
+        "usage": 18,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -7354,7 +7356,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7371,8 +7373,7 @@
               "file": "ltx_2_canny_1st_frame.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": []
+          ]
         },
         "username": "ComfyUI"
       },
@@ -7388,7 +7389,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 83,
+        "usage": 21,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -7420,7 +7421,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess", "ComfyUI-WanVideoWrapper", "comfyui-kjnodes", "comfyui-scail-pose", "comfyui-videohelpersuite", "comfyui_essentials"],
-        "usage": 177,
+        "usage": 206,
         "io": {
           "inputs": [
             {
@@ -7453,7 +7454,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 154,
+        "usage": 218,
         "io": {
           "inputs": [
             {
@@ -7480,7 +7481,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 179,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -7509,7 +7510,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 38,
+        "usage": 25,
         "io": {
           "inputs": [
             {
@@ -7547,7 +7548,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 231,
+        "usage": 208,
         "io": {
           "inputs": [
             {
@@ -7654,7 +7655,7 @@
         "models": ["Vidu Q2"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -7684,7 +7685,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 283,
+        "usage": 201,
         "io": {
           "inputs": [
             {
@@ -7709,7 +7710,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 72,
+        "usage": 42,
         "io": {
           "inputs": [
             {
@@ -7741,7 +7742,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 205,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -7775,7 +7776,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 43,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -7805,7 +7806,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 21,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -7834,7 +7835,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 7,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -7849,7 +7850,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -7874,7 +7875,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 23,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -7906,7 +7907,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -7931,7 +7932,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 168,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -7957,7 +7958,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 24,
         "username": "ComfyUI"
       },
       {
@@ -7971,7 +7972,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 45,
+        "usage": 82,
         "io": {
           "outputs": [
             {
@@ -8000,7 +8001,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 56,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8031,7 +8032,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 60,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -8056,7 +8057,7 @@
         "openSource": true,
         "size": 29635274342,
         "vram": 29635274342,
-        "usage": 50,
+        "usage": 138,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8102,7 +8103,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 26,
+        "usage": 133,
         "io": {
           "inputs": [
             {
@@ -8128,7 +8129,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 7,
+        "usage": 14,
         "requiresCustomNodes": ["comfyui_fill-nodes"],
         "io": {
           "inputs": [
@@ -8154,7 +8155,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6", "Wan"],
-        "usage": 7,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8186,7 +8187,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 82,
+        "usage": 35,
         "io": {
           "inputs": [
             {
@@ -8210,7 +8211,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 78,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -8253,7 +8254,7 @@
         "date": "2025-09-21",
         "size": 27895812588,
         "vram": 27895812588,
-        "usage": 23,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8284,7 +8285,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 40,
+        "usage": 91,
         "username": "ComfyUI"
       },
       {
@@ -8331,7 +8332,7 @@
         "date": "2025-08-17",
         "size": 40050570035,
         "vram": 40050570035,
-        "usage": 39,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -8357,7 +8358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -8394,7 +8395,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 93,
+        "usage": 340,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8420,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -8435,7 +8436,7 @@
         "date": "2025-04-15",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 29,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8465,7 +8466,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 32,
+        "usage": 17,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -8490,7 +8491,7 @@
         "models": ["Vidu Q2", "Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 14,
+        "usage": 12,
         "username": "ComfyUI"
       },
       {
@@ -8506,7 +8507,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -8532,7 +8533,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8558,7 +8559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8589,7 +8590,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 43,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8630,7 +8631,7 @@
         "date": "2025-12-09",
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 12,
+        "usage": 3,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -8648,7 +8649,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 46,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8683,7 +8684,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 55,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -8719,7 +8720,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -8733,7 +8734,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 13,
+        "usage": 22,
         "username": "ComfyUI"
       },
       {
@@ -8748,7 +8749,7 @@
         "date": "2025-03-01",
         "size": 16492674417,
         "vram": 16492674417,
-        "usage": 31,
+        "usage": 56,
         "username": "ComfyUI"
       },
       {
@@ -8764,7 +8765,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8790,7 +8791,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -8816,7 +8817,7 @@
         "date": "2025-05-21",
         "size": 25393994138,
         "vram": 25393994138,
-        "usage": 6,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -8841,7 +8842,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -8857,7 +8858,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "username": "ComfyUI"
       },
       {
@@ -8873,7 +8874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8889,7 +8890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -8915,7 +8916,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 2,
+        "usage": 7,
         "username": "ComfyUI"
       },
       {
@@ -8929,7 +8930,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 21,
+        "usage": 36,
         "io": {
           "inputs": [
             {
@@ -8961,7 +8962,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 3,
+        "usage": 6,
         "io": {
           "inputs": [
             {
@@ -9001,7 +9002,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 71,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -9033,7 +9034,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 8,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -9084,7 +9085,7 @@
         "date": "2025-04-15",
         "size": 42047729828,
         "vram": 42047729828,
-        "usage": 9,
+        "usage": 7,
         "io": {
           "inputs": [
             {
@@ -9109,7 +9110,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 16,
+        "usage": 20,
         "username": "ComfyUI"
       },
       {
@@ -9124,7 +9125,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 5,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -9149,7 +9150,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 9,
+        "usage": 37,
         "io": {
           "inputs": [
             {
@@ -9180,7 +9181,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 34,
+        "usage": 56,
         "username": "ComfyUI"
       }
     ]
@@ -9239,7 +9240,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 2123,
+        "usage": 916,
         "io": {
           "inputs": [
             {
@@ -9592,7 +9593,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 625,
+        "usage": 460,
         "io": {
           "inputs": [
             {
@@ -9691,7 +9692,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 660,
+        "usage": 805,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9733,7 +9734,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 381,
+        "usage": 266,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -9781,7 +9782,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 69,
+        "usage": 280,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -9860,7 +9861,7 @@
         "openSource": true,
         "size": 77202037146,
         "vram": 77202037146,
-        "usage": 9,
+        "usage": 18,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -9887,7 +9888,7 @@
         "openSource": true,
         "size": 39406324941,
         "vram": 39406324941,
-        "usage": 69,
+        "usage": 56,
         "searchRank": 0,
         "username": "shane",
         "io": {
@@ -9982,7 +9983,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 102,
+        "usage": 55,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10027,7 +10028,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 17,
+        "usage": 72,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10065,7 +10066,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 13,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10133,7 +10134,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 69,
+        "usage": 29,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10247,7 +10248,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 80,
+        "usage": 135,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10288,7 +10289,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 39,
+        "usage": 675,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10356,7 +10357,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 53,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -10436,7 +10437,7 @@
         "openSource": true,
         "size": 30816390349,
         "vram": 30816390349,
-        "usage": 146,
+        "usage": 94,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -10463,7 +10464,7 @@
         "openSource": true,
         "size": 30709016166,
         "vram": 30709016166,
-        "usage": 18,
+        "usage": 11,
         "searchRank": 0,
         "username": "enigmatic_e",
         "io": {
@@ -10536,7 +10537,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 39,
+        "usage": 125,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png", "thumbnail/templates_ohneis_i2v-2.png"]
@@ -10558,7 +10559,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 11,
         "searchRank": 0,
         "username": "Doc_workBox",
         "io": {
@@ -10600,7 +10601,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 275,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10639,7 +10640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10691,7 +10692,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 74,
+        "usage": 263,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10717,7 +10718,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 207,
+        "usage": 92,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -10752,7 +10753,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 67,
+        "usage": 55,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10798,7 +10799,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 82,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -10841,7 +10842,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 324,
+        "usage": 453,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10883,7 +10884,7 @@
         "openSource": true,
         "size": 50787988275,
         "vram": 50787988275,
-        "usage": 9,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10917,7 +10918,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10965,7 +10966,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 24,
+        "usage": 59,
         "searchRank": 0,
         "username": "shane"
       },
@@ -11054,7 +11055,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11095,7 +11096,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 46,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11128,7 +11129,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 222,
+        "usage": 56,
         "logos": [
           {
             "provider": "Google"
@@ -11160,7 +11161,7 @@
         "models": ["Qwen", "Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 76,
+        "usage": 40,
         "io": {
           "inputs": [
             {
@@ -11195,7 +11196,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 64,
+        "usage": 62,
         "io": {
           "inputs": [
             {
@@ -11238,7 +11239,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 24,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11266,7 +11267,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 89,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11304,7 +11305,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 15,
+        "usage": 60,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11346,7 +11347,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 89,
+        "usage": 158,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11374,7 +11375,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 40,
+        "usage": 85,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11415,7 +11416,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 18,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11508,7 +11509,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 44,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11548,7 +11549,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 55,
+        "usage": 119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11589,7 +11590,7 @@
         "openSource": true,
         "size": 60129542144,
         "vram": 60129542144,
-        "usage": 14,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11621,7 +11622,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 31,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11700,7 +11701,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 16,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11759,7 +11760,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 352,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -11818,7 +11819,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 57,
+        "usage": 72,
         "io": {
           "inputs": [
             {
@@ -11844,7 +11845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 232,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -11907,7 +11908,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 218,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11933,7 +11934,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 17,
+        "usage": 33,
         "logos": [
           {
             "provider": "Google"
@@ -11977,7 +11978,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 223,
         "logos": [
           {
             "provider": "Google"
@@ -12016,7 +12017,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 44,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12067,7 +12068,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 443,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12106,7 +12107,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 22,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12138,7 +12139,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12174,7 +12175,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 42,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -12201,7 +12202,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12234,7 +12235,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 9,
+        "usage": 50,
         "logos": [
           {
             "provider": ["Google", "Kling", "OpenAI"],
@@ -12279,7 +12280,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -12304,7 +12305,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 10,
+        "usage": 3,
         "logos": [
           {
             "provider": "Google"
@@ -12369,7 +12370,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 38,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12417,7 +12418,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 31,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12461,7 +12462,7 @@
         "size": 31568009626,
         "requiresCustomNodes": ["ComfyUI-WanVideoWrapper", "comfyui_fill-nodes"],
         "vram": 31568009626,
-        "usage": 21,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -12497,7 +12498,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 86,
         "logos": [
           {
             "provider": "Google"
@@ -12535,7 +12536,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 12,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12574,7 +12575,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 35,
         "logos": [
           {
             "provider": "Google"
@@ -12614,7 +12615,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 20,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12682,7 +12683,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -12720,7 +12721,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 37,
         "logos": [
           {
             "provider": "Google"
@@ -12760,7 +12761,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -12797,7 +12798,7 @@
         "openSource": false,
         "size": 48855252992,
         "vram": 48855252992,
-        "usage": 22,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12846,7 +12847,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 6,
+        "usage": 12,
         "logos": [
           {
             "provider": "Google"
@@ -12875,7 +12876,7 @@
         "models": ["Gemini3 Pro Image Preview", "Google", "Nano Banana Pro"],
         "date": "2026-01-13",
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 3,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -12903,7 +12904,7 @@
         "size": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
         "vram": 0,
-        "usage": 3,
+        "usage": 9,
         "logos": [
           {
             "provider": "Google"
@@ -12937,7 +12938,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 27,
+        "usage": 40,
         "logos": [
           {
             "provider": ["ByteDance", "Google"]
@@ -12981,7 +12982,7 @@
         "date": "2026-01-19",
         "openSource": false,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 5,
+        "usage": 1,
         "logos": [
           {
             "provider": ["Kling", "Google"]
@@ -13152,7 +13153,8 @@
         "vram": 0,
         "usage": 0,
         "searchRank": 0,
-        "username": "ComfyUI"
+        "username": "ComfyUI",
+        "thumbnail": ["thumbnail/api_heygen_text_to_speech.png"]
       },
       {
         "name": "api_sonilo_v2m",
@@ -13218,7 +13220,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 29,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13235,7 +13237,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 585,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13251,7 +13253,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 187,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13272,7 +13274,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 699,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13304,7 +13306,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13336,7 +13338,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13375,7 +13377,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 5,
+        "usage": 6,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13407,7 +13409,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13439,7 +13441,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13466,7 +13468,7 @@
         "openSource": true,
         "size": 429496730,
         "vram": 429496730,
-        "usage": 44,
+        "usage": 17,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -13498,7 +13500,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 35,
+        "usage": 15,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -13524,7 +13526,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 44,
+        "usage": 58,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13540,7 +13542,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 2147483648,
-        "usage": 29,
+        "usage": 13,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13556,7 +13558,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 5368709120,
-        "usage": 11,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13571,7 +13573,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 127,
+        "usage": 69,
         "io": {
           "inputs": [
             {
@@ -13596,7 +13598,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 146,
+        "usage": 91,
         "searchRank": 0,
         "tags": ["音频", "语音克隆"],
         "io": {
@@ -13623,7 +13625,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 39,
+        "usage": 37,
         "searchRank": 0,
         "tags": ["音频", "文本转语音", "语音克隆"],
         "io": {
@@ -13657,7 +13659,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 44,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13689,7 +13691,7 @@
         "tutorialUrl": "https://comfyanonymous.github.io/ComfyUI_examples/audio/",
         "size": 5690831667,
         "vram": 5690831667,
-        "usage": 26,
+        "usage": 16,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI"
@@ -13706,7 +13708,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 18,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -13746,7 +13748,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 8,
+        "usage": 4,
         "username": "ComfyUI"
       }
     ]
@@ -13768,7 +13770,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-05-21",
         "openSource": false,
-        "usage": 263,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -13983,7 +13985,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 114,
+        "usage": 52,
         "io": {
           "inputs": [
             {
@@ -14029,7 +14031,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14072,7 +14074,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 53,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14086,7 +14088,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 29,
+        "usage": 46,
         "username": "ComfyUI"
       },
       {
@@ -14107,7 +14109,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 29,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14187,7 +14189,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -14230,7 +14232,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 94,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14273,7 +14275,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "username": "ComfyUI"
       },
       {
@@ -14289,7 +14291,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 8,
         "username": "ComfyUI"
       },
       {
@@ -14305,7 +14307,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 24,
         "io": {
           "inputs": [
             {
@@ -14331,7 +14333,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 48,
         "io": {
           "inputs": [
             {
@@ -14363,7 +14365,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 7,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -14389,7 +14391,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 6,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14415,7 +14417,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -14452,7 +14454,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 145,
+        "usage": 116,
         "io": {
           "inputs": [
             {
@@ -14477,7 +14479,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -14503,7 +14505,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 77,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -14547,7 +14549,7 @@
         "thumbnailVariant": "hoverDissolve",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 52,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -14596,7 +14598,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 38,
         "searchRank": 0,
         "username": "shane"
       },
@@ -14618,7 +14620,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 10,
+        "usage": 9,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_hunyuan3d_model2uv-1.png", "thumbnail/api_hunyuan3d_model2uv-2.png"]
@@ -14690,7 +14692,7 @@
         "description": "GPT-5.6 Luna 通过分析单张参考图并根据用户提示词生成结构化创意文本，简化了视觉前期制作。它接收1张输入图像，不产生显式视觉输出，专注于快速、标准化的文案撰写。非常适合批量场景描述扩展、镜头列表整理以及高容量创意构思。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文本生成"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14721,7 +14723,7 @@
         "description": "使用GPT-5.6 Terra描述一个场景或世界，这是一个平衡的多模态模型，可解读一张上传的图像，以指导视觉叙事和风格一致性。适用于世界构建、情绪板创建以及在一系列作品中保持统一的审美风格。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文本生成"],
         "models": ["ChatGPT"],
         "logos": [
           {
@@ -14783,7 +14785,7 @@
         "description": "Grok 4.5 是一款旗舰多模态模型，专为复杂工程和创意使用例而设计，具备原生视觉解析和高速推理能力。它以创意简报和已生成图像作为输入，生成标准化场景描述和迭代视觉分析。非常适合多镜头故事板、批次图像描述生成以及基于反馈的创意优化。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文本生成"],
         "models": ["Grok"],
         "logos": [
           {
@@ -14814,7 +14816,7 @@
         "description": "使用Kimi K3生成详细的图像描述和创意简报，这是一个具有百万token上下文窗口的多模态模型，用于统一的文本和图像理解。输入一张图像和一个文本提示词，即可生成细致的视觉分析或批次描述。非常适合简化多镜头视觉系列、为基于节点的工作流生成自动化脚本提示词，以及通过图像反馈迭代优化创意概念。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文本生成"],
         "models": ["Kimi K3"],
         "logos": [
           {
@@ -14845,7 +14847,7 @@
         "description": "Claude Fable 5，Anthropic 首个公开的 Mythos 级前沿模型，为 ComfyUI 中的端到端创意工作流提供支持。它接收 1 个文本提示词，生成 1 个结构化输出，包括故事板分解、SD 模型和 ControlNet 的精确提示词，以及自定义节点脚本。非常适合用于细化视觉叙事的概念艺术家、保持系列风格一致的 AI 电影制作人，以及自动化整个渲染管线的数字创作者。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文本生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14868,7 +14870,8 @@
               "mediaType": "image"
             }
           ]
-        }
+        },
+        "thumbnail": ["thumbnail/api_anthropic_claude_fable5.webp"]
       },
       {
         "name": "api_anthropic_claude_sonnet5",
@@ -14876,7 +14879,7 @@
         "description": "利用Claude Sonnet 5执行高价值自主任务，以较低成本弥合与旗舰性能的差距。输入任何文本提示词或脚本，即可生成精确的图像描述、自动化工作流脚本、镜头序列日志或节点逻辑修正。适用于批次生产任务、调试ComfyUI节点逻辑以及在重复性生成工作流中保持一致的输出质量。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文本生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14907,7 +14910,7 @@
         "description": "使用Qwen3-VL模型，通过视觉理解生成文本，处理一张输入图像以产生上下文相关的文本响应。适用于图像描述、视觉问答和多模态内容生成。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文本生成"],
         "models": ["Qwen 3.0"],
         "date": "2026-06-23",
         "openSource": true,
@@ -14933,7 +14936,7 @@
         "description": "从OpenRouter精选列表中选择一个模型（Claude、GPT、Gemini等）。生成文本响应，并可选择上传媒体文件以用于支持视觉的模型。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM", "API"],
+        "tags": ["文本生成", "API"],
         "models": ["OpenRouter"],
         "logos": [
           {
@@ -14964,7 +14967,7 @@
         "description": "输入您的查询或图像进行分析。生成由Anthropic Claude驱动的自然语言响应，支持文本对话和图像理解。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文本生成"],
         "models": ["Claude"],
         "logos": [
           {
@@ -14996,7 +14999,7 @@
         "description": "输入您的文本提示词，并可选择图像、音频或视频。通过可配置的推理、编码和多语言支持生成文本输出。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文本生成"],
         "models": ["Gemma 4"],
         "date": "2026-05-01",
         "openSource": true,
@@ -15035,13 +15038,13 @@
         "description": "使用Qwen3.5模型分析输入图像并生成描述性文本提示词。此工作流执行图像描述和反向提示词工程。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文本生成"],
         "models": ["Qwen3.5"],
         "date": "2026-03-27",
         "openSource": true,
         "size": 9341553869,
         "vram": 9341553869,
-        "usage": 105,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15063,13 +15066,13 @@
         "description": "输入文本提示词，使用Qwen3-4B-Thinking模型生成详细、有推理的回复。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["LLM"],
+        "tags": ["文本生成"],
         "models": ["Qwen 3.0"],
         "date": "2026-02-23",
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 53,
+        "usage": 28,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15087,7 +15090,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 112,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -15112,14 +15115,14 @@
         "description": "体验Google的多模态AI和Gemini的推理能力。",
         "mediaType": "image",
         "mediaSubtype": "webp",
-        "tags": ["API", "LLM"],
+        "tags": ["API", "文本生成"],
         "models": ["Google", "Google Gemini"],
         "date": "2025-03-01",
         "tutorialUrl": "",
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 43,
         "io": {
           "inputs": [
             {
@@ -15193,7 +15196,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 341,
+        "usage": 208,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15231,7 +15234,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 654,
+        "usage": 684,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15267,7 +15270,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 450,
+        "usage": 129,
         "searchRank": 0,
         "logos": [
           {
@@ -15312,7 +15315,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 172,
+        "usage": 102,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -15353,7 +15356,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 297,
+        "usage": 131,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15499,7 +15502,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 230,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15573,7 +15576,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16096,7 +16099,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 14,
+        "usage": 7,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16224,7 +16227,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 4,
+        "usage": 10,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16250,7 +16253,7 @@
         "openSource": true,
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_sdpose_multi_person.mp4"],
@@ -16278,7 +16281,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 64,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16371,7 +16374,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 22,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -16404,7 +16407,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16476,7 +16479,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 236,
+        "usage": 144,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16591,7 +16594,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 88,
+        "usage": 43,
         "searchRank": 0,
         "logos": [
           {
@@ -16623,7 +16626,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -16655,7 +16658,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 65,
+        "usage": 85,
         "searchRank": 0,
         "logos": [
           {
@@ -16743,7 +16746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 72,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16770,7 +16773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 18,
         "searchRank": 0,
         "logos": [
           {
@@ -16802,7 +16805,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "logos": [
           {
@@ -16916,7 +16919,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -16957,7 +16960,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 25,
         "searchRank": 0,
         "logos": [
           {
@@ -17037,7 +17040,7 @@
         "models": ["FlashVSR", "WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 60,
+        "usage": 61,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17070,7 +17073,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 124,
+        "usage": 37,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17096,7 +17099,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 30,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17124,7 +17127,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 34,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -17148,7 +17151,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17195,7 +17198,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 146,
+        "usage": 124,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17236,7 +17239,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 10,
+        "usage": 65,
         "io": {
           "inputs": [
             {
@@ -17266,7 +17269,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17301,7 +17304,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 62,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -17327,7 +17330,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 107,
+        "usage": 357,
         "io": {
           "inputs": [
             {
@@ -17355,7 +17358,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 22,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -17384,7 +17387,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 24,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -17413,7 +17416,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 12,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -17436,7 +17439,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite", "comfyui_controlnet_aux"],
-        "usage": 14,
+        "usage": 41,
         "io": {
           "inputs": [
             {
@@ -17462,7 +17465,7 @@
         "date": "2025-05-21",
         "size": 2040109466,
         "vram": 2040109466,
-        "usage": 13,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -17500,7 +17503,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 19,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17545,7 +17548,7 @@
         "includeOnDistributions": ["local"],
         "size": 2147483648,
         "vram": 2147483648,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -17561,7 +17564,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 1421,
+        "usage": 285,
         "io": {
           "outputs": [
             {
@@ -17590,7 +17593,7 @@
         "includeOnDistributions": ["local"],
         "size": 36829344563,
         "vram": 36829344563,
-        "usage": 32,
+        "usage": 30,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17635,7 +17638,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_essentials"],
-        "usage": 243,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -17679,7 +17682,7 @@
         "includeOnDistributions": ["local"],
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 40,
+        "usage": 37,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17721,7 +17724,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes", "comfyui_essentials"],
-        "usage": 89,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -17753,7 +17756,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 120,
+        "usage": 39,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -17810,7 +17813,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 199,
+        "usage": 40,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17847,7 +17850,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 100,
+        "usage": 101,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17888,7 +17891,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 77,
+        "usage": 82,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -17930,7 +17933,7 @@
         "openSource": true,
         "size": 28346784154,
         "vram": 28346784154,
-        "usage": 119,
+        "usage": 11,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["cloud"],
@@ -17973,7 +17976,7 @@
         "date": "2025-10-17",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 331,
+        "usage": 71,
         "io": {
           "outputs": [
             {
@@ -18001,7 +18004,7 @@
         "date": "2025-10-17",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 1860,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -18038,7 +18041,7 @@
         "date": "2025-10-17",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1651,
+        "usage": 1917,
         "io": {
           "inputs": [
             {
@@ -18074,7 +18077,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/3d/hunyuan3D-2",
         "size": 4939212390,
         "vram": 4939212390,
-        "usage": 71,
+        "usage": 368,
         "io": {
           "inputs": [
             {
@@ -18101,7 +18104,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7730941133,
         "vram": 7730941133,
-        "usage": 27,
+        "usage": 11,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18118,7 +18121,7 @@
         "date": "2025-03-01",
         "size": 2147483648,
         "vram": 3113851290,
-        "usage": 848,
+        "usage": 365,
         "username": "ComfyUI",
         "openSource": true,
         "searchRank": 0
@@ -18214,7 +18217,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 21,
+        "usage": 59,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18283,7 +18286,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 44,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/utility_text_lists_select_prompt.mp4"],
@@ -18301,7 +18304,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 87,
+        "usage": 63,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],


### PR DESCRIPTION
Automated biweekly refresh of `usage` from the Algolia `templates_index` (real PostHog run-clicks). Merging triggers the normal version bump + PyPI publish.

_Raised manually (same steps as the Refresh Run-Click Usage workflow) while the workflow's push token is being granted write access._