### PR TITLE
[DO-NOT-MERGE] ci(i18n): author hub translation PRs via the bot app, not a personal PAT

### DIFF
--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -27,10 +27,30 @@ jobs:
   update-translations:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived token for the bot GitHub App so the translation PR is
+      # authored by the bot (cloud-code-bot[bot]) rather than a person's PAT.
+      # App IDs aren't secret (vars.APP_ID); the paired PEM is the secret.
+      - name: Generate bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}
+
+      - name: Resolve bot committer identity
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          slug='${{ steps.app-token.outputs.app-slug }}'
+          uid=$(gh api "/users/${slug}[bot]" --jq .id)
+          echo "name=${slug}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${uid}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
       - name: Checkout workflow_templates
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # ComfyUI_frontend's UI locales seed the glossary mirror (term consistency).
       - name: Checkout ComfyUI_frontend locales
@@ -130,12 +150,12 @@ jobs:
       - name: Open or update translation PR
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           STABLE_BRANCH="i18n/hub-translations"
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name '${{ steps.bot.outputs.name }}'
+          git config user.email '${{ steps.bot.outputs.email }}'
           # Stage first — the generated content/ files are new/untracked on the
           # initial run, which `git diff` alone would miss.
           git add site/src/i18n


### PR DESCRIPTION
## Summary

Re-authors the daily hub-translation PRs (`i18n-update-hub.yml`) off a personal PAT (`secrets.PAT_TOKEN`) and onto a **bot GitHub App** token. The PR — and its commits, branch push, and CI runs — are now raised by **`cloud-code-bot[bot]`** instead of a maintainer's account. Behaviour is otherwise unchanged.

## Why

The PR "user" (author + CI actor) is whoever owns the token. A PAT authors as its owner, so these PRs currently come from a person and break if their PAT rotates or they leave. A GitHub App gives a stable, org-owned bot identity that you control — and its token still triggers CI, same as the PAT.

## What changed (`i18n-update-hub.yml`)

- Adds an `actions/create-github-app-token@v2` step (`vars.APP_ID` + `secrets.CLOUD_CODE_BOT_PRIVATE_KEY`) — the same app cloud uses for `cursor-review`.
- Swaps `secrets.PAT_TOKEN` → `steps.app-token.outputs.token` for checkout, `git push --force-with-lease`, and `gh pr create`.
- Sets the commit author to the bot identity (`cloud-code-bot[bot]`) instead of `github-actions[bot]`.

## Before it works (admin — I can't do these)

1. Install the **CLOUD_CODE_BOT** app on `workflow_templates` with `contents: write` + `pull requests: write`.
2. Make `vars.APP_ID` and `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` available to this repo (repo- or org-level).

If you'd rather use a **dedicated app** (e.g. a `comfy-templates-bot`) instead of reusing `CLOUD_CODE_BOT`, it's a one-line swap of the app-id var + private-key secret — say the word.

## Follow-up

`refresh-run-click-usage.yml` uses the same personal PAT and can get the identical treatment; left out of this PR to keep it focused.
