### PR TITLE
Use canonical Hub workflow view

### DIFF
--- a/site/src/lib/hub-api.ts
+++ b/site/src/lib/hub-api.ts
@@ -21,6 +21,7 @@ const HUB_API_BASE = (import.meta.env.PUBLIC_HUB_API_URL || 'https://cloud.comfy
 export type MediaType = 'image' | 'video' | 'audio' | '3d';
 export type ThumbnailVariant = 'compareSlider' | 'hoverDissolve' | 'zoomHover' | 'hoverZoom';
 export type WorkflowStatus = 'pending' | 'approved' | 'rejected' | 'deprecated';
+export type DefaultView = 'workflow' | 'app';
 
 export interface LabelRef {
   name: string;
@@ -39,6 +40,7 @@ export interface HubWorkflowSummary {
   share_id: string;
   name: string;
   status: WorkflowStatus;
+  default_view?: DefaultView;
   description?: string;
   tags: LabelRef[];
   models: LabelRef[];
@@ -48,7 +50,6 @@ export interface HubWorkflowSummary {
   thumbnail_comparison_url?: string;
   publish_time?: string;
   usage?: number;
-  isApp?: boolean;
   profile: HubProfile;
 }
 
@@ -96,6 +97,7 @@ export interface HubWorkflowListResponse {
 export interface HubWorkflowTemplateEntry {
   name: string;
   title: string;
+  defaultView?: DefaultView;
   description?: string;
   tags?: string[];
   models?: string[];
@@ -117,7 +119,6 @@ export interface HubWorkflowTemplateEntry {
     inputs?: Record<string, unknown>[];
     outputs?: Record<string, unknown>[];
   };
-  isApp?: boolean;
   includeOnDistributions?: string[];
   thumbnailUrl?: string;
   thumbnailComparisonUrl?: string;
@@ -335,6 +336,10 @@ export function getCreatorsList(profiles: Map<string, HubProfile>): CreatorEntry
 // Serializers — single source of truth for mapping API data → Vue props
 // ---------------------------------------------------------------------------
 
+function isAppView(defaultView: DefaultView | undefined, legacyName: string): boolean {
+  return defaultView === undefined ? legacyName.endsWith('.app') : defaultView === 'app';
+}
+
 /**
  * Convert a HubWorkflowTemplateEntry (from index endpoint) to the shared
  * SerializedTemplate shape used by Vue grid/search islands.
@@ -362,7 +367,7 @@ export function serializeIndexEntry(
     username,
     creatorDisplayName: profile?.display_name || username || 'ComfyUI',
     creatorAvatarUrl: profile?.avatar_url || '',
-    isApp: entry.isApp ?? entry.name.endsWith('.app'),
+    isApp: isAppView(entry.defaultView, entry.name),
     thumbnailVariant: entry.thumbnailVariant,
     mediaSubtype: entry.mediaSubtype,
   };
@@ -461,7 +466,7 @@ export function toSerializedTemplate(workflow: HubWorkflowSummary): SerializedTe
     username: workflow.profile.username,
     creatorDisplayName: workflow.profile.display_name || workflow.profile.username,
     creatorAvatarUrl: workflow.profile.avatar_url || '',
-    isApp: workflow.isApp ?? workflow.name.endsWith('.app'),
+    isApp: isAppView(workflow.default_view, workflow.name),
   };
 }
 

--- a/site/src/lib/workflow-pages/use-case-resolver.ts
+++ b/site/src/lib/workflow-pages/use-case-resolver.ts
@@ -44,7 +44,7 @@ export function resolveUseCasePageTemplates<T extends FilterableTemplate>(
     const found = catalog.find((template) => template.shareId === pin.shareId);
     if (!found) return [];
     seen.add(pin.shareId);
-    return [pin.isApp ? ({ ...found, isApp: true } as T) : found];
+    return [found];
   });
   if (pinned.length === 0) return matched;
 

--- a/site/src/lib/workflow-pages/use-cases.ts
+++ b/site/src/lib/workflow-pages/use-cases.ts
@@ -25,9 +25,6 @@ export interface SeoPageFilters {
 export interface SeoPagePin {
   /** Catalog share id to force-include at the top of the page's grid. */
   shareId: string;
-  /** Files the pin under the "Comfy Apps" tab when the catalog hasn't flagged
-   *  it. Set only after verifying App Mode in cloud.comfy.org. */
-  isApp?: boolean;
 }
 
 export interface SeoPageDef {
@@ -70,7 +67,7 @@ export const SEO_PAGES: SeoPageDef[] = [
     filters: { tags: ['Portrait'] },
     // Headshot Generator app (untagged on the hub, so pinned not tag-matched).
     appShareId: 'd70243b6fc64',
-    pins: [{ shareId: 'd70243b6fc64', isApp: true }],
+    pins: [{ shareId: 'd70243b6fc64' }],
     // Portrait-tagged non-headshot tools: ref-to-video, miniature stylizer, product placement.
     excludeShareIds: ['5a3df986f9f8', '364e72458b36', '163ff33fc4a7'],
   },
@@ -121,7 +118,7 @@ export const SEO_PAGES: SeoPageDef[] = [
     // Photo to Cartoon Style Caricature app. App Mode verified in cloud.comfy.org.
     appShareId: 'd5ce59e59ff3',
     pins: [
-      { shareId: 'd5ce59e59ff3', isApp: true },
+      { shareId: 'd5ce59e59ff3' },
       { shareId: '1043317e75c9' }, // 1 input, multiple styles from prompt
       { shareId: '452e68e4a484' }, // Seedream 5.0 Lite: Image Edit
       { shareId: '4ab928487496' }, // SYSTMS ACTION: Qwen Image Edit 2511 (toy style)
@@ -148,7 +145,7 @@ export const SEO_PAGES: SeoPageDef[] = [
     // Purz's dedicated Tattoo Generator app, pinned atop the grid.
     // App Mode verified in cloud.comfy.org, so it files under the Comfy Apps tab.
     appShareId: '90d086fef9e3',
-    pins: [{ shareId: '90d086fef9e3', isApp: true }],
+    pins: [{ shareId: '90d086fef9e3' }],
     // Non-line-art ControlNet matches: generic editors, depth/pose demos, and
     // union-control t2i demos whose only tattoo link is a canny option.
     excludeShareIds: [
@@ -186,12 +183,8 @@ export const SEO_PAGES: SeoPageDef[] = [
     // Image app, so the CTA matches the image-side hero (video app stays a grid pin).
     appShareId: 'b3bbbf217b89',
     // Video Upscale (0740bf78b7b6) is untagged on the hub, so only a pin can
-    // surface it. Its isApp stays unset until App Mode is verified in cloud.
-    pins: [
-      { shareId: 'c1959fdc5642' },
-      { shareId: 'b3bbbf217b89', isApp: true },
-      { shareId: '0740bf78b7b6' },
-    ],
+    // surface it. App classification still comes from Cloud's default_view.
+    pins: [{ shareId: 'c1959fdc5642' }, { shareId: 'b3bbbf217b89' }, { shareId: '0740bf78b7b6' }],
     // Upscale-tagged non-upscalers: virtual try-on, ad viz, variations apps, event demo.
     excludeShareIds: [
       '5652fbe7f479',
@@ -248,7 +241,7 @@ export const SEO_PAGES: SeoPageDef[] = [
     appShareId: '201003c6d79c',
     // Free-tier anchors lead: LTX 2.3 (the CTA app's source), then Wan 2.2 14B,
     // then the dedicated Image to Video workflow (usage sorting buries it).
-    // Its pin's isApp stays unset until App Mode is verified in cloud.comfy.org.
+    // App classification still comes from Cloud's default_view.
     pins: [{ shareId: '7cc1d3bd2802' }, { shareId: '8c7511104c80' }, { shareId: '3515c5083027' }],
     // Image-to-Video-tagged non-generators: shot annotation, character-swap
     // (brand-safety pending), ByteDance real-human (KYC-gated), and two
@@ -283,7 +276,7 @@ export const SEO_PAGES: SeoPageDef[] = [
     // Dedicated Restore Old Photos workflow. App Mode verified in cloud.comfy.org.
     appShareId: '69850664cf89',
     pins: [
-      { shareId: '69850664cf89', isApp: true },
+      { shareId: '69850664cf89' },
       { shareId: 'b594a01df1d6' }, // Seedream 5.0 Pro: Image Edit
       { shareId: 'cd929d504424' }, // Topaz: Image Enhance
       { shareId: 'f6e9d07c02fd' }, // Image Relight
@@ -314,7 +307,7 @@ export const SEO_PAGES: SeoPageDef[] = [
     // Cloud-save app, not hub-published — CTA-only, so the hero can't match it yet.
     appShareId: '3ec117b8333d',
     // Hub-published Anime Generator workflow, pinned so usage sorting can't bury
-    // it. Its isApp stays unset until App Mode is verified in cloud.comfy.org.
+    // it. App classification still comes from Cloud's default_view.
     // Anima Base v1 + the Illustration LoRA lack the Anime tag, so they need pins.
     pins: [
       { shareId: '9f0b568bf8a1' }, // Anime Generator

--- a/site/tests/unit/hub-api-status-filter.test.ts
+++ b/site/tests/unit/hub-api-status-filter.test.ts
@@ -93,3 +93,46 @@ describe('listWorkflows status param', () => {
     expect(calledUrl).not.toContain('status');
   });
 });
+
+describe('Hub workflow classification', () => {
+  it('uses the canonical index defaultView instead of the filename', async () => {
+    const { serializeIndexEntry } = await import('../../src/lib/hub-api');
+
+    const app = serializeIndexEntry(
+      { name: 'plain-name', title: 'App', status: 'approved', defaultView: 'app' },
+      new Map()
+    );
+    const workflow = serializeIndexEntry(
+      { name: 'legacy.app', title: 'Workflow', status: 'approved', defaultView: 'workflow' },
+      new Map()
+    );
+
+    expect(app.isApp).toBe(true);
+    expect(workflow.isApp).toBe(false);
+  });
+
+  it('uses the canonical summary default_view instead of the display name', async () => {
+    const { toSerializedTemplate } = await import('../../src/lib/hub-api');
+    const template = toSerializedTemplate({
+      share_id: 'share-1',
+      name: 'not-an-app-name',
+      status: 'approved',
+      default_view: 'app',
+      tags: [],
+      models: [],
+      profile: { username: 'alice' },
+    });
+
+    expect(template.isApp).toBe(true);
+  });
+
+  it('keeps the .app fallback for legacy API responses', async () => {
+    const { serializeIndexEntry } = await import('../../src/lib/hub-api');
+    const template = serializeIndexEntry(
+      { name: 'legacy.app', title: 'Legacy', status: 'approved' },
+      new Map()
+    );
+
+    expect(template.isApp).toBe(true);
+  });
+});

--- a/site/tests/unit/use-case-resolver.test.ts
+++ b/site/tests/unit/use-case-resolver.test.ts
@@ -71,15 +71,12 @@ describe('resolveUseCasePageTemplates', () => {
     expect(out.map((t) => t.shareId)).toEqual(['m']);
   });
 
-  it('applies the isApp override without mutating the catalog entry', () => {
-    const entry = tpl('p', ['b']);
+  it('preserves the catalog classification for pinned entries', () => {
+    const entry = { ...tpl('p', ['b']), isApp: true };
     const catalog = [entry];
-    const out = resolveUseCasePageTemplates(
-      page({ pins: [{ shareId: 'p', isApp: true }] }),
-      catalog
-    );
+    const out = resolveUseCasePageTemplates(page({ pins: [{ shareId: 'p' }] }), catalog);
     expect(out[0].isApp).toBe(true);
-    expect(entry.isApp).toBeUndefined();
+    expect(out[0]).toBe(entry);
   });
 
   it('pins bypass the exclude list', () => {


### PR DESCRIPTION
## What changed

- consume Cloud's canonical `default_view` / `defaultView` fields for Hub workflow classification
- derive the existing presentation-level `isApp` boolean only at serialization boundaries
- retain the `.app` filename check solely as a compatibility fallback for older API responses
- remove curated use-case pin overrides so pinned entries cannot disagree with Cloud
- add regression coverage for enum precedence, legacy fallback, and pinned-entry behavior

## Why

Hub workflows were classified as Apps through filename conventions and hand-maintained overrides. Those paths failed for publishers whose workflow names did not end in `.app`, and could disagree with the workflow's actual saved mode.

This PR makes the Hub's canonical workflow view the source of truth.

## Dependency

Depends on [Comfy-Org/cloud#6350](https://github.com/Comfy-Org/cloud/pull/6350), which adds and repairs the canonical Hub API field.

## Validation

- `pnpm exec vitest run tests/unit/hub-api-status-filter.test.ts tests/unit/use-case-resolver.test.ts` — 27 tests passed
- `git diff --check`