### PR TITLE
fix(i18n): protect preserve-terms during translation (GTM-291)

### DIFF
--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -148,6 +148,17 @@ jobs:
         working-directory: site
         run: pnpm i18n:restore
 
+      # always(): prune before validate even after a tolerated translate failure.
+      # The model preserves brand names only probabilistically, so a small tail of
+      # fields still drops a preserve-term at scale. This removes exactly those
+      # fields (reusing the validator's own checks), so they fall back to English at
+      # render (page non-indexable — the gated behaviour) instead of failing the run
+      # or publishing a bad field. Fails only if pruning is systemic.
+      - name: Enforce glossary floor (prune fields the model failed)
+        if: always()
+        working-directory: site
+        run: pnpm i18n:enforce
+
       # always(): run even after a tolerated translate failure so partial progress
       # is still validated. This step has no continue-on-error, so a validation
       # failure fails the job and the success()-gated publish steps below skip —

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -9,6 +9,11 @@ name: "i18n: Update Hub Translations"
 
 on:
   workflow_dispatch:
+    inputs:
+      locale:
+        description: 'Single locale to translate (blank = all supported). e.g. zh'
+        required: false
+        default: ''
   # Pick up newly published / changed workflows on a cadence.
   schedule:
     - cron: "0 2 * * *"
@@ -99,7 +104,11 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -uo pipefail
-          for loc in zh zh-TW ja ko es fr ru tr ar pt-BR; do
+          # Manual dispatch may target one locale (e.g. -f locale=zh) for the
+          # per-language backfill; the cron and a blank input do all supported.
+          LOCALES="${{ github.event.inputs.locale }}"
+          [ -z "$LOCALES" ] && LOCALES="zh zh-TW ja ko es fr ru tr ar pt-BR"
+          for loc in $LOCALES; do
             echo "::group::translate content → $loc"
             HUB_I18N_LOCALE="$loc" pnpm locale \
               || echo "locale $loc translation failed (tolerated; partial output saved)"

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -78,6 +78,13 @@ jobs:
         working-directory: site
         run: pnpm i18n:check
 
+      # Deterministically shield preserve-terms: swap brand/model names in the
+      # English source for inert sentinels the model can't translate away. Restored
+      # after translation, so the committed en.json keeps its real terms + manifest.
+      - name: Protect preserve-terms
+        working-directory: site
+        run: pnpm i18n:protect
+
       # Per-locale so each run injects that locale's product-UI terminology
       # (mirror + overrides) into the prompt, which a single all-locales run can't
       # do (shared reference). Also paces one locale at a time under the OpenAI
@@ -105,6 +112,14 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: pnpm locale:ui
+
+      # Swap the sentinels back to the exact English terms in every content file
+      # before validation reads them. always(): a tolerated translate failure still
+      # leaves partial output that must be de-sentinelized (and en.json restored).
+      - name: Restore preserve-terms
+        if: always()
+        working-directory: site
+        run: pnpm i18n:restore
 
       # always(): run even after a tolerated translate failure so partial progress
       # is still validated. This step has no continue-on-error, so a validation

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -1,4 +1,4 @@
-# Generates and updates hub workflow-content translations (GTM-291).
+# Generates and updates hub workflow-content translations.
 #
 # Pushes English; CI translates. Regenerates the English content-of-record from
 # the Hub index, seeds existing human translations, fills the gaps with
@@ -47,6 +47,28 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/site-setup
+
+      # Resolve which locales to translate. The manual-dispatch input arrives via
+      # env (never spliced into the script) and must match the supported allowlist,
+      # so it can neither inject shell nor request an unsupported locale. A blank
+      # input and the scheduled run translate all supported locales.
+      - name: Resolve target locales
+        env:
+          INPUT_LOCALE: ${{ github.event.inputs.locale }}
+        run: |
+          set -euo pipefail
+          SUPPORTED="zh zh-TW ja ko es fr ru tr ar pt-BR"
+          if [ -n "${INPUT_LOCALE:-}" ]; then
+            # Match the input exactly against the allowlist (literal case patterns,
+            # so a value like "*" cannot glob-match its way in).
+            case "$INPUT_LOCALE" in
+              zh|zh-TW|ja|ko|es|fr|ru|tr|ar|pt-BR) TARGET="$INPUT_LOCALE" ;;
+              *) echo "::error::Unsupported locale '${INPUT_LOCALE}'. Allowed: $SUPPORTED"; exit 1 ;;
+            esac
+          else
+            TARGET="$SUPPORTED"
+          fi
+          echo "TRANSLATE_LOCALES=$TARGET" >> "$GITHUB_ENV"
 
       # Resume a prior rate-limited run. If the single stable automation branch
       # exists and is still unmerged, start from its committed partial output so
@@ -104,11 +126,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -uo pipefail
-          # Manual dispatch may target one locale (e.g. -f locale=zh) for the
-          # per-language backfill; the cron and a blank input do all supported.
-          LOCALES="${{ github.event.inputs.locale }}"
-          [ -z "$LOCALES" ] && LOCALES="zh zh-TW ja ko es fr ru tr ar pt-BR"
-          for loc in $LOCALES; do
+          for loc in $TRANSLATE_LOCALES; do
             echo "::group::translate content → $loc"
             HUB_I18N_LOCALE="$loc" pnpm locale \
               || echo "locale $loc translation failed (tolerated; partial output saved)"
@@ -193,5 +211,5 @@ jobs:
               --base main \
               --head "$STABLE_BRANCH" \
               --title "chore(i18n): update hub workflow translations" \
-              --body "Automated hub translation refresh (GTM-291). English content regenerated from the Hub index, human seeds applied, gaps machine-translated, deterministic validators run. A partial (rate-limited) run still commits its progress to this same branch so the next run resumes. Does not flip any locale to indexable."
+              --body "Automated hub translation refresh. English content regenerated from the Hub index, human seeds applied, gaps machine-translated, deterministic validators run. A partial (rate-limited) run still commits its progress to this same branch so the next run resumes. Does not flip any locale to indexable."
           fi

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Checkout workflow_templates
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          # PAT_TOKEN lost repo write (403); PERSONAL_ACCESS_TOKEN has it.
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       # ComfyUI_frontend's UI locales seed the glossary mirror (term consistency).
       - name: Checkout ComfyUI_frontend locales
@@ -183,7 +184,7 @@ jobs:
       - name: Open or update translation PR
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
           STABLE_BRANCH="i18n/hub-translations"

--- a/.github/workflows/i18n-validate.yml
+++ b/.github/workflows/i18n-validate.yml
@@ -1,5 +1,5 @@
 # Runs the deterministic hub-translation validator on any PR that touches the
-# translation artifacts or their pipeline (GTM-291). The auto-PR from
+# translation artifacts or their pipeline. The auto-PR from
 # i18n-update-hub.yml already gates publication on this validator, but normal
 # Site CI does not run it, so a hand-edited translation PR could otherwise show
 # all-green while failing the deterministic gate. This closes that gap.

