### PR TITLE
ci: auto-sync template index and usage on PRs

### DIFF
--- a/.github/workflows/refresh-run-click-usage.yml
+++ b/.github/workflows/refresh-run-click-usage.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ALGOLIA_APP_ID: 4E0RO38HS8
-      ALGOLIA_API_KEY: 684d998c36b67a9a9fce8fc2d8860579
+      ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
       GH_TOKEN: ${{ secrets.PAT_TOKEN }}
     steps:
       - name: Checkout

--- a/.github/workflows/sync-template-index.yml
+++ b/.github/workflows/sync-template-index.yml
@@ -1,17 +1,29 @@
 name: Sync Template Index
 
-# When templates/ change in a PR:
+# When index files change in a PR:
 #   1. Fetch per-template run_clicks from Algolia (templates_index)
-#   2. Fold usage into templates/index.json via sync_data.py
-#   3. Propagate all technical fields (usage, models, tags, io, …) to every locale index
+#   2. Fold usage into templates/index.json via sync_data.py --index-only
+#   3. Propagate technical fields to every locale index
 #
-# Requires repo secret ALGOLIA_API_KEY (search-only Algolia API key).
+# Optimized for speed: sparse checkout (index files only), no workflow JSON scan,
+# no i18n bookkeeping. Requires repo secret ALGOLIA_API_KEY.
 
 on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - 'templates/**'
+      - 'templates/index.json'
+      - 'templates/index.zh.json'
+      - 'templates/index.zh-TW.json'
+      - 'templates/index.ja.json'
+      - 'templates/index.ko.json'
+      - 'templates/index.es.json'
+      - 'templates/index.fr.json'
+      - 'templates/index.ru.json'
+      - 'templates/index.tr.json'
+      - 'templates/index.ar.json'
+      - 'templates/index.fa.json'
+      - 'templates/index.pt-BR.json'
       - 'scripts/sync/sync_data.py'
       - 'scripts/lib/locale_index_files.py'
       - 'scripts/data/i18n.json'
@@ -39,15 +51,32 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
-          fetch-depth: 0
+          fetch-depth: 1
+          sparse-checkout: |
+            templates/index.json
+            templates/index.zh.json
+            templates/index.zh-TW.json
+            templates/index.ja.json
+            templates/index.ko.json
+            templates/index.es.json
+            templates/index.fr.json
+            templates/index.ru.json
+            templates/index.tr.json
+            templates/index.ar.json
+            templates/index.fa.json
+            templates/index.pt-BR.json
+            scripts/sync/sync_data.py
+            scripts/sync/fetch_algolia_usage.py
+            scripts/lib/locale_index_files.py
+            scripts/lib/paths.py
+            scripts/lib/run_click_coverage.py
+            scripts/data/i18n.json
+          sparse-checkout-cone-mode: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install jsonschema
 
       - name: Fetch usage from Algolia and sync index to all locales
         run: |
@@ -78,7 +107,6 @@ jobs:
             templates/index.ar.json \
             templates/index.fa.json \
             templates/index.pt-BR.json
-          git add scripts/data/i18n.json
 
           if ! git diff --cached --quiet; then
             echo "📝 Changes detected - committing to PR branch"

