### PR TITLE
ci: add @claude Code agent workflow

### DIFF
--- a/.github/workflows/ci-claude.yml
+++ b/.github/workflows/ci-claude.yml
@@ -1,0 +1,48 @@
+# @claude responder + fixer. Mention @claude in an issue, PR, PR review, or
+# review comment and Claude Code acts on the repo (answers, or pushes a branch
+# and opens a PR). Mirrors Comfy-Org/cloud's ci-claude.yml and
+# ComfyUI_frontend's pr-claude-review.
+#
+# Auth: ANTHROPIC_API_KEY is an org-wide secret. PAT_TOKEN (the same token the
+# i18n / refresh-run-click-usage PR bots already use) authors the agent's git
+# operations, so any PR it opens triggers CI — the default GITHUB_TOKEN would
+# not.
+name: CI - Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1.0.141
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the **Claude Code agent bot** to `workflow_templates`, matching Comfy-Org/cloud's `ci-claude.yml` and ComfyUI_frontend's `pr-claude-review`. Mention `@claude` on an issue, PR, PR review, or review comment and Claude Code acts on the repo — answering, or pushing a branch and opening a PR.

## Why

`workflow_templates` already has automation-PR plumbing (the `i18n-update-hub` and `refresh-run-click-usage` bots, via `PAT_TOKEN`) but no AI agent. This adds the `@claude` responder that can auto-author fix PRs — e.g. the kind of `index.json` thumbnail-path correction that is otherwise a manual PR.

## Auth

- **`ANTHROPIC_API_KEY`** — org-wide secret, no repo secret needed.
- **`github_token: secrets.PAT_TOKEN`** — the same token the existing PR bots use. This is the one deliberate difference from cloud's version: it makes the agent's PRs trigger CI (a PR opened with the default `GITHUB_TOKEN` does not).

## Before it works (admin)

- Confirm the org `ANTHROPIC_API_KEY` visibility includes this repo.
- Optionally install the Claude GitHub App on the repo for the app identity; with `PAT_TOKEN` wired it already operates via that token.

## Review focus

- Runs **only** on explicit `@claude` mentions (no auto-run on every event).
- Mirrors cloud's proven workflow; the only change is the `PAT_TOKEN` wiring for CI-triggering.
