### PR TITLE
fix: remove dangling Use Image Size node pair from MiniMax H3 i2v template (BE-6793)

### DIFF
--- a/packages/core/src/comfyui_workflow_templates_core/manifest.json
+++ b/packages/core/src/comfyui_workflow_templates_core/manifest.json
@@ -9629,7 +9629,7 @@
       "assets": [
         {
           "filename": "video_minimax_h3_i2v.json",
-          "sha256": "bb71aecdd3c0b62e56eafe03acb14d1cfeabec7072eaed9cbdf473c2aaf73009"
+          "sha256": "47bd252b8ffb495665653f3d42e9fe062c8e35c3babd751bcae3daf15a3ff8d9"
         },
         {
           "filename": "video_minimax_h3_i2v-1.webp",

--- a/templates/video_minimax_h3_i2v.json
+++ b/templates/video_minimax_h3_i2v.json
@@ -16,7 +16,7 @@
         126
       ],
       "flags": {},
-      "order": 8,
+      "order": 6,
       "mode": 0,
       "inputs": [
         {
@@ -129,7 +129,7 @@
         630
       ],
       "flags": {},
-      "order": 6,
+      "order": 5,
       "mode": 0,
       "inputs": [
         {
@@ -274,89 +274,6 @@
       ],
       "color": "#222",
       "bgcolor": "#000"
-    },
-    {
-      "id": 119,
-      "type": "ImageScaleToTotalPixels",
-      "pos": [
-        -1520,
-        5610
-      ],
-      "size": [
-        280,
-        150
-      ],
-      "flags": {},
-      "order": 5,
-      "mode": 0,
-      "showAdvanced": true,
-      "inputs": [
-        {
-          "name": "image",
-          "type": "IMAGE",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [
-            228
-          ]
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "ImageScaleToTotalPixels"
-      },
-      "widgets_values": [
-        "nearest-exact",
-        1,
-        32
-      ]
-    },
-    {
-      "id": 120,
-      "type": "GetImageSize",
-      "pos": [
-        -1490,
-        5810
-      ],
-      "size": [
-        230,
-        80
-      ],
-      "flags": {},
-      "order": 7,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 228
-        }
-      ],
-      "outputs": [
-        {
-          "name": "width",
-          "type": "INT",
-          "links": null
-        },
-        {
-          "name": "height",
-          "type": "INT",
-          "links": null
-        },
-        {
-          "name": "batch_size",
-          "type": "INT",
-          "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "GetImageSize"
-      },
-      "widgets_values": []
     }
   ],
   "links": [
@@ -391,30 +308,9 @@
       105,
       3,
       "INT"
-    ],
-    [
-      228,
-      119,
-      0,
-      120,
-      0,
-      "IMAGE"
     ]
   ],