--- a/.github/workflows/sync-template-index.yml
+++ b/.github/workflows/sync-template-index.yml
@@ -1,0 +1,107 @@
+name: Sync Template Index
+
+# When templates/ change in a PR:
+#   1. Fetch per-template run_clicks from Algolia (templates_index)
+#   2. Fold usage into templates/index.json via sync_data.py
+#   3. Propagate all technical fields (usage, models, tags, io, …) to every locale index
+#
+# Requires repo secret ALGOLIA_API_KEY (search-only Algolia API key).
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'templates/**'
+      - 'scripts/sync/sync_data.py'
+      - 'scripts/lib/locale_index_files.py'
+      - 'scripts/data/i18n.json'
+      - 'scripts/sync/fetch_algolia_usage.py'
+      - '.github/workflows/sync-template-index.yml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-index:
+    runs-on: ubuntu-latest
+    env:
+      ALGOLIA_APP_ID: 4E0RO38HS8
+      ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+    # Only run on same-repo PRs (fork PRs cannot receive auto-commits).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    concurrency:
+      group: sync-template-index-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.repo.full_name }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install jsonschema
+
+      - name: Fetch usage from Algolia and sync index to all locales
+        run: |
+          echo "=== Fetching run_clicks from Algolia ==="
+          python scripts/sync/fetch_algolia_usage.py --templates-dir ./templates
+          echo "=== Syncing templates/index.json to all locale index files ==="
+          python scripts/sync/sync_data.py --templates-dir ./templates --index-only
+          echo "✅ Template index sync complete"
+
+      - name: Commit index sync updates to PR
+        run: |
+          echo "=== Committing index sync updates to PR ==="
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+          git add templates/index.json
+          git add \
+            templates/index.zh.json \
+            templates/index.zh-TW.json \
+            templates/index.ja.json \
+            templates/index.ko.json \
+            templates/index.es.json \
+            templates/index.fr.json \
+            templates/index.ru.json \
+            templates/index.tr.json \
+            templates/index.ar.json \
+            templates/index.fa.json \
+            templates/index.pt-BR.json
+          git add scripts/data/i18n.json
+
+          if ! git diff --cached --quiet; then
+            echo "📝 Changes detected - committing to PR branch"
+
+            if ! git commit -m "Auto-sync template index fields across locales"; then
+              echo "⚠️ Commit failed, possibly due to conflicts. Retrying..."
+              if ! git pull origin "${{ github.head_ref }}" --rebase; then
+                echo "❌ Rebase failed due to conflicts. Manual intervention required."
+                git status
+                exit 1
+              fi
+              git commit -m "Auto-sync template index fields across locales"
+            fi
+
+            if ! git push origin HEAD; then
+              echo "⚠️ Push failed, retrying after pull..."
+              if ! git pull origin "${{ github.head_ref }}" --rebase; then
+                echo "❌ Rebase failed due to conflicts. Manual intervention required."
+                git status
+                exit 1
+              fi
+              git push origin HEAD
+            fi
+
+            echo "✅ Template index sync committed to PR"
+          else
+            echo "✅ All locale index files are already in sync"
+          fi

--- a/.github/workflows/sync-template-index.yml
+++ b/.github/workflows/sync-template-index.yml
@@ -18,9 +18,9 @@ on:
       - 'scripts/sync/fetch_algolia_usage.py'
       - '.github/workflows/sync-template-index.yml'
 
+# contents: write is required to commit and push synced index files back to the PR branch.
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   sync-index:
@@ -35,14 +35,14 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -58,6 +58,8 @@ jobs:
           echo "✅ Template index sync complete"
 
       - name: Commit index sync updates to PR
+        env:
+          PR_HEAD_REF: ${{ github.head_ref }}
         run: |
           echo "=== Committing index sync updates to PR ==="
           git config --local user.email "action@github.com"
@@ -83,7 +85,7 @@ jobs:
 
             if ! git commit -m "Auto-sync template index fields across locales"; then
               echo "⚠️ Commit failed, possibly due to conflicts. Retrying..."
-              if ! git pull origin "${{ github.head_ref }}" --rebase; then
+              if ! git pull origin "$PR_HEAD_REF" --rebase; then
                 echo "❌ Rebase failed due to conflicts. Manual intervention required."
                 git status
                 exit 1
@@ -93,7 +95,7 @@ jobs:
 
             if ! git push origin HEAD; then
               echo "⚠️ Push failed, retrying after pull..."
-              if ! git pull origin "${{ github.head_ref }}" --rebase; then
+              if ! git pull origin "$PR_HEAD_REF" --rebase; then
                 echo "❌ Rebase failed due to conflicts. Manual intervention required."
                 git status
                 exit 1