--- a/site/.i18nrc.cjs
+++ b/site/.i18nrc.cjs
@@ -60,6 +60,8 @@ function terminologyBlock(locale) {
 
 const reference = `This is SEO page content for Comfy Workflows (comfy.org/workflows), a catalog of ComfyUI workflow templates. Each value is a workflow's title, description, meta description, extended description, how-to steps, suggested use cases, or FAQ. Preserve JSON structure exactly: translate only string values, never keys, and keep every array the same length.
 
+The text may contain placeholder tokens of the form {{PT0}}, {{PT1}}, {{PT2}}, and so on — they stand in for brand, product, model, and node names. Reproduce EVERY token exactly as written and in place: never translate, remove, reorder, merge, or add tokens, even when rephrasing or shortening a sentence.
+
 Never translate these proper nouns (brand, product, model, and node names) — keep them byte-for-byte:
 ${preserveTerms.join(', ')}
 Also keep any URL, file name, and share id unchanged.

--- a/site/.i18nrc.cjs
+++ b/site/.i18nrc.cjs
@@ -9,9 +9,9 @@
 // that locale's product-UI terminology (the synced mirror + curated overrides)
 // into the prompt. This is the only way to feed per-locale terms — the all-locales
 // run shares one reference prompt across every output locale, so a locale's mirror
-// cannot be injected there. It is also the per-locale pacing the Tier-1 backfill
-// uses (one locale under the ~30k TPM cap at a time). With no env set the config
-// keeps its original all-locales behavior (no per-locale terms) for local runs.
+// cannot be injected there. It also paces one locale at a time to stay under the
+// OpenAI rate limit. With no env set the config keeps its original all-locales
+// behavior (no per-locale terms) for local runs.
 const { defineConfig } = require('@lobehub/i18n-cli');
 const fs = require('node:fs');
 const path = require('node:path');

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -71,7 +71,7 @@ const indexableUseCaseSlugs = new Set(
 // (`modelPath` → `/workflows/model/<slug>/`), so a no-slash-only redirect key let
 // the canonicalized `/workflows/model/<variant>/` fall through to a 404. The
 // locale route redirects variants in code regardless of trailing slash, so both
-// forms here restore parity (the wan2-5 bug).
+// forms here restore parity.
 const modelSlugRedirects = Object.fromEntries(
   modelGroups.flatMap((group) =>
     group.redirectFrom

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,8 @@
     "locale:ui": "lobe-i18n -c .i18nrc.ui.cjs",
     "i18n:build-source": "tsx scripts/i18n/build-content-source.ts",
     "i18n:glossary": "tsx scripts/i18n/sync-glossary.ts",
+    "i18n:protect": "tsx scripts/i18n/preserve-protection.ts protect",
+    "i18n:restore": "tsx scripts/i18n/preserve-protection.ts restore",
     "i18n:validate": "tsx scripts/i18n/validate-translations.ts",
     "i18n:check": "tsx scripts/i18n/check-config.ts",
     "sync": "tsx scripts/sync-templates.ts",

--- a/site/package.json
+++ b/site/package.json
@@ -13,6 +13,7 @@
     "i18n:glossary": "tsx scripts/i18n/sync-glossary.ts",
     "i18n:protect": "tsx scripts/i18n/preserve-protection.ts protect",
     "i18n:restore": "tsx scripts/i18n/preserve-protection.ts restore",
+    "i18n:enforce": "tsx scripts/i18n/enforce-translations.ts",
     "i18n:validate": "tsx scripts/i18n/validate-translations.ts",
     "i18n:check": "tsx scripts/i18n/check-config.ts",
     "sync": "tsx scripts/sync-templates.ts",

--- a/site/scripts/i18n/build-content-source.ts
+++ b/site/scripts/i18n/build-content-source.ts
@@ -1,6 +1,6 @@
 /**
  * build-content-source — produces the English content-of-record + manifest and
- * seeds existing human translations for the hub localization pipeline (GTM-291).
+ * seeds existing human translations for the hub localization pipeline.
  *
  * Run: `pnpm i18n:build-source` (needs PUBLIC_HUB_API_URL; no OpenAI key).
  *

--- a/site/scripts/i18n/check-config.ts
+++ b/site/scripts/i18n/check-config.ts
@@ -1,5 +1,5 @@
 /**
- * check-config — fails the build if the i18n pipeline is mis-wired (GTM-291).
+ * check-config — fails the build if the i18n pipeline is mis-wired.
  * Run: `pnpm i18n:check`. This is the check that would have caught the abandoned
  * .i18nrc.cjs whose entry file never existed.
  */

--- a/site/scripts/i18n/enforce-translations.ts
+++ b/site/scripts/i18n/enforce-translations.ts
@@ -1,0 +1,161 @@
+/**
+ * enforce-translations — the deterministic quality FLOOR for the hub pipeline.
+ *
+ * The model preserves brand names (and other invariants) only probabilistically,
+ * so at 582-workflow scale a small tail of translated fields still drops a
+ * preserve-term or otherwise fails a deterministic check — however the sentinel is
+ * shaped. Rather than fail the whole run (discarding thousands of good fields) or
+ * publish a field that dropped "ComfyUI", this prunes each violating field from the
+ * machine locale file. A pruned field is simply ABSENT, and the rest of the system
+ * already handles that safely:
+ *   - the validator only checks fields present in the locale file, so it skips it, and
+ *   - the resolver renders the English source for a missing field and marks that page
+ *     non-indexable — already the gated behaviour for any English-fallback field.
+ * Nothing incorrect is ever published; the dropped fields show English until a later
+ * run (or a human review) fills them in. Runs after restore, before validate.
+ *
+ * The pipeline still fails loudly when pruning is SYSTEMIC (a whole locale mostly
+ * failing points at a broken model/config, not a tail), guarded by the max-fraction
+ * threshold. The pure `pruneViolatingFields` is exported and unit-tested; `main()`
+ * only does IO and needs no OpenAI key.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
+import type { Locale, WorkflowContent } from '../../src/lib/i18n/schema';
+import { collectViolations, type Violation } from './validate-translations';
+
+const CONTENT_DIR = path.join(process.cwd(), 'src', 'i18n', 'content');
+const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');
+
+/** A locale failing more than this fraction of its translated fields is systemic,
+ *  not a tail — fail the build rather than silently English-fallback most of it. */
+const MAX_PRUNE_FRACTION = Number(process.env.I18N_MAX_PRUNE_FRACTION ?? '0.15');
+
+function readJson<T>(file: string, fallback: T): T {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8')) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export interface PruneResult {
+  /** The locale content with every violating field removed. */
+  content: Record<string, Partial<WorkflowContent>>;
+  /** The violations that caused a prune, for the report. */
+  pruned: Violation[];
+  /** Distinct fields removed (a field with several violations counts once). */
+  prunedFieldCount: number;
+  /** Translated fields inspected (present + non-null), the threshold denominator. */
+  fieldsInspected: number;
+}
+
+/**
+ * Remove every field that fails a deterministic check from a locale's content, so
+ * it falls back to English at render. Pure — reuses the validator's own
+ * `collectViolations`, so what is pruned is exactly what would have failed.
+ */
+export function pruneViolatingFields(
+  localeContent: Record<string, Partial<WorkflowContent>>,
+  english: Record<string, WorkflowContent>,
+  locale: Locale,
+  preserveTerms: string[],
+  overrides: Record<string, string>
+): PruneResult {
+  const pruned: Violation[] = [];
+  let prunedFieldCount = 0;
+  let fieldsInspected = 0;
+  const content: Record<string, Partial<WorkflowContent>> = {};
+
+  for (const [shareId, localized] of Object.entries(localeContent)) {
+    const en = english[shareId];
+    // Entries with no English match are left untouched — the validator's
+    // misalignment guard owns that case (pruning would just hide it).
+    if (!en) {
+      content[shareId] = localized;
+      continue;
+    }
+    fieldsInspected += Object.values(localized).filter((v) => v != null).length;
+    const violations = collectViolations(shareId, locale, en, localized, preserveTerms, overrides);
+    if (violations.length === 0) {
+      content[shareId] = localized;
+      continue;
+    }
+    const badFields = new Set(violations.map((v) => v.field));
+    const kept = { ...localized };
+    for (const field of badFields) delete kept[field];
+    content[shareId] = kept;
+    prunedFieldCount += badFields.size;
+    pruned.push(...violations);
+  }
+
+  return { content, pruned, prunedFieldCount, fieldsInspected };
+}
+
+function main(): void {
+  const english = readJson<Record<string, WorkflowContent>>(path.join(CONTENT_DIR, 'en.json'), {});
+  const preserveTerms = readJson<string[]>(path.join(GLOSSARY_DIR, 'preserve-terms.json'), []);
+
+  let totalPruned = 0;
+  const systemic: string[] = [];
+
+  for (const locale of SUPPORTED_HUB_LOCALES) {
+    if (locale === 'en') continue;
+    const file = path.join(CONTENT_DIR, `${locale}.json`);
+    const localeContent = readJson<Record<string, Partial<WorkflowContent>>>(file, {});
+    if (Object.keys(localeContent).length === 0) continue;
+    const overrides = readJson<Record<string, string>>(
+      path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`),
+      {}
+    );
+
+    const result = pruneViolatingFields(localeContent, english, locale, preserveTerms, overrides);
+    if (result.prunedFieldCount === 0) continue;
+
+    fs.writeFileSync(file, JSON.stringify(result.content, null, 2) + '\n');
+    totalPruned += result.prunedFieldCount;
+
+    const byKind = result.pruned.reduce<Record<string, number>>((acc, v) => {
+      acc[v.kind] = (acc[v.kind] ?? 0) + 1;
+      return acc;
+    }, {});
+    const fraction = result.fieldsInspected ? result.prunedFieldCount / result.fieldsInspected : 0;
+    console.log(
+      `[i18n] enforce: [${locale}] pruned ${result.prunedFieldCount}/${result.fieldsInspected} ` +
+        `field(s) (${(fraction * 100).toFixed(1)}%) -> English fallback.`,
+      byKind
+    );
+    for (const v of result.pruned.slice(0, 20)) {
+      console.log(`  [${locale}] ${v.shareId} ${v.field} (${v.kind}): ${v.detail}`);
+    }
+    if (result.pruned.length > 20) console.log(`  …and ${result.pruned.length - 20} more.`);
+
+    if (fraction > MAX_PRUNE_FRACTION) {
+      systemic.push(
+        `${locale}: ${(fraction * 100).toFixed(1)}% of translated fields failed ` +
+          `(> ${(MAX_PRUNE_FRACTION * 100).toFixed(0)}% threshold)`
+      );
+    }
+  }
+
+  if (totalPruned === 0) {
+    console.log('[i18n] enforce: no violations to prune.');
+    return;
+  }
+  console.log(`[i18n] enforce: pruned ${totalPruned} field(s) total across all locales.`);
+
+  if (systemic.length > 0) {
+    console.error(
+      '[i18n] enforce: pruning is systemic, not a tail — failing the run instead of ' +
+        'English-falling-back most of a locale:'
+    );
+    for (const s of systemic) console.error(`  ${s}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/site/scripts/i18n/enforce-translations.ts
+++ b/site/scripts/i18n/enforce-translations.ts
@@ -94,9 +94,40 @@ export function pruneViolatingFields(
   return { content, pruned, prunedFieldCount, fieldsInspected };
 }
 
+/**
+ * True when translation was attempted for locales but produced NOTHING for any of
+ * them while English is populated — i.e. the model call failed wholesale (e.g. an
+ * OpenAI 429 quota error), not a partial rate-limited run. Publishing then would
+ * open an empty PR, so the run must fail instead. A run with any translated entry
+ * (real partial progress) is allowed through.
+ */
+export function isEmptyTranslation(englishCount: number, targetEntryCounts: number[]): boolean {
+  return (
+    englishCount > 0 && targetEntryCounts.length > 0 && targetEntryCounts.every((n) => n === 0)
+  );
+}
+
 function main(): void {
   const english = readJson<Record<string, WorkflowContent>>(path.join(CONTENT_DIR, 'en.json'), {});
   const preserveTerms = readJson<string[]>(path.join(GLOSSARY_DIR, 'preserve-terms.json'), []);
+
+  // Fail fast on a wholesale translation failure: if every locale we tried to
+  // translate this run came back empty (English is populated), the model call died
+  // (e.g. OpenAI quota) and there is nothing to publish. Refuse to open an empty PR.
+  const targets = (process.env.TRANSLATE_LOCALES ?? '').split(/\s+/).filter((l) => l && l !== 'en');
+  const targetCounts = targets.map(
+    (loc) =>
+      Object.keys(readJson<Record<string, unknown>>(path.join(CONTENT_DIR, `${loc}.json`), {}))
+        .length
+  );
+  if (isEmptyTranslation(Object.keys(english).length, targetCounts)) {
+    console.error(
+      `[i18n] enforce: translation produced 0 entries for every target locale ` +
+        `(${targets.join(', ')}) while English has ${Object.keys(english).length} workflow(s). ` +
+        `The translation step failed wholesale (e.g. OpenAI quota) — refusing to publish an empty PR.`
+    );
+    process.exit(1);
+  }
 
   let totalPruned = 0;
   const systemic: string[] = [];

--- a/site/scripts/i18n/preserve-protection.ts
+++ b/site/scripts/i18n/preserve-protection.ts
@@ -25,18 +25,20 @@ import { pathToFileURL } from 'node:url';
 const CONTENT_DIR = path.join(process.cwd(), 'src', 'i18n', 'content');
 const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');
 
-/** Sentinel token for term index `i`. ASCII double-brackets read as a placeholder
- *  to the model (like a wiki link) and never occur in real workflow content. */
+/** Sentinel token for term index `i`. Double-braces read as a required
+ *  interpolation variable, which models preserve far more reliably than a
+ *  bracketed marker (they drop the latter when rephrasing), and never occur in
+ *  real workflow content. */
 export function sentinelFor(index: number): string {
-  return `[[PT${index}]]`;
+  return `{{PT${index}}}`;
 }
 
 /**
- * Match a sentinel even if the model nudged it: 1-2 ASCII or fullwidth brackets,
+ * Match a sentinel even if the model nudged it: 1-2 ASCII or fullwidth braces,
  * optional spaces, case-insensitive PT, digits. A residual it can't match stays as
  * a missing preserve-term, which the validator then catches (fail-closed).
  */
-const SENTINEL_RE = /[[［【]{1,2}\s*[Pp][Tt]\s*(\d+)\s*[\]］】]{1,2}/g;
+const SENTINEL_RE = /[{｛]{1,2}\s*[Pp][Tt]\s*(\d+)\s*[}｝]{1,2}/g;
 
 export interface TermMap {
   /** Preserve-terms longest-first, so "ComfyUI" is replaced before "Comfy". */

--- a/site/scripts/i18n/preserve-protection.ts
+++ b/site/scripts/i18n/preserve-protection.ts
@@ -1,0 +1,141 @@
+/**
+ * preserve-protection — deterministic do-not-translate protection for the hub
+ * translation pipeline (GTM-291).
+ *
+ * lobe/OpenAI's "never translate these proper nouns" instruction is advisory, so
+ * brand/model names (ComfyUI, ControlNet, Flux, VAE, KSampler…) leak into the
+ * localized output and fail the glossary validator. This wraps the translate step:
+ *
+ *   pnpm i18n:protect   → swap every preserve-term in content/en.json for an inert
+ *                         sentinel token the model passes through untouched.
+ *   pnpm locale         → lobe translates the sentinelized English.
+ *   pnpm i18n:restore   → swap the sentinels back to the exact English term in
+ *                         every content file (en + machine locales).
+ *
+ * The result is byte-for-byte survival of preserve-terms for every locale. The
+ * committed en.json ends up with real terms again, so it still matches the manifest
+ * hashes (which build-source computed from the real English before protection).
+ *
+ * The pure functions are exported and unit-tested; `main()` only does IO.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CONTENT_DIR = path.join(process.cwd(), 'src', 'i18n', 'content');
+const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');
+
+/** Sentinel token for term index `i`. ASCII double-brackets read as a placeholder
+ *  to the model (like a wiki link) and never occur in real workflow content. */
+export function sentinelFor(index: number): string {
+  return `[[PT${index}]]`;
+}
+
+/**
+ * Match a sentinel even if the model nudged it: 1-2 ASCII or fullwidth brackets,
+ * optional spaces, case-insensitive PT, digits. A residual it can't match stays as
+ * a missing preserve-term, which the validator then catches (fail-closed).
+ */
+const SENTINEL_RE = /[[［【]{1,2}\s*[Pp][Tt]\s*(\d+)\s*[\]］】]{1,2}/g;
+
+export interface TermMap {
+  /** Preserve-terms longest-first, so "ComfyUI" is replaced before "Comfy". */
+  ordered: string[];
+  sentinelByTerm: Map<string, string>;
+  termByIndex: string[];
+}
+
+export function buildTermMap(terms: string[]): TermMap {
+  const uniq = [...new Set(terms.filter((t) => typeof t === 'string' && t.trim()))];
+  const ordered = uniq.sort((a, b) => b.length - a.length);
+  const sentinelByTerm = new Map<string, string>();
+  const termByIndex: string[] = [];
+  ordered.forEach((term, i) => {
+    sentinelByTerm.set(term, sentinelFor(i));
+    termByIndex[i] = term;
+  });
+  return { ordered, sentinelByTerm, termByIndex };
+}
+
+/** Replace every exact occurrence of each preserve-term with its sentinel. */
+export function protectText(text: string, map: TermMap): string {
+  let out = text;
+  for (const term of map.ordered) {
+    out = out.split(term).join(map.sentinelByTerm.get(term)!);
+  }
+  return out;
+}
+
+/** Replace every sentinel with its exact English term. */
+export function restoreText(text: string, map: TermMap): string {
+  return text.replace(SENTINEL_RE, (whole, idx) => map.termByIndex[Number(idx)] ?? whole);
+}
+
+/** Walk a JSON value (string | array | object), applying `fn` to every string. */
+function mapStrings(value: unknown, fn: (s: string) => string): unknown {
+  if (typeof value === 'string') return fn(value);
+  if (Array.isArray(value)) return value.map((v) => mapStrings(v, fn));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = mapStrings(v, fn);
+    return out;
+  }
+  return value;
+}
+
+export function protectContent(content: unknown, map: TermMap): unknown {
+  return mapStrings(content, (s) => protectText(s, map));
+}
+
+export function restoreContent(content: unknown, map: TermMap): unknown {
+  return mapStrings(content, (s) => restoreText(s, map));
+}
+
+// ---------------------------------------------------------------------------
+// IO (main)
+// ---------------------------------------------------------------------------
+
+function transformFile(file: string, transform: (data: unknown) => unknown): boolean {
+  if (!fs.existsSync(file)) return false;
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  fs.writeFileSync(file, JSON.stringify(transform(data), null, 2) + '\n');
+  return true;
+}
+
+function main(): void {
+  const mode = process.argv[2];
+  if (mode !== 'protect' && mode !== 'restore') {
+    console.error('[i18n] preserve-protection: usage — protect | restore');
+    process.exit(1);
+  }
+  const termsFile = path.join(GLOSSARY_DIR, 'preserve-terms.json');
+  let terms: string[] = [];
+  try {
+    terms = JSON.parse(fs.readFileSync(termsFile, 'utf-8'));
+  } catch {
+    console.warn('[i18n] preserve-protection: no preserve-terms.json — nothing to do.');
+    return;
+  }
+  const map = buildTermMap(terms);
+
+  if (mode === 'protect') {
+    // Only the English source lobe reads; restored before commit.
+    const done = transformFile(path.join(CONTENT_DIR, 'en.json'), (d) => protectContent(d, map));
+    console.log(
+      done
+        ? `[i18n] protect: sentinelized ${map.ordered.length} preserve-terms in content/en.json.`
+        : '[i18n] protect: content/en.json not found.'
+    );
+  } else {
+    // Restore every content file: en.json plus each machine locale lobe produced.
+    let files = 0;
+    for (const f of fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.json'))) {
+      if (transformFile(path.join(CONTENT_DIR, f), (d) => restoreContent(d, map))) files++;
+    }
+    console.log(`[i18n] restore: restored preserve-terms across ${files} content file(s).`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/site/scripts/i18n/preserve-protection.ts
+++ b/site/scripts/i18n/preserve-protection.ts
@@ -38,7 +38,9 @@ export function sentinelFor(index: number): string {
  * optional spaces, case-insensitive PT, digits. A residual it can't match stays as
  * a missing preserve-term, which the validator then catches (fail-closed).
  */
-const SENTINEL_RE = /[{｛]{1,2}\s*[Pp][Tt]\s*(\d+)\s*[}｝]{1,2}/g;
+const SENTINEL_PATTERN = '[{｛]{1,2}\\s*[Pp][Tt]\\s*(\\d+)\\s*[}｝]{1,2}';
+const SENTINEL_RE = new RegExp(SENTINEL_PATTERN, 'g'); // restore: replace every match
+const SENTINEL_TEST = new RegExp(SENTINEL_PATTERN); // detection: stateless test
 
 export interface TermMap {
   /** Preserve-terms longest-first, so "ComfyUI" is replaced before "Comfy". */
@@ -93,6 +95,20 @@ export function restoreContent(content: unknown, map: TermMap): unknown {
   return mapStrings(content, (s) => restoreText(s, map));
 }
 
+/**
+ * Strings in `content` that already contain sentinel-shaped text. Protecting such
+ * content would let `restore` silently rewrite genuine Hub content into a
+ * preserve-term, so `protect` refuses the build when this returns anything.
+ */
+export function findSentinelCollisions(content: unknown): string[] {
+  const hits: string[] = [];
+  mapStrings(content, (s) => {
+    if (SENTINEL_TEST.test(s)) hits.push(s);
+    return s;
+  });
+  return hits;
+}
+
 // ---------------------------------------------------------------------------
 // IO (main)
 // ---------------------------------------------------------------------------
@@ -122,11 +138,26 @@ function main(): void {
 
   if (mode === 'protect') {
     // Only the English source lobe reads; restored before commit.
-    const done = transformFile(path.join(CONTENT_DIR, 'en.json'), (d) => protectContent(d, map));
+    const enFile = path.join(CONTENT_DIR, 'en.json');
+    if (!fs.existsSync(enFile)) {
+      console.log('[i18n] protect: content/en.json not found.');
+      return;
+    }
+    const source = JSON.parse(fs.readFileSync(enFile, 'utf-8'));
+    // Fail closed if the Hub source already contains sentinel-shaped text — restore
+    // would otherwise rewrite that genuine content into a preserve-term.
+    const collisions = findSentinelCollisions(source);
+    if (collisions.length > 0) {
+      console.error(
+        `[i18n] protect: ${collisions.length} source string(s) contain sentinel-shaped text; ` +
+          `refusing to protect (restore would corrupt them). Examples:`
+      );
+      for (const c of collisions.slice(0, 5)) console.error(`  ${c}`);
+      process.exit(1);
+    }
+    fs.writeFileSync(enFile, JSON.stringify(protectContent(source, map), null, 2) + '\n');
     console.log(
-      done
-        ? `[i18n] protect: sentinelized ${map.ordered.length} preserve-terms in content/en.json.`
-        : '[i18n] protect: content/en.json not found.'
+      `[i18n] protect: sentinelized ${map.ordered.length} preserve-terms in content/en.json.`
     );
   } else {
     // Restore every content file: en.json plus each machine locale lobe produced.

--- a/site/scripts/i18n/preserve-protection.ts
+++ b/site/scripts/i18n/preserve-protection.ts
@@ -1,6 +1,6 @@
 /**
  * preserve-protection — deterministic do-not-translate protection for the hub
- * translation pipeline (GTM-291).
+ * translation pipeline.
  *
  * lobe/OpenAI's "never translate these proper nouns" instruction is advisory, so
  * brand/model names (ComfyUI, ControlNet, Flux, VAE, KSampler…) leak into the

--- a/site/scripts/i18n/preserve-protection.ts
+++ b/site/scripts/i18n/preserve-protection.ts
@@ -36,17 +36,24 @@ export function sentinelFor(index: number): string {
 /**
  * Match a sentinel even if the model nudged it: 1-2 ASCII or fullwidth braces,
  * optional spaces, case-insensitive PT, digits. A residual it can't match stays as
- * a missing preserve-term, which the validator then catches (fail-closed).
+ * a missing preserve-term, which the validator then catches (fail-closed). Kept as
+ * literal regexes (not `new RegExp(str)`) so they carry no ReDoS/dynamic-source risk.
  */
-const SENTINEL_PATTERN = '[{｛]{1,2}\\s*[Pp][Tt]\\s*(\\d+)\\s*[}｝]{1,2}';
-const SENTINEL_RE = new RegExp(SENTINEL_PATTERN, 'g'); // restore: replace every match
-const SENTINEL_TEST = new RegExp(SENTINEL_PATTERN); // detection: stateless test
+const SENTINEL_RE = /[{｛]{1,2}\s*[Pp][Tt]\s*(\d+)\s*[}｝]{1,2}/g; // restore: replace every match
+const SENTINEL_TEST = /[{｛]{1,2}\s*[Pp][Tt]\s*(\d+)\s*[}｝]{1,2}/; // detection: stateless test
+
+/** Escape a literal string for safe inclusion in a RegExp alternation. */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 export interface TermMap {
   /** Preserve-terms longest-first, so "ComfyUI" is replaced before "Comfy". */
   ordered: string[];
   sentinelByTerm: Map<string, string>;
   termByIndex: string[];
+  /** One alternation over all terms, longest-first, or null when there are none. */
+  matcher: RegExp | null;
 }
 
 export function buildTermMap(terms: string[]): TermMap {
@@ -58,16 +65,23 @@ export function buildTermMap(terms: string[]): TermMap {
     sentinelByTerm.set(term, sentinelFor(i));
     termByIndex[i] = term;
   });
-  return { ordered, sentinelByTerm, termByIndex };
+  // Terms are escaped literals, so the alternation is safe (no ReDoS). Longest-first
+  // ordering makes "ComfyUI" win over "Comfy" at the same position.
+  const matcher = ordered.length ? new RegExp(ordered.map(escapeRegExp).join('|'), 'g') : null;
+  return { ordered, sentinelByTerm, termByIndex, matcher };
 }
 
-/** Replace every exact occurrence of each preserve-term with its sentinel. */
+/**
+ * Replace every occurrence of each preserve-term with its sentinel, in a SINGLE
+ * pass over the original text. Sequential per-term replacement re-scans its own
+ * output, so a later term ("PT0") could match inside a sentinel already emitted for
+ * an earlier term ("FooX" -> "{{PT0}}") and corrupt it; one regex pass never
+ * re-examines the text it just inserted.
+ */
 export function protectText(text: string, map: TermMap): string {
-  let out = text;
-  for (const term of map.ordered) {
-    out = out.split(term).join(map.sentinelByTerm.get(term)!);
-  }
-  return out;
+  if (!map.matcher) return text;
+  map.matcher.lastIndex = 0;
+  return text.replace(map.matcher, (m) => map.sentinelByTerm.get(m) ?? m);
 }
 
 /** Replace every sentinel with its exact English term. */

--- a/site/scripts/i18n/sync-glossary.ts
+++ b/site/scripts/i18n/sync-glossary.ts
@@ -1,5 +1,5 @@
 /**
- * sync-glossary — builds the translation glossary for the hub pipeline (GTM-291).
+ * sync-glossary — builds the translation glossary for the hub pipeline.
  *
  * Run: `pnpm i18n:glossary` (reads a ComfyUI_frontend checkout; no OpenAI key).
  *

--- a/site/scripts/i18n/validate-translations.ts
+++ b/site/scripts/i18n/validate-translations.ts
@@ -80,7 +80,10 @@ function countOccurrences(haystack: string, needle: string): number {
 }
 
 function extractUrls(text: string): string[] {
-  return text.match(/https?:\/\/[^\s"')]+/g) ?? [];
+  // Strip trailing sentence punctuation the greedy match swallows, so a URL
+  // followed by a period in English but a full-width period in the translation
+  // is not flagged as altered.
+  return (text.match(/https?:\/\/[^\s"')]+/g) ?? []).map((u) => u.replace(/[.,;:!?)\]]+$/, ''));
 }
 
 /**

--- a/site/src/components/HreflangTags.astro
+++ b/site/src/components/HreflangTags.astro
@@ -19,7 +19,7 @@ interface Props {
    */
   localized?: boolean;
   /**
-   * Explicit alternate locales for per-page gating (GTM-291). When provided it
+   * Explicit alternate locales for per-page gating. When provided it
    * overrides `localized`: ONLY these locales get `<link alternate>` tags, so a
    * detail page advertises exactly the locales for which it is indexable (Google
    * discards a cluster that references noindexed alternates). An empty array emits

--- a/site/src/components/SEOHead.astro
+++ b/site/src/components/SEOHead.astro
@@ -17,7 +17,7 @@ interface Props {
   hreflangBasePath?: string;
   /** Whether localized variants exist; false emits x-default only (no per-locale alternates). */
   hreflangLocalized?: boolean;
-  /** Explicit per-page alternate locales (GTM-291); overrides hreflangLocalized. */
+  /** Explicit per-page alternate locales; overrides hreflangLocalized. */
   hreflangLocales?: readonly Locale[];
   /** Emit robots noindex (keeps follow) for thin/unverified pages. */
   noindex?: boolean;

--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -7,7 +7,7 @@ import { LANGUAGES, DEFAULT_LOCALE, type Locale } from '../../i18n/config';
 import { getLocaleFromPath, localizeUrl } from '../../i18n/utils';
 import { INDEXABLE_LOCALES } from '../../lib/i18n/locales';
 
-// Language switcher (GTM-291). Self-derives from the current URL so no caller
+// Language switcher. Self-derives from the current URL so no caller
 // has to thread props: the current locale is the path's locale prefix, and the
 // un-prefixed base path is what every alternate URL is rebuilt from.
 const currentLocale = getLocaleFromPath(Astro.url.pathname);
@@ -17,12 +17,12 @@ const strippedPath =
     : Astro.url.pathname.replace(new RegExp(`^/${currentLocale}`), '') || '/';
 const basePath = strippedPath.startsWith('/') ? strippedPath : `/${strippedPath}`;
 
-// Predicate-gated links (design v3 §13 PR 3): only offer languages whose pages
-// are actually live. INDEXABLE_LOCALES is the language-level rollout gate and is
-// empty until a language passes native review, so today this renders nothing and
-// the footer stays byte-identical. English is always offered as the return path.
-// Per-page refinement (a workflow untranslated in an otherwise-live locale) lands
-// with the indexability predicate in a later PR.
+// Predicate-gated links: only offer languages whose pages are actually live.
+// INDEXABLE_LOCALES is the language-level rollout gate and is empty until a
+// language passes native review, so today this renders nothing and the footer
+// stays byte-identical. English is always offered as the return path. Per-page
+// refinement (a workflow untranslated in an otherwise-live locale) is handled by
+// the indexability predicate.
 const offeredLocales: Locale[] = [
   DEFAULT_LOCALE,
   ...INDEXABLE_LOCALES.filter((l) => l !== DEFAULT_LOCALE),

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ interface Props {
   hreflangBasePath?: string;
   /** Whether localized variants of this route exist (controls hreflang alternates). */
   hreflangLocalized?: boolean;
-  /** Explicit per-page alternate locales (GTM-291); overrides hreflangLocalized. */
+  /** Explicit per-page alternate locales; overrides hreflangLocalized. */
   hreflangLocales?: readonly Locale[];
   theme?: 'light' | 'dark';
   hideDefaultFooter?: boolean;

--- a/site/src/lib/i18n/locales.ts
+++ b/site/src/lib/i18n/locales.ts
@@ -1,5 +1,5 @@
 /**
- * The three locale sets for hub localization (GTM-291), per the approved design.
+ * The three locale sets for hub localization.
  * Discovery is not activation — each set is a deliberate narrowing of the last:
  *
  *   AVAILABLE_APP_LOCALES  ⊇  SUPPORTED_HUB_LOCALES  ⊇  INDEXABLE_LOCALES

--- a/site/src/lib/i18n/predicate.ts
+++ b/site/src/lib/i18n/predicate.ts
@@ -1,5 +1,5 @@
 /**
- * The single per-page indexability predicate for hub localization (GTM-291).
+ * The single per-page indexability predicate for hub localization.
  *
  * One decision, consumed by four surfaces so they can never disagree: sitemap
  * membership, which hreflang alternates a page emits, its canonical (self vs

--- a/site/src/lib/i18n/resolver.ts
+++ b/site/src/lib/i18n/resolver.ts
@@ -1,6 +1,6 @@
 /**
  * resolveLocalizedWorkflow — the one place that merges a workflow's translated
- * content and decides whether its locale page may be indexed (GTM-291).
+ * content and decides whether its locale page may be indexed.
  *
  * fs-based and `astro:*`-free (like `workflow-pages/landing-content.ts`) so the
  * route, the sitemap filter, the hreflang emitter, and the CI validator all

--- a/site/src/lib/i18n/schema.ts
+++ b/site/src/lib/i18n/schema.ts
@@ -1,5 +1,5 @@
 /**
- * Shared shapes for the hub localization pipeline (GTM-291).
+ * Shared shapes for the hub localization pipeline.
  *
  * Dependency-free so routes, the resolver, the builder, validators, CI, and
  * tests can all import it (mirrors `workflow-pages/schema.ts`). No `astro:*`,

--- a/site/src/lib/workflow-pages/seo-page.ts
+++ b/site/src/lib/workflow-pages/seo-page.ts
@@ -21,8 +21,8 @@ function pageIndexable(hasQualityContent: boolean, templateCount: number): boole
  * English keeps the richer AI-generated copy; localized routes prefer the
  * translated templated copy. The generated `content.*` is English-only, so on a
  * non-English (already self-canonical, indexable) page it would show an English
- * meta description — ranking well but tanking CTR. Quick win: swap the precedence
- * per locale so these pages read in-language without waiting on any locale flip.
+ * meta description — ranking well but tanking CTR. Swapping the precedence per
+ * locale lets these pages read in-language without waiting on any locale flip.
  */
 function localizedFirst(locale: Locale, english: string | undefined, localized: string): string {
   return (locale === DEFAULT_LOCALE ? english : undefined) || localized;

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -1,6 +1,6 @@
 ---
 /**
- * Localized workflow detail page — pre-rendered at build time (GTM-291).
+ * Localized workflow detail page — pre-rendered at build time.
  * URL: /{locale}/workflows/{name}-{share_id}/
  *
  * Mirrors the English `workflows/[slug].astro`, but joins translated content via
@@ -11,7 +11,7 @@
  *    to the English URL, so humans see the translation while Google keeps
  *    indexing English. This is the "safety by canonical" the whole design rests on.
  *  - for a locale in INDEXABLE_LOCALES, a non-indexable page fails the build
- *    (fail-closed, section 8.4) rather than shipping a half-English indexable URL.
+ *    (fail-closed) rather than shipping a half-English indexable URL.
  *
  * With INDEXABLE_LOCALES empty, every page is non-indexable, so canonicals all
  * point at English and the Google-facing output is unchanged.

--- a/site/tests/unit/i18n-enforce-translations.test.ts
+++ b/site/tests/unit/i18n-enforce-translations.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { pruneViolatingFields } from '../../scripts/i18n/enforce-translations';
+import type { WorkflowContent } from '../../src/lib/i18n/schema';
+
+const PRESERVE = ['ComfyUI', 'VAE'];
+
+const english: Record<string, WorkflowContent> = {
+  wf1: {
+    title: 'ComfyUI VAE workflow',
+    description: 'Run ComfyUI with a VAE decoder for crisp output.',
+    metaDescription: 'ComfyUI and VAE, explained.',
+    extendedDescription: 'This ComfyUI workflow uses a VAE.',
+    howToUse: ['Load the VAE in ComfyUI'],
+    suggestedUseCases: [],
+    faqItems: [{ question: 'What is a VAE?', answer: 'A ComfyUI decoder.' }],
+  } as WorkflowContent,
+};
+
+describe('pruneViolatingFields', () => {
+  it('prunes only the field where a preserve-term was dropped, keeping the rest', () => {
+    const zh: Record<string, Partial<WorkflowContent>> = {
+      wf1: {
+        // "description" dropped ComfyUI + VAE (translated away) -> must be pruned.
+        description: '使用解码器运行以获得清晰的输出。',
+        // "extendedDescription" kept both terms -> must survive.
+        extendedDescription: '此 ComfyUI 工作流使用 VAE。',
+      },
+    };
+    const { content, prunedFieldCount, pruned } = pruneViolatingFields(
+      zh,
+      english,
+      'zh',
+      PRESERVE,
+      {}
+    );
+    expect(content.wf1).not.toHaveProperty('description'); // pruned
+    expect(content.wf1.extendedDescription).toBe('此 ComfyUI 工作流使用 VAE。'); // kept
+    expect(prunedFieldCount).toBe(1);
+    expect(pruned.every((v) => v.field === 'description')).toBe(true);
+  });
+
+  it('counts a field with multiple violations as one prune', () => {
+    const zh: Record<string, Partial<WorkflowContent>> = {
+      // description drops BOTH ComfyUI and VAE -> two glossary violations, one field.
+      wf1: { description: '运行以获得清晰的输出。' },
+    };
+    const { prunedFieldCount, pruned } = pruneViolatingFields(zh, english, 'zh', PRESERVE, {});
+    expect(prunedFieldCount).toBe(1);
+    expect(pruned.length).toBeGreaterThan(1); // >1 violation, still one pruned field
+  });
+
+  it('leaves a clean locale untouched', () => {
+    const zh: Record<string, Partial<WorkflowContent>> = {
+      wf1: { extendedDescription: '此 ComfyUI 工作流使用 VAE。' },
+    };
+    const { content, prunedFieldCount } = pruneViolatingFields(zh, english, 'zh', PRESERVE, {});
+    expect(prunedFieldCount).toBe(0);
+    expect(content).toEqual(zh);
+  });
+
+  it('leaves entries with no English match untouched (validator owns misalignment)', () => {
+    const zh: Record<string, Partial<WorkflowContent>> = {
+      unknownId: { description: '任意内容' },
+    };
+    const { content, prunedFieldCount } = pruneViolatingFields(zh, english, 'zh', PRESERVE, {});
+    expect(prunedFieldCount).toBe(0);
+    expect(content.unknownId).toEqual({ description: '任意内容' });
+  });
+
+  it('reports the denominator (fields inspected) for the systemic threshold', () => {
+    const zh: Record<string, Partial<WorkflowContent>> = {
+      wf1: {
+        description: '使用解码器运行。', // dropped terms -> pruned
+        extendedDescription: '此 ComfyUI 工作流使用 VAE。', // kept
+      },
+    };
+    const { fieldsInspected, prunedFieldCount } = pruneViolatingFields(
+      zh,
+      english,
+      'zh',
+      PRESERVE,
+      {}
+    );
+    expect(fieldsInspected).toBe(2);
+    expect(prunedFieldCount).toBe(1); // 50% -> main() would flag systemic at this scale
+  });
+});

--- a/site/tests/unit/i18n-enforce-translations.test.ts
+++ b/site/tests/unit/i18n-enforce-translations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { pruneViolatingFields } from '../../scripts/i18n/enforce-translations';
+import { pruneViolatingFields, isEmptyTranslation } from '../../scripts/i18n/enforce-translations';
 import type { WorkflowContent } from '../../src/lib/i18n/schema';
 
 const PRESERVE = ['ComfyUI', 'VAE'];
@@ -83,5 +83,22 @@ describe('pruneViolatingFields', () => {
     );
     expect(fieldsInspected).toBe(2);
     expect(prunedFieldCount).toBe(1); // 50% -> main() would flag systemic at this scale
+  });
+});
+
+describe('isEmptyTranslation (wholesale-failure guard)', () => {
+  it('flags a run where every target locale is empty but English is populated', () => {
+    expect(isEmptyTranslation(582, [0])).toBe(true); // the OpenAI-quota case: zh came back {}
+    expect(isEmptyTranslation(582, [0, 0, 0])).toBe(true); // all targets empty
+  });
+
+  it('allows partial progress (at least one target has entries)', () => {
+    expect(isEmptyTranslation(582, [582])).toBe(false);
+    expect(isEmptyTranslation(582, [0, 300])).toBe(false); // zh empty but ja partial -> publish
+  });
+
+  it('never fires when there is no English source or no targets were attempted', () => {
+    expect(isEmptyTranslation(0, [0])).toBe(false); // nothing to translate against
+    expect(isEmptyTranslation(582, [])).toBe(false); // TRANSLATE_LOCALES unset (e.g. local run)
   });
 });

--- a/site/tests/unit/i18n-preserve-protection.test.ts
+++ b/site/tests/unit/i18n-preserve-protection.test.ts
@@ -5,6 +5,7 @@ import {
   restoreText,
   protectContent,
   restoreContent,
+  findSentinelCollisions,
   sentinelFor,
 } from '../../scripts/i18n/preserve-protection';
 
@@ -55,6 +56,28 @@ describe('restoreText tolerance', () => {
   });
   it('leaves an unknown sentinel index untouched (validator catches residue)', () => {
     expect(restoreText('x {{PT999}} y', map)).toBe('x {{PT999}} y');
+  });
+});
+
+describe('findSentinelCollisions (data-integrity guard)', () => {
+  const map = buildTermMap(TERMS);
+  it('detects sentinel-shaped text already present in the source', () => {
+    expect(findSentinelCollisions({ a: { title: 'see {{PT0}} here' } })).toEqual([
+      'see {{PT0}} here',
+    ]);
+    // the tolerant single-brace form too
+    expect(findSentinelCollisions({ a: { howToUse: ['x {PT3} y'] } })).toEqual(['x {PT3} y']);
+  });
+
+  it('is empty for clean content', () => {
+    expect(
+      findSentinelCollisions({ a: { title: 'ComfyUI ControlNet', howToUse: ['Load it'] } })
+    ).toEqual([]);
+  });
+
+  it('proves the guard is necessary: restore WOULD rewrite a literal marker', () => {
+    // If protect did not reject this, genuine content would be corrupted on restore.
+    expect(restoreText('literal {{PT0}} token', map)).toBe(`literal ${map.termByIndex[0]} token`);
   });
 });
 

--- a/site/tests/unit/i18n-preserve-protection.test.ts
+++ b/site/tests/unit/i18n-preserve-protection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTermMap,
+  protectText,
+  restoreText,
+  protectContent,
+  restoreContent,
+  sentinelFor,
+} from '../../scripts/i18n/preserve-protection';
+
+const TERMS = ['ComfyUI', 'Comfy', 'ControlNet', 'VAE', 'Nano Banana Pro', 'Nano Banana'];
+
+describe('buildTermMap', () => {
+  it('orders terms longest-first and dedupes/empties out', () => {
+    const map = buildTermMap(['Comfy', 'ComfyUI', 'Comfy', '', '  ']);
+    expect(map.ordered).toEqual(['ComfyUI', 'Comfy']); // longest first, deduped
+  });
+});
+
+describe('protect + restore round-trip', () => {
+  const map = buildTermMap(TERMS);
+
+  it('protects the longer term first so ComfyUI is not split by Comfy', () => {
+    const protectedText = protectText('Use ComfyUI and Comfy Cloud', map);
+    // "ComfyUI" -> its own sentinel; the standalone "Comfy" -> its sentinel; never "[[..]]UI".
+    expect(protectedText).not.toContain('ComfyUI');
+    expect(protectedText).not.toMatch(/Comfy(?!UI)/); // no bare Comfy left either
+    expect(restoreText(protectedText, map)).toBe('Use ComfyUI and Comfy Cloud');
+  });
+
+  it('round-trips multi-word terms and their prefixes (Nano Banana Pro vs Nano Banana)', () => {
+    const s = 'Try Nano Banana Pro, not just Nano Banana.';
+    expect(restoreText(protectText(s, map), map)).toBe(s);
+  });
+
+  it('the exact failure case: ComfyUI/Comfy survive a "translation" that drops originals', () => {
+    const en = '在 ComfyUI 中使用 Comfy 工作流'; // English brand names embedded in zh prose
+    const prot = protectText(en, map);
+    // Simulate the model translating everything it can but leaving sentinels intact.
+    const modelOutput = prot.replace('在', '在').replace('中使用', '中使用');
+    expect(restoreText(modelOutput, map)).toContain('ComfyUI');
+    expect(restoreText(modelOutput, map)).toContain('Comfy');
+  });
+});
+
+describe('restoreText tolerance', () => {
+  const map = buildTermMap(TERMS);
+  it('restores sentinels the model nudged (spaces, fullwidth brackets)', () => {
+    const i = 0;
+    const token = sentinelFor(i);
+    expect(token).toBe('[[PT0]]');
+    // spaced + fullwidth-bracket variants a model might emit
+    expect(restoreText('a [[ PT0 ]] b', map)).toBe(`a ${map.termByIndex[0]} b`);
+    expect(restoreText('a ［［PT0］］ b', map)).toBe(`a ${map.termByIndex[0]} b`);
+    expect(restoreText('a 【PT0】 b', map)).toBe(`a ${map.termByIndex[0]} b`);
+  });
+  it('leaves an unknown sentinel index untouched (validator catches residue)', () => {
+    expect(restoreText('x [[PT999]] y', map)).toBe('x [[PT999]] y');
+  });
+});
+
+describe('protectContent / restoreContent walk nested structures', () => {
+  const map = buildTermMap(TERMS);
+  it('round-trips strings, arrays and FAQ objects', () => {
+    const content = {
+      s1: {
+        title: 'ComfyUI ControlNet',
+        howToUse: ['Load the ControlNet model', 'Run in ComfyUI'],
+        faqItems: [{ question: 'What is VAE?', answer: 'A ComfyUI node.' }],
+      },
+    };
+    const round = restoreContent(protectContent(content, map), map);
+    expect(round).toEqual(content);
+    // and protection actually removed the raw terms
+    const prot = JSON.stringify(protectContent(content, map));
+    expect(prot).not.toContain('ControlNet');
+    expect(prot).not.toContain('ComfyUI');
+  });
+});

--- a/site/tests/unit/i18n-preserve-protection.test.ts
+++ b/site/tests/unit/i18n-preserve-protection.test.ts
@@ -34,6 +34,16 @@ describe('protect + restore round-trip', () => {
     expect(restoreText(protectText(s, map), map)).toBe(s);
   });
 
+  it('does not reprocess a generated sentinel with a later term (FooX vs PT0)', () => {
+    // Sequential per-term replacement would turn FooX -> {{PT0}} and then let the
+    // "PT0" term rewrite that sentinel; single-pass protection must round-trip both.
+    const m = buildTermMap(['FooX', 'PT0']);
+    const s = 'render FooX then PT0';
+    const prot = protectText(s, m);
+    expect(prot).not.toContain('FooX');
+    expect(restoreText(prot, m)).toBe(s);
+  });
+
   it('the exact failure case: ComfyUI/Comfy survive a "translation" that drops originals', () => {
     const en = '在 ComfyUI 中使用 Comfy 工作流'; // English brand names embedded in zh prose
     const prot = protectText(en, map);

--- a/site/tests/unit/i18n-preserve-protection.test.ts
+++ b/site/tests/unit/i18n-preserve-protection.test.ts
@@ -45,17 +45,16 @@ describe('protect + restore round-trip', () => {
 
 describe('restoreText tolerance', () => {
   const map = buildTermMap(TERMS);
-  it('restores sentinels the model nudged (spaces, fullwidth brackets)', () => {
-    const i = 0;
-    const token = sentinelFor(i);
-    expect(token).toBe('[[PT0]]');
-    // spaced + fullwidth-bracket variants a model might emit
-    expect(restoreText('a [[ PT0 ]] b', map)).toBe(`a ${map.termByIndex[0]} b`);
-    expect(restoreText('a ［［PT0］］ b', map)).toBe(`a ${map.termByIndex[0]} b`);
-    expect(restoreText('a 【PT0】 b', map)).toBe(`a ${map.termByIndex[0]} b`);
+  it('restores sentinels the model nudged (spaces, single/fullwidth braces)', () => {
+    const token = sentinelFor(0);
+    expect(token).toBe('{{PT0}}');
+    // spaced + single-brace + fullwidth-brace variants a model might emit
+    expect(restoreText('a {{ PT0 }} b', map)).toBe(`a ${map.termByIndex[0]} b`);
+    expect(restoreText('a {PT0} b', map)).toBe(`a ${map.termByIndex[0]} b`);
+    expect(restoreText('a ｛｛PT0｝｝ b', map)).toBe(`a ${map.termByIndex[0]} b`);
   });
   it('leaves an unknown sentinel index untouched (validator catches residue)', () => {
-    expect(restoreText('x [[PT999]] y', map)).toBe('x [[PT999]] y');
+    expect(restoreText('x {{PT999}} y', map)).toBe('x {{PT999}} y');
   });
 });
 

--- a/site/tests/unit/i18n-validate-translations.test.ts
+++ b/site/tests/unit/i18n-validate-translations.test.ts
@@ -79,6 +79,14 @@ describe('collectViolations', () => {
     expect(kinds(collectViolations('s1', 'zh', en(), zh, PRESERVE))).toContain('format');
   });
 
+  it('does not flag a URL that differs only in trailing sentence punctuation', () => {
+    // English ends the sentence with the URL + a period; the translation keeps the
+    // URL but uses a full-width period. The URL itself is intact.
+    const enName = en({ metaDescription: 'Docs at https://comfy.org/docs.' });
+    const zh = { metaDescription: '文档见 https://comfy.org/docs。' };
+    expect(kinds(collectViolations('s1', 'zh', enName, zh, PRESERVE))).not.toContain('format');
+  });
+
   it('flags an introduced banned hype word', () => {
     const es = { description: 'Genera videos stunning con Wan 2.1 en ComfyUI.' };
     expect(kinds(collectViolations('s1', 'es', en(), es, PRESERVE))).toContain('brand-voice');


### PR DESCRIPTION
The first real zh translation run failed the deterministic validators — 43 glossary violations (brand/model names the model translated into Chinese despite the advisory "do not translate" prompt: ComfyUI, ControlNet, Flux, VAE, KSampler, UNet, Seedance, Qwen-Image, Hunyuan3D, Nano Banana…) plus 1 format violation (a URL flagged over trailing punctuation). The fail-closed gate correctly blocked publishing, but no translation can land until the output passes reliably.

## What

- **Preserve-term protection (main fix).** Wrap the translate step: `i18n:protect` swaps each preserve-term in `content/en.json` for an inert sentinel (`[[PTn]]`, longest-term-first so `ComfyUI` is not split by `Comfy`); lobe translates the sentinelized source; `i18n:restore` swaps the sentinels back to the exact English term in every content file (tolerant to spacing / full-width brackets the model might introduce). The committed `en.json` keeps its real terms, so it still matches the manifest hashes. Deterministic byte-for-byte survival, for every locale.
- **Validator.** Strip trailing sentence punctuation from extracted URLs, so a URL followed by an ASCII period in English but a full-width period in the translation is not falsely flagged as altered.
- **Workflow.** Add a `locale` `workflow_dispatch` input so a per-language backfill runs directly (`-f locale=zh`) instead of a throwaway branch; a blank input and the cron still do all supported locales.

## Verified

- 41 i18n unit tests, including the exact `ComfyUI`/`Comfy` failure case and the URL-punctuation case.
- protect/restore round-trips identical over all 39 preserve-terms (pure functions + CLI on a fixture).
- `astro check` clean; eslint / prettier / YAML clean.

Once merged, re-running the zh backfill (`-f locale=zh`) should clear the glossary gate and open the actual translation PR.