-  "groups": [
-    {
-      "id": 5,
-      "title": "Use Image Size",
-      "bounding": [
-        -1530,
-        5540,
-        296.484375,
-        354
-      ],
-      "color": "#3f789e",
-      "flags": {}
-    }
-  ],
+  "groups": [],
   "definitions": {
     "subgraphs": [
       {


### PR DESCRIPTION
## ELI-5

The MiniMax H3 image-to-video template shipped with two leftover nodes floating in a corner of the graph — a "Use Image Size" helper whose input wire was never connected and whose outputs went nowhere. ComfyUI refuses to run a graph that has a required input with no wire plugged into it, so the very first thing a new user does with this template (fetch it from the gallery, hit run) failed before generation even started. This PR deletes the two dead nodes, so the template runs as fetched.

## What changed

`templates/video_minimax_h3_i2v.json`:

- Removed node `119` (`ImageScaleToTotalPixels`) — its required `image` input had `"link": null`. This is the node that made the graph invalid.
- Removed node `120` (`GetImageSize`) — its only consumer-side wire was link `228` from node 119, and its three outputs (`width`, `height`, `batch_size`) all had `"links": null`, so nothing in the graph read them.
- Removed link `228` (the only link between the two) and group `5` ("Use Image Size"), which contained nothing else. `"groups"` is now `[]`, matching the three sibling `api_minimax_h3_*` templates.
- Renumbered the surviving nodes' `order` values contiguously (`0..6`), preserving their exact relative order. Deleting nodes at order 5 and 7 left holes; only 4 of 566 templates in the repo ship non-contiguous `order`, so this restores the file to the corpus norm rather than introducing an oddity.

`packages/core/src/comfyui_workflow_templates_core/manifest.json`: regenerated the `sha256` for `video_minimax_h3_i2v.json`.

Nothing else needed updating: `bundles.json` still lists the template (it was not removed), `templates/index*.json` and `index.mcp.json` carry only display metadata (title/description/io), none of which changed, and the packaged template directories under `packages/*/src/*/templates/` are generated by `sync_bundles.py`, not checked in.

## Why prune rather than rewire

The ticket blessed either fix and QA verified both. Pruning is the honest one here: as shipped, the group was not a working affordance a user could benefit from. `GetImageSize`'s outputs fed nothing, and `ImageScaleToTotalPixels`'s output fed only `GetImageSize` — so even with the missing input wired, the group would have computed a size that no downstream node consumed. The template's real resolution path is `ResolutionSelector` (node 115) → the `MiniMaxH3ImageToVideo` subgraph (node 105, slots 2/3), and that path is untouched by this PR. Removing the pair therefore removes dead weight, not a capability. A user who wants image-derived sizing still adds the same two nodes and wires them, exactly as they would have had to before.

## Verification

- `python scripts/validate/validate_templates.py` — **all 7 checks pass** repo-wide (file consistency, duplicate names, thumbnails, model metadata, logos, ComfyUI 0.4 schema).
- `python scripts/validate/validate_manifests.py` — output is **byte-identical to the pre-change baseline on `main`**, i.e. this change introduces zero new manifest errors. (`main` currently carries 39 pre-existing stale-hash errors, all on `index*.json` entries and unrelated to this change — see the judgment call below.)
- `python scripts/sync/sync_bundles.py` then `validate_manifests.py` — **✅ No errors found**, which is what CI does (the `Validate Manifests` workflow runs `sync_bundles.py` before validating). Confirmed the manifest entry the generator produces for `video_minimax_h3_i2v` is **exactly** the one committed here, `sha256 47bd252b…3ff8d9`.
- `pytest packages/core/tests` — 35 passed / 3 failed before this change and 35 passed / 3 failed after, identical failures (`test_resolve_sample_asset`, `test_static_handler_serves_samples`, `test_resolve_additive_and_legacy_logos`) — all pre-existing and caused by the un-synced package asset directories in a fresh checkout. After running `sync_bundles.py` (the CI-equivalent state): 37 passed, 1 failed, same pre-existing `test_static_handler_serves_samples`.
- Structural check on the fixed graph: 7 nodes, 4 links, every link endpoint resolves to a live node, and **no node has a required (non-optional, non-widget) input with a null link**. The two remaining null-link entries on node 105 (`value_1`, `vae_name_1`) are promoted subgraph widget slots, not link slots.

## Judgment calls and unmet criteria — please read

**Two acceptance criteria could not be verified in this environment, and I am not claiming them.** The ticket asks that `comfy validate` pass and `comfy run` execute "on the template fetched fresh from the gallery." I installed `comfy-cli` 1.15.0 and confirmed empirically that `comfy validate --workflow …` requires a live ComfyUI at `/object_info` (it fails `cql_no_graph: cannot reach http://127.0.0.1:8188/object_info`); there is no ComfyUI server, GPU, or model set on this machine. Separately, "as fetched from the gallery" is only testable **after** this fix is published to the CDN/PyPI, which is post-merge by construction. What I can evidence is the structural cause and its removal: the sole defect `comfy validate` would have flagged — a required input with a null link — is gone, and the graph is otherwise unchanged. **A reviewer with a local ComfyUI should run `comfy validate --workflow templates/video_minimax_h3_i2v.json` on this branch before merging, and `comfy run` on the published template after release.**

**I did not regenerate the whole manifest.** `main`'s checked-in manifest already disagrees with the working tree on 39 entries (the `index*.json` locale files). Running the full `sync_bundles.py` would sweep all of them into this PR — an unrelated ~40-entry diff. Since CI regenerates the manifest before validating, and since I confirmed my one-line hash matches the generator's output exactly, I patched only this template's entry and left the pre-existing drift alone. Happy to split that cleanup into its own PR if you want it.

**Nodes 119/120 are not "recycled."** `last_node_id` (120) and `last_link_id` (228) are deliberately left as-is. They are high-water marks, not counts — lowering them risks id collisions on a future edit, and 183 of 566 templates already ship `last_node_id` above their highest live node id.

**Out-of-scope note (free signal, no action taken).** Ticket out-of-scope item 3 asked for a quick check of the sibling MiniMax H3 templates. I ran it: `api_minimax_h3_flf2v`, `api_minimax_h3_r2v`, `api_minimax_h3_t2v`, `video_minimax_h3_r2v` and `video_minimax_h3_t2v` are **clean** — every null-link input on those is an explicitly optional slot (`"shape": 7`), which is normal and valid. Two *non*-MiniMax templates do look like they carry the same defect class and may deserve their own ticket: `api_flux_vto.json` (node 9 `ImageStitch`, required `image1` unlinked) and `image_anima_lllite_image_inpainting.json` (node 696 `ResizeImageMaskNode`, required `input` unlinked). I have not touched either.

**Not applicable: feature flag.** As the ticket states, this is a correctness fix to an already-shipped template, not new user-visible behavior.