--- a/scripts/sync/fetch_algolia_usage.py
+++ b/scripts/sync/fetch_algolia_usage.py
@@ -10,9 +10,9 @@ the build-time bridge: it reuses the existing usage.csv pipeline rather than
 writing ``index.json`` directly, so ranking data flows through the same path as
 the manual CSV it replaces.
 
-Credentials are the public, search-only Algolia key (safe to commit), read from
-``ALGOLIA_APP_ID`` / ``ALGOLIA_API_KEY`` (unprefixed — the site uses ``PUBLIC_``
-prefixed names for Vite; this Python script does not).
+Credentials: ``ALGOLIA_APP_ID`` (default 4E0RO38HS8) and ``ALGOLIA_API_KEY``
+(GitHub Actions secret). The site uses ``PUBLIC_`` prefixed names for Vite;
+this Python script does not.
 """
 
 import argparse

--- a/scripts/sync/sync_data.py
+++ b/scripts/sync/sync_data.py
@@ -1631,7 +1631,10 @@ class TemplateSyncManager:
             self.syncer.logger.info(f"   Templates marked for vram/size management: {len(self.syncer.vram_size_update_templates)}")
 
         if self.sync_options.get('index_only'):
-            self.syncer.logger.info("\n⏭️  Index-only mode: skipping bundles, asset checks, model analysis, spellcheck, and validation")
+            self.syncer.logger.info(
+                "\n⏭️  Index-only mode: skipping bundles, asset checks, model analysis, "
+                "spellcheck, and validation"
+            )
             if self.errors:
                 self.syncer.logger.error("\n❌ Errors summary:")
                 for err in self.errors:
@@ -1760,7 +1763,10 @@ Translation System:
     parser.add_argument(
         '--index-only',
         action='store_true',
-        help='Sync index.json and locale index files only (skip bundles, asset checks, model analysis, spellcheck, validation)',
+        help=(
+            'Sync index.json and locale index files only (skip bundles, asset checks, '
+            'model analysis, spellcheck, validation)'
+        ),
     )
     
     args = parser.parse_args()

--- a/scripts/sync/sync_data.py
+++ b/scripts/sync/sync_data.py
@@ -1629,6 +1629,16 @@ class TemplateSyncManager:
             self.syncer.logger.info(f"   New category fields found: {len(self.syncer.new_category_fields)}")
         if self.syncer.vram_size_update_templates:
             self.syncer.logger.info(f"   Templates marked for vram/size management: {len(self.syncer.vram_size_update_templates)}")
+
+        if self.sync_options.get('index_only'):
+            self.syncer.logger.info("\n⏭️  Index-only mode: skipping bundles, asset checks, model analysis, spellcheck, and validation")
+            if self.errors:
+                self.syncer.logger.error("\n❌ Errors summary:")
+                for err in self.errors:
+                    self.syncer.logger.error(f"  - {err}")
+            else:
+                self.syncer.logger.info("\n✅ No errors detected.")
+            return success
         
         # Step 4: Sync bundles (manifest and bundle package assets)
         if sync_bundles is not None:
@@ -1747,11 +1757,17 @@ Translation System:
     parser.add_argument('--dry-run', action='store_true', help='Show what would be done without making changes')
     parser.add_argument('--force-sync-language-fields', action='store_true', 
                        help='Force sync language-specific fields (title, description) - overwrite existing translations')
+    parser.add_argument(
+        '--index-only',
+        action='store_true',
+        help='Sync index.json and locale index files only (skip bundles, asset checks, model analysis, spellcheck, validation)',
+    )
     
     args = parser.parse_args()
     
     sync_options = {
-        'force_sync_language_fields': args.force_sync_language_fields
+        'force_sync_language_fields': args.force_sync_language_fields,
+        'index_only': args.index_only,
     }
     
     try:

--- a/scripts/sync/sync_data.py
+++ b/scripts/sync/sync_data.py
@@ -1518,34 +1518,40 @@ class TemplateSyncManager:
             return False
 
         success = True
+        index_only = self.sync_options.get('index_only')
 
         # Step 0: Fix vram data in master file first
         self.fix_master_vram_data()
 
-        # Step 0b: Generate workflow I/O in master index.json
-        if generate_workflow_io is not None:
-            self.syncer.logger.info("\n📎 Step 0b: Generating workflow I/O in master index.json...")
-            try:
-                self.generate_workflow_io()
-            except Exception as e:
-                self.record_error(f"Workflow I/O generation failed: {e}")
-                success = False
+        if not index_only:
+            # Step 0b: Generate workflow I/O in master index.json
+            if generate_workflow_io is not None:
+                self.syncer.logger.info("\n📎 Step 0b: Generating workflow I/O in master index.json...")
+                try:
+                    self.generate_workflow_io()
+                except Exception as e:
+                    self.record_error(f"Workflow I/O generation failed: {e}")
+                    success = False
+            else:
+                self.syncer.logger.warning(
+                    "\n⚠️  generate_workflow_io module not available, skipping workflow I/O generation"
+                )
+
+            # Step 0c: Drop io rows with no filename (outputs like SaveVideo/SaveImage placeholders)
+            self.cleanup_master_empty_io_file_entries()
+
+            # Step 1: Sync English fields to i18n.json from master file
+            self.syncer.logger.info("\n📥 Step 1: Syncing English fields to i18n.json...")
+            en_fields_updated = self.sync_i18n_from_master()
+
+            # Step 1b: Collect translations for NEW templates only
+            self.syncer.logger.info("\n📥 Step 1b: Collecting translations for new templates...")
+            self.collect_new_templates_from_language_files()
         else:
-            self.syncer.logger.warning("\n⚠️  generate_workflow_io module not available, skipping workflow I/O generation")
+            en_fields_updated = 0
 
-        # Step 0c: Drop io rows with no filename (outputs like SaveVideo/SaveImage placeholders)
-        self.cleanup_master_empty_io_file_entries()
-
-        # Step 1: Sync English fields to i18n.json from master file
-        self.syncer.logger.info("\n📥 Step 1: Syncing English fields to i18n.json...")
-        en_fields_updated = self.sync_i18n_from_master()
-        
-        # Step 1b: Collect translations for NEW templates only
-        self.syncer.logger.info("\n📥 Step 1b: Collecting translations for new templates...")
-        self.collect_new_templates_from_language_files()
-        
-        # Step 2: Sync i18n.json translations to all language files
-        self.syncer.logger.info("\n🔄 Step 2: Syncing i18n.json to language files...")
+        # Step 2: Sync master technical fields to all language files
+        self.syncer.logger.info("\n🔄 Step 2: Syncing master index to language files...")
         for lang, lang_file in self.syncer.language_files.items():
             try:
                 if not self.sync_language_file(lang, lang_file):
@@ -1553,66 +1559,71 @@ class TemplateSyncManager:
             except Exception as e:
                 self.record_error(f"Sync language file failed ({lang}): {e}")
                 success = False
-        
-        # Step 3: Collect ALL translations from language files back to i18n.json
-        self.syncer.logger.info("\n📥 Step 3: Collecting all translations to i18n.json...")
-        collected_count, category_title_collected_count = self.collect_all_translations_from_language_files()
-                
-        # Check for unused tags in i18n data
-        unused_tags = set(self.syncer.i18n_data.get("tags", {}).keys()) - self.syncer.used_tags
-        if unused_tags:
-            self.syncer.logger.info(f"\n🗑️  Unused tags in i18n data: {len(unused_tags)}")
-            self.syncer.logger.info(f"   These tags exist in i18n.json but are not used in any template:")
-            for tag in sorted(unused_tags):
-                self.syncer.logger.info(f"   - {tag}")
-            self.syncer.logger.info(f"   💡 You can manually remove these from {self.syncer.i18n_file} if they are no longer needed")
-        
-        # Save i18n data
-        needs_save = False
-        
-        if en_fields_updated > 0:
-            needs_save = True
-        
-        if collected_count > 0 or category_title_collected_count > 0:
-            needs_save = True
-        
-        if self.syncer.new_tags:
-            self.syncer.logger.info(f"\n🆕 New tags discovered: {len(self.syncer.new_tags)}")
-            for tag in sorted(self.syncer.new_tags):
-                self.syncer.logger.info(f"   - {tag}")
-            needs_save = True
-        
-        if self.syncer.new_category_titles:
-            self.syncer.logger.info(f"\n🆕 New category titles discovered: {len(self.syncer.new_category_titles)}")
-            for title in sorted(self.syncer.new_category_titles):
-                self.syncer.logger.info(f"   - {title}")
-            needs_save = True
-        
-        if self.syncer.new_category_fields:
-            self.syncer.logger.info(f"\n🆕 New category fields discovered: {len(self.syncer.new_category_fields)}")
-            for field in sorted(self.syncer.new_category_fields):
-                self.syncer.logger.info(f"   - {field}")
-            needs_save = True
-        
-        # Update vram_size_update_templates in i18n data
-        if self.syncer.vram_size_update_templates:
-            vram_size_update_list = list(self.syncer.vram_size_update_templates)
-            self.syncer.i18n_data["_status"]["vram_size_update_templates"]["templates"] = vram_size_update_list
-            self.syncer.logger.info(f"\n🔧 Templates marked for vram/size data management: {len(vram_size_update_list)}")
-            for template in sorted(vram_size_update_list):
-                self.syncer.logger.info(f"   - {template}")
-            needs_save = True
-        
-        if self.syncer.i18n_data["_status"]["pending_templates"]:
-            self.syncer.logger.info(f"\n💾 Saving translation tracking data...")
-            needs_save = True
-        
-        if needs_save:
-            self.syncer.save_i18n()
-            self.syncer.logger.info(f"✅ Saved to: {self.syncer.i18n_file}")
-        
-        # Generate translation report
-        self.generate_translation_report()
+
+        if not index_only:
+            # Step 3: Collect ALL translations from language files back to i18n.json
+            self.syncer.logger.info("\n📥 Step 3: Collecting all translations to i18n.json...")
+            collected_count, category_title_collected_count = (
+                self.collect_all_translations_from_language_files()
+            )
+
+            # Check for unused tags in i18n data
+            unused_tags = set(self.syncer.i18n_data.get("tags", {}).keys()) - self.syncer.used_tags
+            if unused_tags:
+                self.syncer.logger.info(f"\n🗑️  Unused tags in i18n data: {len(unused_tags)}")
+                self.syncer.logger.info(f"   These tags exist in i18n.json but are not used in any template:")
+                for tag in sorted(unused_tags):
+                    self.syncer.logger.info(f"   - {tag}")
+                self.syncer.logger.info(
+                    f"   💡 You can manually remove these from {self.syncer.i18n_file} if they are no longer needed"
+                )
+
+            # Save i18n data
+            needs_save = False
+
+            if en_fields_updated > 0:
+                needs_save = True
+
+            if collected_count > 0 or category_title_collected_count > 0:
+                needs_save = True
+
+            if self.syncer.new_tags:
+                self.syncer.logger.info(f"\n🆕 New tags discovered: {len(self.syncer.new_tags)}")
+                for tag in sorted(self.syncer.new_tags):
+                    self.syncer.logger.info(f"   - {tag}")
+                needs_save = True
+
+            if self.syncer.new_category_titles:
+                self.syncer.logger.info(f"\n🆕 New category titles discovered: {len(self.syncer.new_category_titles)}")
+                for title in sorted(self.syncer.new_category_titles):
+                    self.syncer.logger.info(f"   - {title}")
+                needs_save = True
+
+            if self.syncer.new_category_fields:
+                self.syncer.logger.info(f"\n🆕 New category fields discovered: {len(self.syncer.new_category_fields)}")
+                for field in sorted(self.syncer.new_category_fields):
+                    self.syncer.logger.info(f"   - {field}")
+                needs_save = True
+
+            # Update vram_size_update_templates in i18n data
+            if self.syncer.vram_size_update_templates:
+                vram_size_update_list = list(self.syncer.vram_size_update_templates)
+                self.syncer.i18n_data["_status"]["vram_size_update_templates"]["templates"] = vram_size_update_list
+                self.syncer.logger.info(f"\n🔧 Templates marked for vram/size data management: {len(vram_size_update_list)}")
+                for template in sorted(vram_size_update_list):
+                    self.syncer.logger.info(f"   - {template}")
+                needs_save = True
+
+            if self.syncer.i18n_data["_status"]["pending_templates"]:
+                self.syncer.logger.info(f"\n💾 Saving translation tracking data...")
+                needs_save = True
+
+            if needs_save:
+                self.syncer.save_i18n()
+                self.syncer.logger.info(f"✅ Saved to: {self.syncer.i18n_file}")
+
+            # Generate translation report
+            self.generate_translation_report()
         
         # Print summary
         self.syncer.logger.info(f"\n📊 Synchronization Summary:")
@@ -1632,8 +1643,8 @@ class TemplateSyncManager:
 
         if self.sync_options.get('index_only'):
             self.syncer.logger.info(
-                "\n⏭️  Index-only mode: skipping bundles, asset checks, model analysis, "
-                "spellcheck, and validation"
+                "\n⏭️  Index-only mode: skipped workflow I/O and i18n bookkeeping; "
+                "also skipping bundles, asset checks, model analysis, spellcheck, and validation"
             )
             if self.errors:
                 self.syncer.logger.error("\n❌ Errors summary:")
@@ -1764,8 +1775,8 @@ Translation System:
         '--index-only',
         action='store_true',
         help=(
-            'Sync index.json and locale index files only (skip bundles, asset checks, '
-            'model analysis, spellcheck, validation)'
+            'Sync index.json to locale index files only: apply usage and other technical '
+            'fields without workflow I/O generation, i18n bookkeeping, bundles, or validation'
         ),
     )
     


### PR DESCRIPTION
## Summary

Adds a new PR workflow (`sync-template-index.yml`) that runs when a pull request touches `templates/`. It fetches template usage from Algolia and syncs index fields to every locale index file, then **commits the results back to the same PR branch** (same pattern as `sync-custom-nodes.yml`).

- Fetches `run_clicks` from the Algolia `templates_index` index and writes them to the `usage` field (requires repo secret `ALGOLIA_API_KEY`)
- Runs `sync_data.py --index-only` to propagate technical fields from the English master `index.json` (`usage`, `models`, `tags`, `io`, `searchRank`, etc.) to all 12 locale index files
- If anything changed, pushes an `Auto-sync template index fields across locales` commit to **the same PR**
- Only runs on same-repo PRs (fork PRs do not receive auto-commits)
- Adds `--index-only` to `sync_data.py` to skip bundles, validation, and other heavy steps in CI
- Updates `refresh-run-click-usage.yml` to use `secrets.ALGOLIA_API_KEY` instead of a hardcoded key

## How it works

1. A developer opens or updates a PR with changes under `templates/**`
2. CI fetches Algolia usage and runs index sync
3. If locale index files or `scripts/data/i18n.json` differ, the workflow **auto-commits and pushes to that PR**
4. The PR gets an extra bot commit; no need to run `npm run i18n` manually

## Test plan

- [ ] Confirm repo secret `ALGOLIA_API_KEY` is configured
- [ ] After merge, open a test PR that changes `templates/` and verify the workflow runs
- [ ] Confirm the bot commits synced `templates/index*.json` back to the PR branch
- [ ] Confirm fork PRs do not receive auto-commits