### PR TITLE
fix(tests): point bundle samples at templates that still ship

### DIFF
--- a/packages/core/tests/test_http_routes.py
+++ b/packages/core/tests/test_http_routes.py
@@ -7,22 +7,25 @@ from aiohttp.test_utils import make_mocked_request
 from comfyui_workflow_templates_core import iter_assets
 
 
+# Sampled templates per bundle. These ids must stay in sync with what the bundles
+# actually ship: archiving a template removes its assets, so an id left here after
+# an archive fails this test even though nothing is wrong with the handler.
 BUNDLE_SAMPLES = {
     "media-api": [
         "api_bfl_flux_1_kontext_max_image",
         "api_bfl_flux_1_kontext_multiple_images_input",
     ],
     "media-image": [
-        "01_get_started_text_to_image",
-        "02_qwen_Image_edit_subgraphed",
+        "3d_hunyuan3d-v2.1",
+        "3d_hunyuan3d_image_to_model",
     ],
     "media-other": [
-        "04_hunyuan_3d_2.1_subgraphed",
-        "05_audio_ace_step_1_t2a_song_subgraphed",
+        "3d_moge_panorama_to_mesh",
+        "3d_moge_perspective_to_mesh",
     ],
     "media-video": [
-        "03_video_wan2_2_14B_i2v_subgraphed",
         "hunyuan_video_text_to_video",
+        "api_google_gemini_omni_flash_i2v",
     ],
 }
 


### PR DESCRIPTION
## The failure

`Build & Test` is red on `main` and therefore on every PR branched from it, including the open translation PRs (#1061, #1098):

```
AssertionError: No assets found for template 01_get_started_text_to_image in media-image
packages/core/tests/test_http_routes.py:55
1 failed, 37 passed
```

## Where it comes from

#1088 archived the Getting Started and Reve templates, which moved their files out of `templates/`:

```
R100  templates/01_get_started_text_to_image-1.webp -> archived/01_get_started_text_to_image-1.webp
R100  templates/02_qwen_Image_edit_subgraphed.json -> archived/02_qwen_Image_edit_subgraphed.json
```

CI runs `scripts/sync/sync_bundles.py` before the tests, and that only copies assets for templates still in `templates/`. So the archived templates have no assets in the media packages, while `BUNDLE_SAMPLES` still named them — and the test asserts every sampled template has assets.

Checking all eight sampled ids against what the loader actually yields, **five** were no longer servable:

| bundle | id | servable |
|---|---|---|
| media-api | `api_bfl_flux_1_kontext_max_image` | yes |
| media-api | `api_bfl_flux_1_kontext_multiple_images_input` | yes |
| media-image | `01_get_started_text_to_image` | **no** |
| media-image | `02_qwen_Image_edit_subgraphed` | **no** |
| media-other | `04_hunyuan_3d_2.1_subgraphed` | **no** |
| media-other | `05_audio_ace_step_1_t2a_song_subgraphed` | **no** |
| media-video | `03_video_wan2_2_14B_i2v_subgraphed` | **no** |
| media-video | `hunyuan_video_text_to_video` | yes |

The test only reported the first one because the assertion stops there.

## The fix

Repoint the five stale ids at templates the bundles currently ship, chosen from what `iter_assets()` actually returns. The handler was never broken — the samples were.

## Verification

Reproduced locally with the same steps CI uses (`sync_bundles.py`, then `pytest packages/core/tests`):

- before: `1 failed, 37 passed` — the exact CI error
- after: `38 passed`

## One thing worth a separate look

While tracing this I noticed the committed `packages/core/src/.../manifest.json` is stale against `templates/index.json` (records `9e3ec0bd…`, actual is `a9917f81…`). It is regenerated by the sync step, so it does not affect this fix or the tests, and `validate-manifests` is green — but someone who owns that pipeline may want to confirm it is intentional. Deliberately left out of this PR to keep the diff to one file.
