### PR TITLE
ltx2.3 i2v: Connect the input image to PE

### DIFF
--- a/templates/video_ltx2_3_i2v.json
+++ b/templates/video_ltx2_3_i2v.json
@@ -372,7 +372,7 @@
         "state": {
           "lastGroupId": 26,
           "lastNodeId": 329,
-          "lastLinkId": 646,
+          "lastLinkId": 647,
           "lastRerouteId": 0
         },
         "revision": 0,
@@ -1229,7 +1229,8 @@
                 "name": "images",
                 "type": "IMAGE",
                 "links": [
-                  505
+                  505,
+                  647
                 ]
               }
             ],
@@ -3576,7 +3577,7 @@
                 "name": "image",
                 "shape": 7,
                 "type": "IMAGE",
-                "link": null
+                "link": 647
               },
               {
                 "localized_name": "video",
@@ -4642,6 +4643,14 @@
             "target_id": 277,
             "target_slot": 0,
             "type": "INT"
+          },
+          {
+            "id": 647,
+            "origin_id": 286,
+            "origin_slot": 0,
+            "target_id": 325,
+            "target_slot": 1,
+            "type": "IMAGE"
           }
         ],
         "extra": {


### PR DESCRIPTION
This lets the prompt enhancer see the image and develop it and avoid prompting with contradicatory detail.

<img width="2206" height="1017" alt="image" src="https://github.com/user-attachments/assets/7cf214b0-5358-40bb-ae87-33e0ca4b5f55" />

<img width="2129" height="874" alt="image" src="https://github.com/user-attachments/assets/f232ad45-ffa1-4012-8a70-835334e272eb" />
