### PR TITLE
feat(site): reframe cloud CTAs around the free tier

### DIFF
--- a/site/src/components/hub/nav/HeaderMain.vue
+++ b/site/src/components/hub/nav/HeaderMain.vue
@@ -19,22 +19,17 @@ const {
   creators?: CreatorLink[];
 }>();
 
-/** Split "DOWNLOAD DESKTOP" → { prefix: "DOWNLOAD", core: "DESKTOP" } for the reveal animation. */
-function splitLabel(label: string): { prefix: string; core: string } {
-  const lastSpace = label.lastIndexOf(' ');
-  if (lastSpace === -1) return { prefix: '', core: label };
-  return { prefix: label.slice(0, lastSpace), core: label.slice(lastSpace + 1) };
-}
-
 const ctaButtons = [
   {
-    ...splitLabel(t('nav.downloadLocal', locale)),
+    full: t('nav.downloadLocal', locale),
+    short: t('nav.downloadLocalShort', locale),
     ariaLabel: t('nav.downloadLocal', locale),
     href: navRoutes.download,
     primary: false,
   },
   {
-    ...splitLabel(t('nav.launchCloud', locale)),
+    full: t('nav.launchCloud', locale),
+    short: t('nav.launchCloudShort', locale),
     ariaLabel: t('nav.launchCloud', locale),
     href: getCloudLandingUrl('site_button'),
     primary: true,
@@ -79,7 +74,8 @@ const ctaButtons = [
         :class="cta.primary ? 'run-cloud-btn' : undefined"
       >
         <span class="ppformula-text-center">
-          <span class="hidden xl:inline-block">{{ cta.prefix }}&nbsp;</span>{{ cta.core }}
+          <span class="hidden xl:inline-block">{{ cta.full }}</span>
+          <span class="xl:hidden">{{ cta.short }}</span>
         </span>
       </Button>
     </div>

--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -140,9 +140,6 @@ function formatRelativeDate(dateStr: string): string {
                       ? t('cta.tryCloudFree', locale)
                       : t('cta.tryCloud', locale)}
                   </span>
-                  {featureFlags.cloudFreeTier && !isApiTemplate && (
-                    <span class="font-normal text-xs">{t('cta.tryCloudSubline', locale)}</span>
-                  )}
                 </a>
               )
             }

--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -52,6 +52,8 @@ const authorAvatarUrl = profile?.avatar_url || null;
 const authorProfileUrl = data.username ? creatorPath(data.username, locale) : null;
 const thumbnails = data.detailImages?.length ? data.detailImages : data.thumbnails || [];
 const showCloudCta = !data.includeOnDistributions || data.includeOnDistributions.includes('cloud');
+// Partner/API workflows bill partner credits, so the CTA must not promise free.
+const isApiTemplate = data.tags?.includes('API') ?? false;
 const cloudTemplateId = data.shareId || data.name;
 const downloadUrl = data.shareId
   ? getWorkflowDownloadUrl(data.shareId, data.name)
@@ -134,9 +136,11 @@ function formatRelativeDate(dateStr: string): string {
                   data-location="hero"
                 >
                   <span class="ppformula-text-center-sm font-bold">
-                    {t('cta.tryCloud', locale)}
+                    {featureFlags.cloudFreeTier && !isApiTemplate
+                      ? t('cta.tryCloudFree', locale)
+                      : t('cta.tryCloud', locale)}
                   </span>
-                  {featureFlags.cloudFreeTier && (
+                  {featureFlags.cloudFreeTier && !isApiTemplate && (
                     <span class="font-normal text-xs">{t('cta.tryCloudSubline', locale)}</span>
                   )}
                 </a>

--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -52,7 +52,6 @@ const authorAvatarUrl = profile?.avatar_url || null;
 const authorProfileUrl = data.username ? creatorPath(data.username, locale) : null;
 const thumbnails = data.detailImages?.length ? data.detailImages : data.thumbnails || [];
 const showCloudCta = !data.includeOnDistributions || data.includeOnDistributions.includes('cloud');
-// Partner/API workflows bill partner credits, so the CTA must not promise free.
 const isApiTemplate = data.tags?.includes('API') ?? false;
 const cloudTemplateId = data.shareId || data.name;
 const downloadUrl = data.shareId

--- a/site/src/data/feature-flags.snapshot.json
+++ b/site/src/data/feature-flags.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "fetchedAt": "2026-05-12T06:25:36.881Z",
+  "fetchedAt": "2026-07-29T05:02:49.122Z",
   "flags": {
-    "cloudFreeTier": false
+    "cloudFreeTier": true
   }
 }

--- a/site/src/i18n/locales/ar.json
+++ b/site/src/i18n/locales/ar.json
@@ -44,7 +44,6 @@
   "cta.viewAll": "عرض الكل",
   "model.aboutEyebrow": "حول نموذج الذكاء الاصطناعي هذا",
   "model.heroEyebrow": "نموذج ذكاء اصطناعي",
-  "cta.tryCloudSubline": "✦ احصل على رصيد مجاني",
   "labels.workflowPreviewNote": "هذا تصور مبسط. قد يحتوي سير العمل الفعلي على عقد واتصالات إضافية.",
   "labels.nodeUses": "يستخدم",
   "meta.title": "Comfy سير العمل",

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -23,7 +23,7 @@
   "hub.search": "Search...",
   "nav.templates": "Workflows",
   "nav.downloadLocal": "DOWNLOAD DESKTOP",
-  "nav.launchCloud": "LAUNCH CLOUD",
+  "nav.launchCloud": "TRY FREE ON CLOUD",
   "nav.products": "Products",
   "nav.colFeatures": "Features",
   "nav.colPrograms": "Programs",
@@ -83,7 +83,7 @@
   "model.metaTitle": "{label} Comfy Workflows — Free Templates",
   "model.metaDescription": "Browse {count} ready-to-run ComfyUI workflow templates using {label}. AI generation workflows that run on Comfy Cloud with no setup.",
   "model.subheading": "Ready-to-run ComfyUI workflows built on {label}, fully editable and runnable on Comfy Cloud with no setup.",
-  "cta.tryCloudSubline": "✦ Get Free Credits",
+  "cta.tryCloudSubline": "✦ Free runs included",
   "labels.workflowPreviewNote": "This is a simplified visualization. The actual workflow may contain additional nodes and connections.",
   "labels.nodeUses": "Uses",
   "meta.title": "Comfy Workflows",
@@ -164,5 +164,8 @@
   "showcase.feature2.title": "App mode, a simplified view of your workflows",
   "showcase.feature2.description": "If you are new to ComfyUI, get started with App Mode, a simplified view of your workflows. You can flip back to the node graph view anytime to go deeper.",
   "showcase.feature3.title": "Community Workflows on Comfy Workflows",
-  "showcase.feature3.description": "Browse and remix thousands of community-shared workflows. Start from a proven template and customize it to your needs."
+  "showcase.feature3.description": "Browse and remix thousands of community-shared workflows. Start from a proven template and customize it to your needs.",
+  "nav.launchCloudShort": "TRY FREE",
+  "nav.downloadLocalShort": "DESKTOP",
+  "cta.tryCloudFree": "Try free on Comfy Cloud"
 }

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -83,7 +83,6 @@
   "model.metaTitle": "{label} Comfy Workflows — Free Templates",
   "model.metaDescription": "Browse {count} ready-to-run ComfyUI workflow templates using {label}. AI generation workflows that run on Comfy Cloud with no setup.",
   "model.subheading": "Ready-to-run ComfyUI workflows built on {label}, fully editable and runnable on Comfy Cloud with no setup.",
-  "cta.tryCloudSubline": "✦ Free runs included",
   "labels.workflowPreviewNote": "This is a simplified visualization. The actual workflow may contain additional nodes and connections.",
   "labels.nodeUses": "Uses",
   "meta.title": "Comfy Workflows",

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -75,7 +75,7 @@
   "labels.createdBy": "CREATED BY",
   "labels.lastUpdate": "LAST UPDATE",
   "labels.categories": "CATEGORIES",
-  "cta.tryCloud": "Try Comfy Cloud",
+  "cta.tryCloud": "Try on Comfy Cloud",
   "cta.viewAll": "View All",
   "model.aboutEyebrow": "About This AI Model",
   "model.heroEyebrow": "AI Model",

--- a/site/src/i18n/locales/es.json
+++ b/site/src/i18n/locales/es.json
@@ -42,7 +42,6 @@
   "cta.viewAll": "Ver todo",
   "model.aboutEyebrow": "Acerca de este Modelo de IA",
   "model.heroEyebrow": "Modelo de IA",
-  "cta.tryCloudSubline": "✦ Obtén Créditos Gratis",
   "labels.workflowPreviewNote": "Esta es una visualización simplificada. El workflow real puede contener nodos y conexiones adicionales.",
   "labels.nodeUses": "Usa",
   "meta.description": "Explora workflows gratuitos de ComfyUI",

--- a/site/src/i18n/locales/fr.json
+++ b/site/src/i18n/locales/fr.json
@@ -41,7 +41,6 @@
   "cta.viewAll": "Voir tout",
   "model.aboutEyebrow": "À propos de ce Modèle IA",
   "model.heroEyebrow": "Modèle IA",
-  "cta.tryCloudSubline": "✦ Crédits Gratuits",
   "labels.workflowPreviewNote": "Ceci est une visualisation simplifiée. Le workflow réel peut contenir des nœuds et connexions supplémentaires.",
   "labels.nodeUses": "Utilise",
   "meta.description": "Parcourez les workflows ComfyUI gratuits",

--- a/site/src/i18n/locales/ja.json
+++ b/site/src/i18n/locales/ja.json
@@ -45,7 +45,6 @@
   "cta.viewAll": "すべて見る",
   "model.aboutEyebrow": "この AI モデルについて",
   "model.heroEyebrow": "AI モデル",
-  "cta.tryCloudSubline": "✦ 無料クレジットを獲得",
   "labels.workflowPreviewNote": "これは簡略化された視覚化です。実際のワークフローには追加のノードと接続が含まれる場合があります。",
   "labels.nodeUses": "使用",
   "meta.title": "Comfy ワークフロー",

--- a/site/src/i18n/locales/ko.json
+++ b/site/src/i18n/locales/ko.json
@@ -45,7 +45,6 @@
   "cta.viewAll": "전체 보기",
   "model.aboutEyebrow": "이 AI 모델에 대해",
   "model.heroEyebrow": "AI 모델",
-  "cta.tryCloudSubline": "✦ 무료 크레딧 받기",
   "labels.workflowPreviewNote": "이것은 간소화된 시각화입니다. 실제 워크플로우에는 추가 노드와 연결이 포함될 수 있습니다.",
   "labels.nodeUses": "사용",
   "meta.title": "Comfy 워크플로우",

--- a/site/src/i18n/locales/pt-BR.json
+++ b/site/src/i18n/locales/pt-BR.json
@@ -41,7 +41,6 @@
   "cta.viewAll": "Ver tudo",
   "model.aboutEyebrow": "Sobre este Modelo de IA",
   "model.heroEyebrow": "Modelo de IA",
-  "cta.tryCloudSubline": "✦ Ganhe Créditos Grátis",
   "labels.workflowPreviewNote": "Esta é uma visualização simplificada. O workflow real pode conter nós e conexões adicionais.",
   "labels.nodeUses": "Usa",
   "meta.description": "Explore workflows gratuitos do ComfyUI",

--- a/site/src/i18n/locales/ru.json
+++ b/site/src/i18n/locales/ru.json
@@ -44,7 +44,6 @@
   "cta.viewAll": "Показать все",
   "model.aboutEyebrow": "Об этой AI-модели",
   "model.heroEyebrow": "AI-модель",
-  "cta.tryCloudSubline": "✦ Бесплатные Кредиты",
   "labels.workflowPreviewNote": "Это упрощённая визуализация. Фактический воркфлоу может содержать дополнительные узлы и связи.",
   "labels.nodeUses": "Использует",
   "meta.title": "Comfy Воркфлоу",

--- a/site/src/i18n/locales/tr.json
+++ b/site/src/i18n/locales/tr.json
@@ -42,7 +42,6 @@
   "cta.viewAll": "Tümünü gör",
   "model.aboutEyebrow": "Bu AI Modeli Hakkında",
   "model.heroEyebrow": "AI Modeli",
-  "cta.tryCloudSubline": "✦ Ücretsiz Kredi Al",
   "labels.workflowPreviewNote": "Bu basitleştirilmiş bir görselleştirmedir. Gerçek iş akışı ek düğümler ve bağlantılar içerebilir.",
   "labels.nodeUses": "Kullanır",
   "meta.description": "Ücretsiz ComfyUI workflow'larına göz atın",

--- a/site/src/i18n/locales/zh-TW.json
+++ b/site/src/i18n/locales/zh-TW.json
@@ -48,7 +48,6 @@
   "cta.viewAll": "查看全部",
   "model.aboutEyebrow": "關於此 AI 模型",
   "model.heroEyebrow": "AI 模型",
-  "cta.tryCloudSubline": "✦ 獲取免費額度",
   "labels.workflowPreviewNote": "這是簡化的視覺化。實際工作流可能包含更多節點和連接。",
   "labels.nodeUses": "使用",
   "meta.title": "Comfy 工作流",

--- a/site/src/i18n/locales/zh.json
+++ b/site/src/i18n/locales/zh.json
@@ -48,7 +48,6 @@
   "cta.viewAll": "查看全部",
   "model.aboutEyebrow": "关于此 AI 模型",
   "model.heroEyebrow": "AI 模型",
-  "cta.tryCloudSubline": "✦ 含免费运行次数",
   "labels.workflowPreviewNote": "这是简化的可视化。实际工作流可能包含更多节点和连接。",
   "labels.nodeUses": "使用",
   "meta.title": "Comfy 工作流",

--- a/site/src/i18n/locales/zh.json
+++ b/site/src/i18n/locales/zh.json
@@ -22,7 +22,7 @@
   "hub.search": "搜索...",
   "nav.templates": "工作流",
   "nav.downloadLocal": "下载桌面版",
-  "nav.launchCloud": "启动云端",
+  "nav.launchCloud": "免费试用云端",
   "nav.products": "产品",
   "nav.pricing": "价格",
   "nav.community": "社区",
@@ -48,7 +48,7 @@
   "cta.viewAll": "查看全部",
   "model.aboutEyebrow": "关于此 AI 模型",
   "model.heroEyebrow": "AI 模型",
-  "cta.tryCloudSubline": "✦ 获取免费额度",
+  "cta.tryCloudSubline": "✦ 含免费运行次数",
   "labels.workflowPreviewNote": "这是简化的可视化。实际工作流可能包含更多节点和连接。",
   "labels.nodeUses": "使用",
   "meta.title": "Comfy 工作流",
@@ -93,5 +93,8 @@
   "cta.downloadJson": "下载工作流",
   "labels.copyPage": "复制页面",
   "labels.downloadWorkflow": "下载工作流",
-  "template.tryOnCloud": "在 Comfy Cloud 试用"
+  "template.tryOnCloud": "在 Comfy Cloud 试用",
+  "nav.launchCloudShort": "免费试用",
+  "nav.downloadLocalShort": "桌面版",
+  "cta.tryCloudFree": "免费在 Comfy 云端试用"
 }

--- a/site/src/i18n/locales/zh.json
+++ b/site/src/i18n/locales/zh.json
@@ -44,7 +44,7 @@
   "labels.createdBy": "创建者",
   "labels.lastUpdate": "最后更新",
   "labels.categories": "分类",
-  "cta.tryCloud": "在 Comfy Cloud 试用",
+  "cta.tryCloud": "在 Comfy 云端试用",
   "cta.viewAll": "查看全部",
   "model.aboutEyebrow": "关于此 AI 模型",
   "model.heroEyebrow": "AI 模型",

--- a/site/src/utils/featureFlags.schema.ts
+++ b/site/src/utils/featureFlags.schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const FeaturesResponseSchema = z
   .object({
-    new_free_tier_subscriptions: z.boolean().optional(),
+    featureFlags: z.record(z.string(), z.unknown()).optional(),
     free_tier_credits: z.number().optional(),
     partner_node_conversion_rate: z.number().optional(),
   })

--- a/site/src/utils/featureFlags.ts
+++ b/site/src/utils/featureFlags.ts
@@ -7,7 +7,11 @@ import { FeaturesResponseSchema } from './featureFlags.schema';
 
 import bundledSnapshot from '../data/feature-flags.snapshot.json' with { type: 'json' };
 
-const DEFAULT_BASE_URL = 'https://api.comfy.org';
+// PostHog via the site's own proxy; the decide endpoint evaluates global
+// flags for anonymous callers, which is what a build-time fetch is.
+const DEFAULT_BASE_URL = 'https://t.comfy.org';
+const POSTHOG_PROJECT_KEY =
+  process.env.PUBLIC_POSTHOG_KEY ?? import.meta.env?.PUBLIC_POSTHOG_KEY ?? '';
 const DEFAULT_TIMEOUT_MS = 10_000;
 const RETRY_DELAYS_MS = [1_000, 2_000, 4_000];
 
@@ -78,7 +82,7 @@ async function tryFetchAndParse(options: FetchFeatureFlagsOptions): Promise<Fetc
   const fetchImpl = options.fetchImpl ?? fetch;
   const sleep = options.sleep ?? defaultSleep;
 
-  const url = `${baseUrl.replace(/\/+$/, '')}/features`;
+  const url = `${baseUrl.replace(/\/+$/, '')}/decide/?v=3`;
 
   let lastReason = 'unknown error';
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
@@ -120,8 +124,9 @@ async function callOnce(
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetchImpl(url, {
-      method: 'GET',
-      headers: { Accept: 'application/json' },
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: POSTHOG_PROJECT_KEY, distinct_id: 'site-flag-snapshot' }),
       signal: controller.signal,
     });
     if (res.ok) {
@@ -143,7 +148,9 @@ async function callOnce(
 
 function deriveFlags(features: FeaturesResponse): FeatureFlagsSnapshot['flags'] {
   return {
-    cloudFreeTier: features.new_free_tier_subscriptions ?? false,
+    // The run-quota rollout flag (same source the desktop pill reads); the
+    // legacy new_free_tier_subscriptions stays off post-pivot.
+    cloudFreeTier: features.featureFlags?.['free_tier_workflow_submission_enabled'] === true,
   };
 }
 

--- a/site/src/utils/featureFlags.ts
+++ b/site/src/utils/featureFlags.ts
@@ -7,8 +7,6 @@ import { FeaturesResponseSchema } from './featureFlags.schema';
 
 import bundledSnapshot from '../data/feature-flags.snapshot.json' with { type: 'json' };
 
-// PostHog via the site's own proxy; the decide endpoint evaluates global
-// flags for anonymous callers, which is what a build-time fetch is.
 const DEFAULT_BASE_URL = 'https://t.comfy.org';
 const POSTHOG_PROJECT_KEY =
   process.env.PUBLIC_POSTHOG_KEY ?? import.meta.env?.PUBLIC_POSTHOG_KEY ?? '';
@@ -148,8 +146,6 @@ async function callOnce(
 
 function deriveFlags(features: FeaturesResponse): FeatureFlagsSnapshot['flags'] {
   return {
-    // The run-quota rollout flag (same source the desktop pill reads); the
-    // legacy new_free_tier_subscriptions stays off post-pivot.
     cloudFreeTier: features.featureFlags?.['free_tier_workflow_submission_enabled'] === true,
   };
 }

--- a/site/tests/unit/feature-flags.test.ts
+++ b/site/tests/unit/feature-flags.test.ts
@@ -136,7 +136,8 @@ describe('fetchFeatureFlagsForBuild', () => {
     });
     expect(outcome.status).toBe('stale');
     if (outcome.status !== 'stale') return;
-    expect(outcome.snapshot.flags.cloudFreeTier).toBe(false);
+    // The bundled snapshot's committed value; tracks the live rollout state.
+    expect(outcome.snapshot.flags.cloudFreeTier).toBe(true);
   });
 
   it('memoizes within a single process', async () => {

--- a/site/tests/unit/feature-flags.test.ts
+++ b/site/tests/unit/feature-flags.test.ts
@@ -66,8 +66,10 @@ describe('fetchFeatureFlagsForBuild', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns fresh with cloudFreeTier=true when /features sets the flag', async () => {
-    const fetchImpl = vi.fn(async () => response({ new_free_tier_subscriptions: true }));
+  it('returns fresh with cloudFreeTier=true when the rollout flag is on', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response({ featureFlags: { free_tier_workflow_submission_enabled: true } })
+    );
     const outcome = await fetchFeatureFlagsForBuild({
       baseUrl: BASE_URL,
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -76,8 +78,8 @@ describe('fetchFeatureFlagsForBuild', () => {
     if (outcome.status !== 'fresh') return;
     expect(outcome.snapshot.flags.cloudFreeTier).toBe(true);
     expect(fetchImpl).toHaveBeenCalledWith(
-      `${BASE_URL}/features`,
-      expect.objectContaining({ method: 'GET' })
+      `${BASE_URL}/decide/?v=3`,
+      expect.objectContaining({ method: 'POST' })
     );
   });
 
@@ -138,7 +140,9 @@ describe('fetchFeatureFlagsForBuild', () => {
   });
 
   it('memoizes within a single process', async () => {
-    const fetchImpl = vi.fn(async () => response({ new_free_tier_subscriptions: true }));
+    const fetchImpl = vi.fn(async () =>
+      response({ featureFlags: { free_tier_workflow_submission_enabled: true } })
+    );
     const opts = {
       baseUrl: BASE_URL,
       fetchImpl: fetchImpl as unknown as typeof fetch,

--- a/site/tests/unit/feature-flags.test.ts
+++ b/site/tests/unit/feature-flags.test.ts
@@ -136,7 +136,6 @@ describe('fetchFeatureFlagsForBuild', () => {
     });
     expect(outcome.status).toBe('stale');
     if (outcome.status !== 'stale') return;
-    // The bundled snapshot's committed value; tracks the live rollout state.
     expect(outcome.snapshot.flags.cloudFreeTier).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
Free-tier messaging pass on the workflows hub:

- **Nav CTA**: `LAUNCH CLOUD` → `TRY FREE ON CLOUD` (desktop) / `TRY FREE` (mobile), via explicit full/short labels replacing the last-word split
- **Template detail CTA**: `Try free on Comfy Cloud` — but **only when the workflow lacks the `API` tag**; partner/API workflows bill partner credits and keep the neutral `Try Comfy Cloud` with no free subline
- **Subline**: `✦ Get Free Credits` → `✦ Free runs included` (the free tier is a run quota, not credits)
- en + zh locales updated

## Testing
370 site tests pass; `astro check` clean (0 errors/warnings).