### PR TITLE
feat(templates): add isApp to index.json, derived from extra.linearMode

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -87,6 +87,7 @@ mediaType
 mediaSubtype
 tutorialUrl
 thumbnailVariant
+isApp
 hoverDissolve
 hoverZoom
 compareSlider

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Lint Python modules
         run: |
           source .venv/bin/activate
-          ruff check scripts/sync/sync_bundles.py scripts/sync/fetch_algolia_usage.py packages/core packages/meta
+          ruff check scripts/sync/sync_bundles.py scripts/sync/fetch_algolia_usage.py scripts/sync/sync_is_app.py scripts/lib/index_format.py packages/core packages/meta
 
       - name: Build packages
         run: |

--- a/.github/workflows/sync-custom-nodes.yml
+++ b/.github/workflows/sync-custom-nodes.yml
@@ -17,6 +17,9 @@ on:
     types: [opened, synchronize]
     paths:
       - 'templates/**.json'
+      - 'scripts/sync/sync_custom_nodes.py'
+      - 'scripts/lib/index_format.py'
+      - '.github/workflows/sync-custom-nodes.yml'
 
 permissions:
   contents: write
@@ -41,6 +44,7 @@ jobs:
           sparse-checkout: |
             templates/*.json
             scripts/sync/sync_custom_nodes.py
+            scripts/lib/index_format.py
             scripts/lib/paths.py
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/validate-is-app.yml
+++ b/.github/workflows/validate-is-app.yml
@@ -1,0 +1,54 @@
+name: Validate isApp
+
+# `isApp` in templates/index.json is derived from each workflow's own
+# extra.linearMode. Nothing recomputes it at read time, so a PR that adds or
+# flips an App Mode workflow without running the sync ships an index that
+# disagrees with the workflows beside it.
+#
+# A gate rather than an auto-commit: this writes to templates/index.json, which
+# sync-custom-nodes.yml and sync-template-index.yml also write, and three jobs
+# pushing to the same file on the same PR race each other. Failing with the
+# command to run keeps one writer.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize]
+    branches: [ main ]
+    paths:
+      - 'templates/**.json'
+      - 'scripts/sync/sync_is_app.py'
+      - 'scripts/lib/index_format.py'
+      - '.github/workflows/validate-is-app.yml'
+
+jobs:
+  validate-is-app:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          templates/*.json
+          scripts/sync/sync_is_app.py
+          scripts/lib/index_format.py
+          scripts/lib/paths.py
+        sparse-checkout-cone-mode: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Check isApp is in sync with extra.linearMode
+      run: |
+        if ! python scripts/sync/sync_is_app.py --templates-dir ./templates --check; then
+          echo ""
+          echo "::error::templates/index.json disagrees with the workflows' extra.linearMode."
+          echo "Run: python scripts/sync/sync_is_app.py"
+          echo "Then commit the updated templates/index.json."
+          exit 1
+        fi
+        echo "✅ isApp is in sync"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - `npm run validate:manifests` — Validate package manifests
 - `npm run validate:comfyui-nodes` — Compare templates to ComfyUI node baseline (local: live `/object_info`)
 - `python scripts/sync/sync_bundles.py` — Same as `npm run sync:bundles`
+- `python scripts/sync/sync_is_app.py` — Write `isApp` into `index.json` from each workflow's `extra.linearMode` (`--dry-run` to report, `--check` for the CI gate)
 - `python scripts/validate/validate_templates.py` — Same as `npm run validate:templates`
 - `python scripts/comfyui_node_compat/check.py --static-scan --clone-comfyui --no-fail` — CI-style static compat scan
 - `python scripts/sync/sync_frozen_inventory.py` — Regenerate frozen bundle template inventory from `bundles.json`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -53,7 +53,7 @@ The `index.json` file is an array of category objects. See `templates/index.sche
 | `size` | number | ❌ | Size of the template in bytes |
 | `vram` | number | ❌ | VRAM requirement in bytes |
 | `openSource` | boolean | ❌ | Whether the template is open source |
-| `isApp` | boolean | ❌ | Opens in App Mode rather than as a node graph. Derived from the workflow's own `extra.linearMode`; regenerate with `python scripts/sync/sync_is_app.py`. Omitted when false. Do not infer this from a `.app` filename, which is wrong in both directions |
+| `isApp` | `true` | ❌ | Opens in App Mode rather than as a node graph. Derived from the workflow's own `extra.linearMode`; regenerate with `python scripts/sync/sync_is_app.py`. Only ever written as `true`: omitted means false, and the schema rejects a literal `false`. Do not infer this from a `.app` filename, which is wrong in both directions |
 | `status` | string | ❌ | Lifecycle status: "active", "archived", "deprecated" |
 | `requiresCustomNodes` | array of strings | ❌ | Custom node package IDs from the Custom Node Registry |
 | `usage` | number | ❌ | Usage count |
@@ -142,9 +142,11 @@ This validates:
 1. Create workflow and thumbnails following naming conventions
 2. Add entry to `index.json` in appropriate category
 3. Add template ID to `bundles.json` (required — CI enforces this)
-4. Run validation script
-5. Bump version in `pyproject.toml`
-6. Submit PR
+4. If the workflow sets `extra.linearMode: true`, run `python scripts/sync/sync_is_app.py`
+   to write `isApp` into `index.json` (CI fails otherwise)
+5. Run validation script
+6. Bump version in `pyproject.toml`
+7. Submit PR
 
 ## Categories
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -53,6 +53,7 @@ The `index.json` file is an array of category objects. See `templates/index.sche
 | `size` | number | ❌ | Size of the template in bytes |
 | `vram` | number | ❌ | VRAM requirement in bytes |
 | `openSource` | boolean | ❌ | Whether the template is open source |
+| `isApp` | boolean | ❌ | Opens in App Mode rather than as a node graph. Derived from the workflow's own `extra.linearMode`; regenerate with `python scripts/sync/sync_is_app.py`. Omitted when false. Do not infer this from a `.app` filename, which is wrong in both directions |
 | `status` | string | ❌ | Lifecycle status: "active", "archived", "deprecated" |
 | `requiresCustomNodes` | array of strings | ❌ | Custom node package IDs from the Custom Node Registry |
 | `usage` | number | ❌ | Usage count |

--- a/packages/core/tests/test_index_format.py
+++ b/packages/core/tests/test_index_format.py
@@ -1,0 +1,73 @@
+"""Tests for scripts/lib/index_format.py.
+
+Two scripts write templates/index.json. If they disagree on formatting, each run
+reformats what the other wrote and the file churns thousands of lines. These pin
+the format, including that it reproduces the committed file exactly.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_lib = REPO_ROOT / "scripts" / "lib"
+if str(_lib) not in sys.path:
+    sys.path.insert(0, str(_lib))
+
+from index_format import MAX_INLINE_ARRAY_CHARS, dumps_index  # noqa: E402
+
+
+def test_short_string_arrays_go_inline_without_a_space():
+    out = dumps_index([{"tags": ["Image to Video", "Video"]}])
+    assert '"tags": ["Image to Video","Video"]' in out
+
+
+def test_empty_and_single_element_arrays():
+    assert '"tags": []' in dumps_index([{"tags": []}])
+    assert '"tags": ["One"]' in dumps_index([{"tags": ["One"]}])
+
+
+def test_arrays_of_objects_stay_expanded():
+    out = dumps_index([{"io": [{"a": 1}]}])
+    assert '"io": [\n' in out
+
+
+def test_mixed_type_arrays_stay_expanded():
+    out = dumps_index([{"mixed": ["a", 1]}])
+    assert '"mixed": [\n' in out
+
+
+def test_a_long_array_stays_expanded():
+    out = dumps_index([{"tags": ["x" * 60, "y" * 60, "z" * 60, "w" * 60]}])
+    assert '"tags": [\n' in out
+
+
+# The length is measured on the inline result, not on the expanded source. A
+# short array nested deeply carries enough indentation to exceed the limit on
+# whitespace alone, and used to be left expanded because of it.
+def test_the_limit_measures_the_result_not_the_indentation():
+    deep = {"a": {"b": {"c": {"d": {"e": {"f": {"g": {"tags": ["One", "Two"]}}}}}}}}
+    expanded = json.dumps(deep, indent=2)
+    source_len = expanded[expanded.index("[") : expanded.index("]")]
+    assert len(source_len) > 20, "fixture should carry real indentation"
+
+    assert '"tags": ["One","Two"]' in dumps_index(deep)
+
+
+def test_an_array_just_over_the_limit_stays_expanded():
+    # Two items whose inline form lands just past the cap.
+    item = "x" * (MAX_INLINE_ARRAY_CHARS // 2)
+    out = dumps_index([{"tags": [item, item]}])
+    assert '"tags": [\n' in out
+
+
+def test_non_ascii_is_not_escaped():
+    assert '"tags": ["图像"]' in dumps_index([{"tags": ["图像"]}])
+
+
+def test_reproduces_the_committed_index_byte_for_byte():
+    """The format is only safe to share if it is already what is on disk."""
+    path = REPO_ROOT / "templates" / "index.json"
+    committed = path.read_text(encoding="utf-8")
+    assert dumps_index(json.loads(committed)) == committed

--- a/packages/core/tests/test_sync_is_app.py
+++ b/packages/core/tests/test_sync_is_app.py
@@ -1,33 +1,35 @@
 """Tests for scripts/sync/sync_is_app.py, the isApp bake into index.json.
 
-The point of interest is that the plan pass and the write pass have to agree on
-what "already correct" means. Canonical is `isApp: true` present for an App and
-the key absent otherwise, so an explicit `isApp: false` and any non-boolean
-value are both stale. When the two passes judged that independently, `--check`
-could report the index clean while the write pass would still have changed it.
+Two properties matter. The plan pass and the write pass must agree on what
+"already correct" means, or `--check` passes on a file a real run still rewrites.
+And a workflow that cannot be read must never be treated as "not an App", since
+the write pass deletes the key for that answer and would erase a correct flag.
 """
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
+_lib = REPO_ROOT / "scripts" / "lib"
+if str(_lib) not in sys.path:
+    sys.path.insert(0, str(_lib))
+
 _spec = importlib.util.spec_from_file_location(
     "sync_is_app", REPO_ROOT / "scripts" / "sync" / "sync_is_app.py"
 )
 sync_is_app = importlib.util.module_from_spec(_spec)
+# Registered before exec so @dataclass can resolve the module it is defined in.
+sys.modules[_spec.name] = sync_is_app
 _spec.loader.exec_module(sync_is_app)
 
 
 def _write_workflow(templates_dir: Path, name: str, linear_mode) -> None:
-    """Write a minimal workflow file, with extra.linearMode set to `linear_mode`.
-
-    Passing `None` writes a workflow with no `linearMode` key at all, which is
-    the normal node-graph case.
-    """
+    """Write a workflow with extra.linearMode set; None omits linearMode."""
     extra = {} if linear_mode is None else {"linearMode": linear_mode}
     (templates_dir / f"{name}.json").write_text(
         json.dumps({"nodes": [], "extra": extra}), encoding="utf-8"
@@ -38,6 +40,12 @@ def _categories(*templates):
     return [{"category": "Basics", "templates": list(templates)}]
 
 
+def _write_index(templates_dir: Path, *templates) -> Path:
+    path = templates_dir / "index.json"
+    path.write_text(json.dumps(_categories(*templates)), encoding="utf-8")
+    return path
+
+
 # ── workflow_is_app ──────────────────────────────────────────────────────────
 
 
@@ -45,18 +53,65 @@ def _categories(*templates):
     "linear_mode,expected",
     [(True, True), (False, False), (None, False), ("true", False), (1, False)],
 )
-def test_workflow_is_app_only_accepts_a_true_boolean(tmp_path, linear_mode, expected):
+def test_only_a_true_boolean_is_an_app(tmp_path, linear_mode, expected):
     _write_workflow(tmp_path, "demo", linear_mode)
     assert sync_is_app.workflow_is_app(tmp_path, "demo") is expected
 
 
-def test_workflow_is_app_tolerates_a_missing_file(tmp_path):
-    assert sync_is_app.workflow_is_app(tmp_path, "absent") is False
+def test_absent_extra_block_is_a_node_graph(tmp_path):
+    (tmp_path / "demo.json").write_text('{"nodes":[]}', encoding="utf-8")
+    assert sync_is_app.workflow_is_app(tmp_path, "demo") is False
 
 
-def test_workflow_is_app_tolerates_unreadable_json(tmp_path):
-    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
-    assert sync_is_app.workflow_is_app(tmp_path, "broken") is False
+# ── unreadable workflows are not answers ─────────────────────────────────────
+# Each of these used to return False, which the write pass turns into a deletion.
+
+
+def test_missing_file_is_unreadable(tmp_path):
+    with pytest.raises(sync_is_app.WorkflowUnreadable):
+        sync_is_app.workflow_is_app(tmp_path, "absent")
+
+
+def test_malformed_json_is_unreadable(tmp_path):
+    (tmp_path / "demo.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(sync_is_app.WorkflowUnreadable):
+        sync_is_app.workflow_is_app(tmp_path, "demo")
+
+
+def test_non_object_top_level_is_unreadable(tmp_path):
+    (tmp_path / "demo.json").write_text("[1,2,3]", encoding="utf-8")
+    with pytest.raises(sync_is_app.WorkflowUnreadable):
+        sync_is_app.workflow_is_app(tmp_path, "demo")
+
+
+def test_non_object_extra_is_unreadable(tmp_path):
+    (tmp_path / "demo.json").write_text('{"extra":"nope"}', encoding="utf-8")
+    with pytest.raises(sync_is_app.WorkflowUnreadable):
+        sync_is_app.workflow_is_app(tmp_path, "demo")
+
+
+def test_unreadable_permissions_are_reported(tmp_path):
+    path = tmp_path / "demo.json"
+    path.write_text('{"extra":{"linearMode":true}}', encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        with pytest.raises(sync_is_app.WorkflowUnreadable):
+            sync_is_app.workflow_is_app(tmp_path, "demo")
+    finally:
+        path.chmod(0o644)
+
+
+# The regression this guards: a read failure must not delete a correct flag.
+def test_an_unreadable_workflow_never_erases_a_stored_true(tmp_path):
+    entry = {"name": "demo", "isApp": True}
+    plan = sync_is_app.plan_changes(tmp_path, _categories(entry))
+
+    assert plan.changes == []
+    assert plan.updates == []
+    assert len(plan.unreadable) == 1
+
+    assert sync_is_app.apply_changes(plan) == 0
+    assert entry["isApp"] is True
 
 
 # ── entry_is_canonical ───────────────────────────────────────────────────────
@@ -65,16 +120,16 @@ def test_workflow_is_app_tolerates_unreadable_json(tmp_path):
 @pytest.mark.parametrize(
     "stored,desired,canonical",
     [
-        ({}, False, True),  # absent + not an App: already correct
-        ({}, True, False),  # absent + App: needs writing
-        ({"isApp": True}, True, True),  # present true + App: already correct
-        ({"isApp": True}, False, False),  # present true + not an App: needs deleting
+        ({}, False, True),
+        ({}, True, False),
+        ({"isApp": True}, True, True),
+        ({"isApp": True}, False, False),
         ({"isApp": False}, False, False),  # explicit false is never canonical
         ({"isApp": False}, True, False),
         ({"isApp": "yes"}, True, False),  # truthy non-boolean is never canonical
         ({"isApp": "yes"}, False, False),
         ({"isApp": 1}, True, False),
-        ({"isApp": None}, False, False),  # an explicit null is present, so not absent
+        ({"isApp": None}, False, False),  # an explicit null is present, not absent
         ({"isApp": None}, True, False),
     ],
 )
@@ -82,105 +137,101 @@ def test_entry_is_canonical(stored, desired, canonical):
     assert sync_is_app.entry_is_canonical(dict(stored), desired) is canonical
 
 
-# ── plan_changes and apply_changes agree ─────────────────────────────────────
+# ── plan and write agree ─────────────────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
     "stored,linear_mode",
     [
-        ({"isApp": False}, None),  # the case that used to report clean
-        ({"isApp": "yes"}, True),  # the case whose write used to be skipped
+        ({"isApp": False}, None),  # used to report clean
+        ({"isApp": "yes"}, True),  # used to skip the write
         ({"isApp": 1}, True),
+        ({"isApp": None}, True),
         ({}, True),
         ({"isApp": True}, None),
     ],
 )
 def test_a_stale_entry_is_planned_and_written(tmp_path, stored, linear_mode):
-    """Whatever the plan reports as a change, the write pass must also count."""
     _write_workflow(tmp_path, "demo", linear_mode)
-    categories = _categories({"name": "demo", **stored})
+    entry = {"name": "demo", **stored}
+    plan = sync_is_app.plan_changes(tmp_path, _categories(entry))
+    assert len(plan.changes) == 1
+    assert sync_is_app.apply_changes(plan) == 1
 
-    changes, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
-    assert len(changes) == 1
-
-    changed = sync_is_app.apply_changes(categories, desired_by_entry)
-    assert changed == 1
-
-    # And the result is canonical, so a second run is a no-op.
-    again, desired_again = sync_is_app.plan_changes(tmp_path, categories)
-    assert again == []
-    assert sync_is_app.apply_changes(categories, desired_again) == 0
+    again = sync_is_app.plan_changes(tmp_path, _categories(entry))
+    assert again.changes == []
+    assert sync_is_app.apply_changes(again) == 0
 
 
 @pytest.mark.parametrize("stored,linear_mode", [({}, None), ({}, False), ({"isApp": True}, True)])
 def test_a_canonical_entry_is_left_alone(tmp_path, stored, linear_mode):
     _write_workflow(tmp_path, "demo", linear_mode)
-    categories = _categories({"name": "demo", **stored})
+    entry = {"name": "demo", **stored}
+    plan = sync_is_app.plan_changes(tmp_path, _categories(entry))
+    assert plan.changes == []
+    assert sync_is_app.apply_changes(plan) == 0
+    assert entry == {"name": "demo", **stored}
 
-    changes, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
-    assert changes == []
-    assert sync_is_app.apply_changes(categories, desired_by_entry) == 0
-    assert categories[0]["templates"][0] == {"name": "demo", **stored}
 
-
-def test_apply_changes_normalises_a_truthy_non_boolean(tmp_path):
-    """`isApp: "yes"` on an App becomes a real boolean rather than being kept."""
+def test_apply_normalises_a_truthy_non_boolean(tmp_path):
     _write_workflow(tmp_path, "demo", True)
-    categories = _categories({"name": "demo", "isApp": "yes"})
-
-    _, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
-    assert sync_is_app.apply_changes(categories, desired_by_entry) == 1
-    assert categories[0]["templates"][0]["isApp"] is True
+    entry = {"name": "demo", "isApp": "yes"}
+    sync_is_app.apply_changes(sync_is_app.plan_changes(tmp_path, _categories(entry)))
+    assert entry["isApp"] is True
 
 
-def test_apply_changes_drops_an_explicit_false(tmp_path):
+def test_apply_drops_an_explicit_false(tmp_path):
     _write_workflow(tmp_path, "demo", None)
-    categories = _categories({"name": "demo", "isApp": False})
-
-    _, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
-    assert sync_is_app.apply_changes(categories, desired_by_entry) == 1
-    assert "isApp" not in categories[0]["templates"][0]
+    entry = {"name": "demo", "isApp": False}
+    sync_is_app.apply_changes(sync_is_app.plan_changes(tmp_path, _categories(entry)))
+    assert "isApp" not in entry
 
 
 def test_entries_without_a_name_are_skipped(tmp_path):
-    categories = _categories({"title": "no name here"})
-    changes, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
-    assert changes == []
-    assert desired_by_entry == {}
+    plan = sync_is_app.plan_changes(tmp_path, _categories({"title": "no name"}))
+    assert plan.changes == [] and plan.updates == [] and plan.unreadable == []
 
 
-# ── the --check CLI contract ─────────────────────────────────────────────────
+# ── the CLI contract ─────────────────────────────────────────────────────────
 
 
-def _run_check(monkeypatch, templates_dir: Path) -> int:
+def _run(monkeypatch, templates_dir: Path, *flags: str) -> int:
     monkeypatch.setattr(
-        "sys.argv",
-        ["sync_is_app.py", "--templates-dir", str(templates_dir), "--check"],
+        "sys.argv", ["sync_is_app.py", "--templates-dir", str(templates_dir), *flags]
     )
     return sync_is_app.main()
 
 
 def test_check_fails_on_an_explicit_false(tmp_path, monkeypatch):
-    """The regression: this combination used to exit 0 while still being stale."""
     _write_workflow(tmp_path, "demo", None)
-    (tmp_path / "index.json").write_text(
-        json.dumps(_categories({"name": "demo", "isApp": False})), encoding="utf-8"
-    )
-    assert _run_check(monkeypatch, tmp_path) == 1
+    _write_index(tmp_path, {"name": "demo", "isApp": False})
+    assert _run(monkeypatch, tmp_path, "--check") == 1
 
 
 def test_check_passes_on_a_canonical_index(tmp_path, monkeypatch):
     _write_workflow(tmp_path, "graph", None)
     _write_workflow(tmp_path, "app", True)
-    (tmp_path / "index.json").write_text(
-        json.dumps(_categories({"name": "graph"}, {"name": "app", "isApp": True})),
-        encoding="utf-8",
-    )
-    assert _run_check(monkeypatch, tmp_path) == 0
+    _write_index(tmp_path, {"name": "graph"}, {"name": "app", "isApp": True})
+    assert _run(monkeypatch, tmp_path, "--check") == 0
+
+
+# An index that is canonical as far as it goes, but where a workflow could not be
+# read, must not pass: nothing proved that entry is right.
+def test_check_fails_when_a_workflow_is_unreadable(tmp_path, monkeypatch, capsys):
+    _write_workflow(tmp_path, "app", True)
+    _write_index(tmp_path, {"name": "app", "isApp": True}, {"name": "ghost"})
+    assert _run(monkeypatch, tmp_path, "--check") == 1
+    assert "ghost" in capsys.readouterr().err
 
 
 def test_check_reports_a_missing_index(tmp_path, monkeypatch):
-    assert _run_check(monkeypatch, tmp_path) == 1
+    assert _run(monkeypatch, tmp_path, "--check") == 1
+
+
+def test_a_malformed_index_is_an_error_not_a_traceback(tmp_path, monkeypatch, capsys):
+    (tmp_path / "index.json").write_text("{not json", encoding="utf-8")
+    assert _run(monkeypatch, tmp_path, "--check") == 1
+    assert "could not read" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(
@@ -193,14 +244,55 @@ def test_check_reports_a_missing_index(tmp_path, monkeypatch):
     ],
 )
 def test_check_reports_the_stored_value_as_written(tmp_path, monkeypatch, capsys, stored, reported):
-    """An explicit null must not be reported as an absent key.
-
-    Both read back as None through `.get`, so the report distinguishes them with
-    a sentinel. Getting this wrong tells someone reading a dry run that a key
-    they can see in the file is not there.
-    """
+    """An explicit null must not be reported as an absent key."""
     _write_workflow(tmp_path, "demo", True)
-    (tmp_path / "index.json").write_text(json.dumps(_categories(stored)), encoding="utf-8")
-
-    assert _run_check(monkeypatch, tmp_path) == 1
+    _write_index(tmp_path, stored)
+    assert _run(monkeypatch, tmp_path, "--check") == 1
     assert f"demo: isApp {reported} -> True" in capsys.readouterr().out
+
+
+# ── --dry-run ────────────────────────────────────────────────────────────────
+
+
+def test_dry_run_writes_nothing_and_exits_zero(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, "demo", True)
+    index = _write_index(tmp_path, {"name": "demo"})
+    before = index.read_text(encoding="utf-8")
+
+    assert _run(monkeypatch, tmp_path, "--dry-run") == 0
+    assert index.read_text(encoding="utf-8") == before
+
+
+def test_dry_run_reports_the_same_entries_a_write_would_change(tmp_path, monkeypatch, capsys):
+    _write_workflow(tmp_path, "demo", True)
+    _write_index(tmp_path, {"name": "demo"})
+
+    _run(monkeypatch, tmp_path, "--dry-run")
+    dry = capsys.readouterr().out
+
+    _run(monkeypatch, tmp_path)
+    assert "demo: isApp absent -> True" in dry
+    assert json.loads((tmp_path / "index.json").read_text())[0]["templates"][0]["isApp"] is True
+
+
+# ── the write path ───────────────────────────────────────────────────────────
+
+
+def test_write_leaves_an_up_to_date_index_untouched(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, "app", True)
+    index = _write_index(tmp_path, {"name": "app", "isApp": True})
+    before = index.read_text(encoding="utf-8")
+
+    assert _run(monkeypatch, tmp_path) == 0
+    assert index.read_text(encoding="utf-8") == before
+
+
+def test_write_exits_non_zero_when_something_was_unreadable(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, "app", True)
+    _write_index(tmp_path, {"name": "app"}, {"name": "ghost"})
+
+    assert _run(monkeypatch, tmp_path) == 1
+    entries = json.loads((tmp_path / "index.json").read_text())[0]["templates"]
+    # The readable entry is still corrected; the unreadable one is left alone.
+    assert entries[0]["isApp"] is True
+    assert "isApp" not in entries[1]

--- a/packages/core/tests/test_sync_is_app.py
+++ b/packages/core/tests/test_sync_is_app.py
@@ -74,6 +74,8 @@ def test_workflow_is_app_tolerates_unreadable_json(tmp_path):
         ({"isApp": "yes"}, True, False),  # truthy non-boolean is never canonical
         ({"isApp": "yes"}, False, False),
         ({"isApp": 1}, True, False),
+        ({"isApp": None}, False, False),  # an explicit null is present, so not absent
+        ({"isApp": None}, True, False),
     ],
 )
 def test_entry_is_canonical(stored, desired, canonical):
@@ -179,3 +181,26 @@ def test_check_passes_on_a_canonical_index(tmp_path, monkeypatch):
 
 def test_check_reports_a_missing_index(tmp_path, monkeypatch):
     assert _run_check(monkeypatch, tmp_path) == 1
+
+
+@pytest.mark.parametrize(
+    "stored,reported",
+    [
+        ({"name": "demo"}, "absent"),
+        ({"name": "demo", "isApp": None}, "null"),
+        ({"name": "demo", "isApp": False}, "false"),
+        ({"name": "demo", "isApp": "yes"}, '"yes"'),
+    ],
+)
+def test_check_reports_the_stored_value_as_written(tmp_path, monkeypatch, capsys, stored, reported):
+    """An explicit null must not be reported as an absent key.
+
+    Both read back as None through `.get`, so the report distinguishes them with
+    a sentinel. Getting this wrong tells someone reading a dry run that a key
+    they can see in the file is not there.
+    """
+    _write_workflow(tmp_path, "demo", True)
+    (tmp_path / "index.json").write_text(json.dumps(_categories(stored)), encoding="utf-8")
+
+    assert _run_check(monkeypatch, tmp_path) == 1
+    assert f"demo: isApp {reported} -> True" in capsys.readouterr().out

--- a/packages/core/tests/test_sync_is_app.py
+++ b/packages/core/tests/test_sync_is_app.py
@@ -1,0 +1,181 @@
+"""Tests for scripts/sync/sync_is_app.py, the isApp bake into index.json.
+
+The point of interest is that the plan pass and the write pass have to agree on
+what "already correct" means. Canonical is `isApp: true` present for an App and
+the key absent otherwise, so an explicit `isApp: false` and any non-boolean
+value are both stale. When the two passes judged that independently, `--check`
+could report the index clean while the write pass would still have changed it.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_spec = importlib.util.spec_from_file_location(
+    "sync_is_app", REPO_ROOT / "scripts" / "sync" / "sync_is_app.py"
+)
+sync_is_app = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sync_is_app)
+
+
+def _write_workflow(templates_dir: Path, name: str, linear_mode) -> None:
+    """Write a minimal workflow file, with extra.linearMode set to `linear_mode`.
+
+    Passing `None` writes a workflow with no `linearMode` key at all, which is
+    the normal node-graph case.
+    """
+    extra = {} if linear_mode is None else {"linearMode": linear_mode}
+    (templates_dir / f"{name}.json").write_text(
+        json.dumps({"nodes": [], "extra": extra}), encoding="utf-8"
+    )
+
+
+def _categories(*templates):
+    return [{"category": "Basics", "templates": list(templates)}]
+
+
+# ── workflow_is_app ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "linear_mode,expected",
+    [(True, True), (False, False), (None, False), ("true", False), (1, False)],
+)
+def test_workflow_is_app_only_accepts_a_true_boolean(tmp_path, linear_mode, expected):
+    _write_workflow(tmp_path, "demo", linear_mode)
+    assert sync_is_app.workflow_is_app(tmp_path, "demo") is expected
+
+
+def test_workflow_is_app_tolerates_a_missing_file(tmp_path):
+    assert sync_is_app.workflow_is_app(tmp_path, "absent") is False
+
+
+def test_workflow_is_app_tolerates_unreadable_json(tmp_path):
+    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+    assert sync_is_app.workflow_is_app(tmp_path, "broken") is False
+
+
+# ── entry_is_canonical ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stored,desired,canonical",
+    [
+        ({}, False, True),  # absent + not an App: already correct
+        ({}, True, False),  # absent + App: needs writing
+        ({"isApp": True}, True, True),  # present true + App: already correct
+        ({"isApp": True}, False, False),  # present true + not an App: needs deleting
+        ({"isApp": False}, False, False),  # explicit false is never canonical
+        ({"isApp": False}, True, False),
+        ({"isApp": "yes"}, True, False),  # truthy non-boolean is never canonical
+        ({"isApp": "yes"}, False, False),
+        ({"isApp": 1}, True, False),
+    ],
+)
+def test_entry_is_canonical(stored, desired, canonical):
+    assert sync_is_app.entry_is_canonical(dict(stored), desired) is canonical
+
+
+# ── plan_changes and apply_changes agree ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stored,linear_mode",
+    [
+        ({"isApp": False}, None),  # the case that used to report clean
+        ({"isApp": "yes"}, True),  # the case whose write used to be skipped
+        ({"isApp": 1}, True),
+        ({}, True),
+        ({"isApp": True}, None),
+    ],
+)
+def test_a_stale_entry_is_planned_and_written(tmp_path, stored, linear_mode):
+    """Whatever the plan reports as a change, the write pass must also count."""
+    _write_workflow(tmp_path, "demo", linear_mode)
+    categories = _categories({"name": "demo", **stored})
+
+    changes, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
+    assert len(changes) == 1
+
+    changed = sync_is_app.apply_changes(categories, desired_by_entry)
+    assert changed == 1
+
+    # And the result is canonical, so a second run is a no-op.
+    again, desired_again = sync_is_app.plan_changes(tmp_path, categories)
+    assert again == []
+    assert sync_is_app.apply_changes(categories, desired_again) == 0
+
+
+@pytest.mark.parametrize("stored,linear_mode", [({}, None), ({}, False), ({"isApp": True}, True)])
+def test_a_canonical_entry_is_left_alone(tmp_path, stored, linear_mode):
+    _write_workflow(tmp_path, "demo", linear_mode)
+    categories = _categories({"name": "demo", **stored})
+
+    changes, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
+    assert changes == []
+    assert sync_is_app.apply_changes(categories, desired_by_entry) == 0
+    assert categories[0]["templates"][0] == {"name": "demo", **stored}
+
+
+def test_apply_changes_normalises_a_truthy_non_boolean(tmp_path):
+    """`isApp: "yes"` on an App becomes a real boolean rather than being kept."""
+    _write_workflow(tmp_path, "demo", True)
+    categories = _categories({"name": "demo", "isApp": "yes"})
+
+    _, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
+    assert sync_is_app.apply_changes(categories, desired_by_entry) == 1
+    assert categories[0]["templates"][0]["isApp"] is True
+
+
+def test_apply_changes_drops_an_explicit_false(tmp_path):
+    _write_workflow(tmp_path, "demo", None)
+    categories = _categories({"name": "demo", "isApp": False})
+
+    _, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
+    assert sync_is_app.apply_changes(categories, desired_by_entry) == 1
+    assert "isApp" not in categories[0]["templates"][0]
+
+
+def test_entries_without_a_name_are_skipped(tmp_path):
+    categories = _categories({"title": "no name here"})
+    changes, desired_by_entry = sync_is_app.plan_changes(tmp_path, categories)
+    assert changes == []
+    assert desired_by_entry == {}
+
+
+# ── the --check CLI contract ─────────────────────────────────────────────────
+
+
+def _run_check(monkeypatch, templates_dir: Path) -> int:
+    monkeypatch.setattr(
+        "sys.argv",
+        ["sync_is_app.py", "--templates-dir", str(templates_dir), "--check"],
+    )
+    return sync_is_app.main()
+
+
+def test_check_fails_on_an_explicit_false(tmp_path, monkeypatch):
+    """The regression: this combination used to exit 0 while still being stale."""
+    _write_workflow(tmp_path, "demo", None)
+    (tmp_path / "index.json").write_text(
+        json.dumps(_categories({"name": "demo", "isApp": False})), encoding="utf-8"
+    )
+    assert _run_check(monkeypatch, tmp_path) == 1
+
+
+def test_check_passes_on_a_canonical_index(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, "graph", None)
+    _write_workflow(tmp_path, "app", True)
+    (tmp_path / "index.json").write_text(
+        json.dumps(_categories({"name": "graph"}, {"name": "app", "isApp": True})),
+        encoding="utf-8",
+    )
+    assert _run_check(monkeypatch, tmp_path) == 0
+
+
+def test_check_reports_a_missing_index(tmp_path, monkeypatch):
+    assert _run_check(monkeypatch, tmp_path) == 1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ Python maintenance scripts for ComfyUI workflow templates (packages, CI, i18n).
 | Sync bundles only | `python scripts/sync/sync_bundles.py` |
 | Regenerate frozen bundle inventory | `python scripts/sync/sync_frozen_inventory.py` |
 | Sync blueprints | `python scripts/sync/sync_blueprints.py` |
+| Sync App Mode flag | `python scripts/sync/sync_is_app.py` (`--dry-run`, `--check`) |
 | Validate templates | `python scripts/validate/validate_templates.py` |
 | Validate manifests | `python scripts/validate/validate_manifests.py` |
 | ComfyUI node compatibility | `npm run validate:comfyui-nodes` |
@@ -65,6 +66,7 @@ Also runs workflow I/O extraction via `generate_workflow_io.py` before locale sy
 | `report-comfyui-node-compat.yml` | `comfyui_node_compat/check.py` (static scan; PR comment only) |
 | `check_input_assets.yml`, `generate-upload-json.yml` | `validate/check_input_assets.py` |
 | `sync-custom-nodes.yml` | `sync/sync_custom_nodes.py` |
+| `validate-is-app.yml` | `sync/sync_is_app.py --check` |
 | `version-check.yml`, `publish.yml` | `ci/ci_version_manager.py`, `ci/check_frozen_policy.py`, `sync/sync_bundles.py`, `sync/sync_frozen_inventory.py`, `ci/*` |
 | `build-test.yml` | `sync/sync_bundles.py` |
 

--- a/scripts/lib/index_format.py
+++ b/scripts/lib/index_format.py
@@ -1,0 +1,50 @@
+"""Serialise templates/index.json the way it is committed.
+
+`json.dump(indent=2)` puts every array element on its own line, which rewrites
+the whole file and buries a one-field edit in thousands of diff lines. This keeps
+short string arrays on one line, so a small change stays a small diff.
+
+Arrays join with a bare comma, matching the committed `templates/index.json`
+(`["Image to Video","Video"]`). Every writer of that file has to agree on this,
+or two sync scripts reformat it in opposite directions on alternate runs. This is
+separate from `json_format.dumps_compact_arrays`, which joins with `", "` and is
+what the MCP pipeline writes its own files with.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+# Arrays longer than this stay expanded: a single very long line is harder to
+# read in a diff than the multi-line form it replaces.
+MAX_INLINE_ARRAY_CHARS = 200
+
+# Matches an array that json.dumps rendered across multiple lines. Already-inline
+# arrays have no newline after `[` and are left alone.
+_MULTILINE_ARRAY = re.compile(r"\[\s*\n\s*([^[\]]*?)\s*\n\s*\]", re.DOTALL)
+
+
+def _compact_array(match: re.Match[str]) -> str:
+    content = match.group(1)
+    try:
+        items = json.loads(f"[{content}]")
+    except json.JSONDecodeError:
+        return match.group(0)
+
+    if not all(isinstance(item, str) for item in items):
+        return match.group(0)
+
+    inline = f"[{','.join(json.dumps(item, ensure_ascii=False) for item in items)}]"
+    # Measured on the result, not on the expanded source: the source carries the
+    # indentation this is removing, so a short array nested deeply could exceed
+    # the limit on whitespace alone and never collapse.
+    if len(inline) > MAX_INLINE_ARRAY_CHARS:
+        return match.group(0)
+    return inline
+
+
+def dumps_index(data: Any, *, indent: int = 2) -> str:
+    """Render index data with short string arrays inline."""
+    return _MULTILINE_ARRAY.sub(_compact_array, json.dumps(data, ensure_ascii=False, indent=indent))

--- a/scripts/sync/sync_custom_nodes.py
+++ b/scripts/sync/sync_custom_nodes.py
@@ -27,6 +27,7 @@ _lib_dir = Path(__file__).resolve().parent.parent / "lib"
 if str(_lib_dir) not in sys.path:
     sys.path.insert(0, str(_lib_dir))
 
+from index_format import dumps_index  # noqa: E402
 from paths import WHITELIST_FILE  # noqa: E402
 
 
@@ -187,26 +188,11 @@ class CustomNodesSyncer:
         index_file = self.templates_dir / self.language_files[lang]
         
         try:
-            # Use the same formatting as sync_i18n.py
-            json_str = json.dumps(data, ensure_ascii=False, indent=2)
-            
-            # Compact arrays (like tags, models, requiresCustomNodes) to single line
-            def compact_array(match):
-                content = match.group(1)
-                # Only compact if array contains only strings and is not too long
-                try:
-                    array_content = json.loads(f"[{content}]")
-                    if all(isinstance(item, str) for item in array_content) and len(content) < 200:
-                        return f"[{', '.join(json.dumps(item, ensure_ascii=False) for item in array_content)}]"
-                except:
-                    pass
-                return match.group(0)
-            
-            # Compact arrays that span multiple lines
-            json_str = re.sub(r'\[\s*\n\s*([^[\]]*?)\s*\n\s*\]', compact_array, json_str, flags=re.DOTALL)
-            
+            # Shared with sync_is_app.py: this joined arrays with ", " while the
+            # committed index files use ",", so whichever script wrote last
+            # reformatted every array the other had written.
             with open(index_file, 'w', encoding='utf-8') as f:
-                f.write(json_str)
+                f.write(dumps_index(data))
             
             self.logger.info(f"Saved {self.language_files[lang]}")
         except Exception as e:

--- a/scripts/sync/sync_data.py
+++ b/scripts/sync/sync_data.py
@@ -113,7 +113,8 @@ class TemplateSyncer:
             "searchRank",
             "includeOnDistributions",
             "logos",
-            "io"
+            "io",
+            "isApp"
         }
         self.language_specific_fields = {"title", "description"}
         self.special_handling_fields = {"tags"}

--- a/scripts/sync/sync_is_app.py
+++ b/scripts/sync/sync_is_app.py
@@ -66,32 +66,38 @@ def workflow_is_app(templates_dir: Path, name: str) -> bool:
     return extra.get("linearMode") is True
 
 
-def collect_changes(
+def plan_changes(
     templates_dir: Path, categories: List[Dict[str, Any]]
-) -> List[Tuple[str, bool, bool]]:
-    """Return (name, current, desired) for every entry whose isApp is wrong."""
+) -> Tuple[List[Tuple[str, bool, bool]], Dict[int, bool]]:
+    """Read every workflow once and return the diff plus the desired values.
+
+    The desired value is keyed by `id()` of the template dict so the write pass
+    can reuse it. Reading the files twice (once to report, once to write) parsed
+    all 574 workflows twice on every run.
+    """
     changes: List[Tuple[str, bool, bool]] = []
+    desired_by_entry: Dict[int, bool] = {}
     for category in categories:
         for template in category.get("templates", []):
             name = template.get("name")
             if not name:
                 continue
             desired = workflow_is_app(templates_dir, name)
+            desired_by_entry[id(template)] = desired
             current = bool(template.get("isApp", False))
             if current != desired:
                 changes.append((name, current, desired))
-    return changes
+    return changes, desired_by_entry
 
 
-def apply_changes(categories: List[Dict[str, Any]], templates_dir: Path) -> int:
-    """Write isApp onto every entry. Returns the number of entries changed."""
+def apply_changes(categories: List[Dict[str, Any]], desired_by_entry: Dict[int, bool]) -> int:
+    """Write isApp onto every entry from the already-computed plan."""
     changed = 0
     for category in categories:
         for template in category.get("templates", []):
-            name = template.get("name")
-            if not name:
+            desired = desired_by_entry.get(id(template))
+            if desired is None:
                 continue
-            desired = workflow_is_app(templates_dir, name)
             current = bool(template.get("isApp", False))
             if desired:
                 # Only written when true, to keep the index diff small and match
@@ -99,10 +105,9 @@ def apply_changes(categories: List[Dict[str, Any]], templates_dir: Path) -> int:
                 if not current:
                     changed += 1
                 template["isApp"] = True
-            else:
-                if "isApp" in template:
-                    changed += 1
-                    del template["isApp"]
+            elif "isApp" in template:
+                changed += 1
+                del template["isApp"]
     return changed
 
 
@@ -159,7 +164,7 @@ def main() -> int:
     with index_path.open(encoding="utf-8") as handle:
         categories = json.load(handle)
 
-    changes = collect_changes(templates_dir, categories)
+    changes, desired_by_entry = plan_changes(templates_dir, categories)
 
     if args.check or args.dry_run:
         for name, current, desired in changes:
@@ -170,7 +175,7 @@ def main() -> int:
         print(f"{len(changes)} entr{'y' if len(changes) == 1 else 'ies'} out of date")
         return 1 if args.check else 0
 
-    changed = apply_changes(categories, templates_dir)
+    changed = apply_changes(categories, desired_by_entry)
     if changed == 0:
         print("index.json is up to date")
         return 0

--- a/scripts/sync/sync_is_app.py
+++ b/scripts/sync/sync_is_app.py
@@ -1,165 +1,156 @@
 #!/usr/bin/env python3
 """Sync the `isApp` flag from each workflow file into templates/index.json.
 
-A workflow can be viewed as a node graph or as an App, and the author picks
-which one it opens in. That choice is stored in the workflow itself, as
-`extra.linearMode`. Nothing in `index.json` carried it, so consumers had to
-guess from the filename: anything ending in `.app` was treated as an App.
+A workflow opens either as a node graph or as an App, and the author picks which.
+That choice lives in the workflow as `extra.linearMode`. Nothing in `index.json`
+carried it, so consumers guessed from the filename: anything ending `.app` was an
+App. The guess is wrong both ways, which is what showed 14 apps instead of 55.
 
-The guess is wrong in both directions. It misses App Mode workflows whose name
-does not end in `.app` (`template_qwen_image_illustration_lora` is one), and it
-cannot be fixed by renaming, because the same guess is what made the hub site
-show 14 apps instead of 55.
+Only `true` is stored. Absent means "not an App", matching the other optional
+booleans in the index, so the write pass removes the key rather than writing
+`false`.
 
-Reading `extra.linearMode` needs no network: the workflow files sit next to the
-index. This writes the answer into the index so the app, the site and anything
-else can filter on a real field.
-
-`linearMode` is only meaningful as "the author chose App Mode". Its absence is a
-normal node-graph workflow, so absent and `false` both write `isApp: false`.
+A workflow that cannot be read or parsed is reported and skipped, never treated
+as "not an App": that would delete a correct `isApp: true` on a transient failure.
 
 Usage:
     python scripts/sync/sync_is_app.py
     python scripts/sync/sync_is_app.py --dry-run
     python scripts/sync/sync_is_app.py --check    # non-zero exit if stale (CI)
+
+Writes `index.json` only. The locale index files carry `isApp` through
+`npm run sync:templates`, which copies template entries wholesale.
+
+`index.mcp.json` does NOT carry it: that index is a curated shape (`capabilities`,
+`task`, `recommend`) rather than a copy of these fields, so exposing App Mode to
+MCP consumers means extending that pipeline. Until then MCP answers App Mode
+wrongly for every App.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 _lib_dir = Path(__file__).resolve().parent.parent / "lib"
 if str(_lib_dir) not in sys.path:
     sys.path.insert(0, str(_lib_dir))
 
+from index_format import dumps_index  # noqa: E402
 from paths import TEMPLATES_DIR  # noqa: E402
 
 INDEX_FILENAME = "index.json"
 
-# Distinguishes "no isApp key" from "isApp: null" when reporting. `.get("isApp")`
-# returns None for both, which would print an explicit null as "absent".
+# Distinguishes "no isApp key" from "isApp: null" when reporting, since
+# `.get("isApp")` returns None for both.
 ABSENT = object()
 
 
-def workflow_is_app(templates_dir: Path, name: str) -> bool:
-    """Whether the workflow file for `name` opens in App Mode.
+class WorkflowUnreadable(Exception):
+    """The workflow could not be classified, so its isApp must not be changed."""
 
-    A missing or unreadable workflow answers False. The index is the thing being
-    corrected here, so a template with no file on disk is a separate problem and
-    `validate_templates.py` is what reports it.
+
+def workflow_is_app(templates_dir: Path, name: str) -> bool:
+    """Whether the workflow for `name` opens in App Mode.
+
+    Raises WorkflowUnreadable when the file is missing, unreadable, or malformed.
+    Only a workflow that parsed can answer False; anything else is unknown, and
+    treating unknown as False would delete a correct flag.
     """
     path = templates_dir / f"{name}.json"
-    if not path.is_file():
-        return False
-
     try:
         with path.open(encoding="utf-8") as handle:
             data = json.load(handle)
-    except (OSError, json.JSONDecodeError):
-        return False
+    except FileNotFoundError as exc:
+        raise WorkflowUnreadable(f"{path} does not exist") from exc
+    except OSError as exc:
+        raise WorkflowUnreadable(f"could not read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise WorkflowUnreadable(f"could not parse {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise WorkflowUnreadable(f"{path}: top level is {type(data).__name__}, expected object")
 
     extra = data.get("extra")
-    if not isinstance(extra, dict):
+    if extra is None:
+        # No extra block at all is a normal node graph, not a malformed file.
         return False
+    if not isinstance(extra, dict):
+        raise WorkflowUnreadable(f"{path}: extra is {type(extra).__name__}, expected object")
 
     return extra.get("linearMode") is True
 
 
-def entry_is_canonical(template: Dict[str, Any], desired: bool) -> bool:
+def entry_is_canonical(template: dict[str, Any], desired: bool) -> bool:
     """Whether the entry already stores `desired` in its canonical form.
 
-    Canonical is `isApp: true` present for an App and the key absent otherwise,
-    so the index diff stays small and matches how the other optional booleans
-    here behave. An explicit `isApp: false` and any non-boolean value are both
-    non-canonical and count as out of date.
-
-    `plan_changes` and `apply_changes` both decide through this. When they read
-    the stored field independently they can disagree: `bool(...)` accepted an
-    explicit `isApp: false`, so `--check` reported the index clean while the
-    write pass would still have deleted the field, and a truthy non-boolean such
-    as `"yes"` was left in place because the write pass counted no change and
-    returned before writing.
+    Canonical is `isApp: true` present for an App and the key absent otherwise.
+    An explicit `false` and any non-boolean are both out of date. The plan and the
+    write pass both decide through this so they cannot disagree.
     """
     if desired:
         return template.get("isApp") is True
     return "isApp" not in template
 
 
-def plan_changes(
-    templates_dir: Path, categories: List[Dict[str, Any]]
-) -> Tuple[List[Tuple[str, Any, bool]], Dict[int, bool]]:
-    """Read every workflow once and return the diff plus the desired values.
+@dataclass
+class Plan:
+    """What a run would change, and what it could not look at."""
 
-    The desired value is keyed by `id()` of the template dict so the write pass
-    can reuse it. Reading the files twice (once to report, once to write) parsed
-    all 574 workflows twice on every run.
+    # (name, stored value or ABSENT, desired) for reporting.
+    changes: list[tuple[str, Any, bool]] = field(default_factory=list)
+    # (entry, desired) for the write pass. Holds the dicts themselves rather than
+    # keying on id(), so the two passes cannot drift apart.
+    updates: list[tuple[dict[str, Any], bool]] = field(default_factory=list)
+    # Messages for entries that could not be classified.
+    unreadable: list[str] = field(default_factory=list)
 
-    Each change carries the raw stored value rather than a coerced boolean, so a
-    stale `false` or an invalid `"yes"` is visible in the report instead of being
-    flattened into the same output as an absent field. A missing key reports as
-    `ABSENT` rather than None, so an explicit `isApp: null` is not disguised as
-    an absent one.
+
+def plan_changes(templates_dir: Path, categories: list[dict[str, Any]]) -> Plan:
+    """Read every workflow once and return what would change.
+
+    Each change carries the raw stored value, so a stale `false` or an invalid
+    `"yes"` is visible in the report rather than flattened into the same output as
+    an absent key.
     """
-    changes: List[Tuple[str, Any, bool]] = []
-    desired_by_entry: Dict[int, bool] = {}
+    plan = Plan()
     for category in categories:
         for template in category.get("templates", []):
             name = template.get("name")
             if not name:
                 continue
-            desired = workflow_is_app(templates_dir, name)
-            desired_by_entry[id(template)] = desired
-            if not entry_is_canonical(template, desired):
-                changes.append((name, template.get("isApp", ABSENT), desired))
-    return changes, desired_by_entry
-
-
-def apply_changes(categories: List[Dict[str, Any]], desired_by_entry: Dict[int, bool]) -> int:
-    """Write isApp onto every entry from the already-computed plan."""
-    changed = 0
-    for category in categories:
-        for template in category.get("templates", []):
-            desired = desired_by_entry.get(id(template))
-            if desired is None:
+            try:
+                desired = workflow_is_app(templates_dir, name)
+            except WorkflowUnreadable as exc:
+                plan.unreadable.append(f"{name}: {exc}")
                 continue
             if entry_is_canonical(template, desired):
                 continue
-            changed += 1
-            if desired:
-                template["isApp"] = True
-            else:
-                del template["isApp"]
-    return changed
+            plan.changes.append((name, template.get("isApp", ABSENT), desired))
+            plan.updates.append((template, desired))
+    return plan
 
 
-def format_index(categories: List[Dict[str, Any]]) -> str:
-    """Serialise index.json the way the other sync scripts do.
+def apply_changes(plan: Plan) -> int:
+    """Write isApp onto every entry the plan selected."""
+    for template, desired in plan.updates:
+        if desired:
+            template["isApp"] = True
+        else:
+            template.pop("isApp", None)
+    return len(plan.updates)
 
-    Plain `json.dump(indent=2)` puts every array element on its own line, which
-    rewrites the whole file and buries a small change in thousands of diff lines.
-    This mirrors `sync_custom_nodes.save_index_file` so a one-field edit shows up
-    as a one-field diff. Arrays are joined without a space after the comma, which
-    is how the committed index.json is written; the older script adds one and
-    would rewrite every tag line.
-    """
-    json_str = json.dumps(categories, ensure_ascii=False, indent=2)
 
-    def compact_array(match: "re.Match[str]") -> str:
-        content = match.group(1)
-        try:
-            array_content = json.loads(f"[{content}]")
-        except json.JSONDecodeError:
-            return match.group(0)
-        if all(isinstance(item, str) for item in array_content) and len(content) < 200:
-            return f"[{','.join(json.dumps(item, ensure_ascii=False) for item in array_content)}]"
-        return match.group(0)
-
-    return re.sub(r"\[\s*\n\s*([^[\]]*?)\s*\n\s*\]", compact_array, json_str, flags=re.DOTALL)
+def _report(plan: Plan) -> None:
+    for name, current, desired in plan.changes:
+        stored = "absent" if current is ABSENT else json.dumps(current)
+        print(f"  {name}: isApp {stored} -> {desired}")
+    for message in plan.unreadable:
+        print(f"warning: skipped {message}", file=sys.stderr)
 
 
 def main() -> int:
@@ -187,30 +178,39 @@ def main() -> int:
         print(f"error: {index_path} not found", file=sys.stderr)
         return 1
 
-    with index_path.open(encoding="utf-8") as handle:
-        categories = json.load(handle)
+    try:
+        with index_path.open(encoding="utf-8") as handle:
+            categories = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: could not read {index_path}: {exc}", file=sys.stderr)
+        return 1
 
-    changes, desired_by_entry = plan_changes(templates_dir, categories)
+    plan = plan_changes(templates_dir, categories)
+    _report(plan)
 
     if args.check or args.dry_run:
-        for name, current, desired in changes:
-            stored = "absent" if current is ABSENT else json.dumps(current)
-            print(f"  {name}: isApp {stored} -> {desired}")
-        if not changes:
+        if not plan.changes:
             print("index.json is up to date")
+        else:
+            count = len(plan.changes)
+            print(f"{count} entr{'y' if count == 1 else 'ies'} out of date")
+        if not args.check:
             return 0
-        print(f"{len(changes)} entr{'y' if len(changes) == 1 else 'ies'} out of date")
-        return 1 if args.check else 0
+        # Unreadable entries fail --check too: the index cannot be called correct
+        # while some of it was never looked at.
+        return 1 if plan.changes or plan.unreadable else 0
 
-    changed = apply_changes(categories, desired_by_entry)
-    if changed == 0:
+    changed = apply_changes(plan)
+    if changed:
+        index_path.write_text(dumps_index(categories), encoding="utf-8")
+        print(f"Updated {changed} entr{'y' if changed == 1 else 'ies'} in {index_path}")
+        print("Locale index files and index.mcp.json are separate: run `npm run sync:templates`")
+        print("and `npm run mcp`, or let CI auto-sync them.")
+    else:
         print("index.json is up to date")
-        return 0
 
-    index_path.write_text(format_index(categories), encoding="utf-8")
-
-    print(f"Updated {changed} entr{'y' if changed == 1 else 'ies'} in {index_path}")
-    return 0
+    # Something went unread, so the run cannot claim the index is now correct.
+    return 1 if plan.unreadable else 0
 
 
 if __name__ == "__main__":

--- a/scripts/sync/sync_is_app.py
+++ b/scripts/sync/sync_is_app.py
@@ -66,16 +66,40 @@ def workflow_is_app(templates_dir: Path, name: str) -> bool:
     return extra.get("linearMode") is True
 
 
+def entry_is_canonical(template: Dict[str, Any], desired: bool) -> bool:
+    """Whether the entry already stores `desired` in its canonical form.
+
+    Canonical is `isApp: true` present for an App and the key absent otherwise,
+    so the index diff stays small and matches how the other optional booleans
+    here behave. An explicit `isApp: false` and any non-boolean value are both
+    non-canonical and count as out of date.
+
+    `plan_changes` and `apply_changes` both decide through this. When they read
+    the stored field independently they can disagree: `bool(...)` accepted an
+    explicit `isApp: false`, so `--check` reported the index clean while the
+    write pass would still have deleted the field, and a truthy non-boolean such
+    as `"yes"` was left in place because the write pass counted no change and
+    returned before writing.
+    """
+    if desired:
+        return template.get("isApp") is True
+    return "isApp" not in template
+
+
 def plan_changes(
     templates_dir: Path, categories: List[Dict[str, Any]]
-) -> Tuple[List[Tuple[str, bool, bool]], Dict[int, bool]]:
+) -> Tuple[List[Tuple[str, Any, bool]], Dict[int, bool]]:
     """Read every workflow once and return the diff plus the desired values.
 
     The desired value is keyed by `id()` of the template dict so the write pass
     can reuse it. Reading the files twice (once to report, once to write) parsed
     all 574 workflows twice on every run.
+
+    Each change carries the raw stored value rather than a coerced boolean, so a
+    stale `false` or an invalid `"yes"` is visible in the report instead of being
+    flattened into the same output as an absent field.
     """
-    changes: List[Tuple[str, bool, bool]] = []
+    changes: List[Tuple[str, Any, bool]] = []
     desired_by_entry: Dict[int, bool] = {}
     for category in categories:
         for template in category.get("templates", []):
@@ -84,9 +108,8 @@ def plan_changes(
                 continue
             desired = workflow_is_app(templates_dir, name)
             desired_by_entry[id(template)] = desired
-            current = bool(template.get("isApp", False))
-            if current != desired:
-                changes.append((name, current, desired))
+            if not entry_is_canonical(template, desired):
+                changes.append((name, template.get("isApp"), desired))
     return changes, desired_by_entry
 
 
@@ -98,15 +121,12 @@ def apply_changes(categories: List[Dict[str, Any]], desired_by_entry: Dict[int, 
             desired = desired_by_entry.get(id(template))
             if desired is None:
                 continue
-            current = bool(template.get("isApp", False))
+            if entry_is_canonical(template, desired):
+                continue
+            changed += 1
             if desired:
-                # Only written when true, to keep the index diff small and match
-                # how the other optional booleans here behave.
-                if not current:
-                    changed += 1
                 template["isApp"] = True
-            elif "isApp" in template:
-                changed += 1
+            else:
                 del template["isApp"]
     return changed
 
@@ -168,7 +188,8 @@ def main() -> int:
 
     if args.check or args.dry_run:
         for name, current, desired in changes:
-            print(f"  {name}: isApp {current} -> {desired}")
+            stored = "absent" if current is None else json.dumps(current)
+            print(f"  {name}: isApp {stored} -> {desired}")
         if not changes:
             print("index.json is up to date")
             return 0

--- a/scripts/sync/sync_is_app.py
+++ b/scripts/sync/sync_is_app.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Sync the `isApp` flag from each workflow file into templates/index.json.
+
+A workflow can be viewed as a node graph or as an App, and the author picks
+which one it opens in. That choice is stored in the workflow itself, as
+`extra.linearMode`. Nothing in `index.json` carried it, so consumers had to
+guess from the filename: anything ending in `.app` was treated as an App.
+
+The guess is wrong in both directions. It misses App Mode workflows whose name
+does not end in `.app` (`template_qwen_image_illustration_lora` is one), and it
+cannot be fixed by renaming, because the same guess is what made the hub site
+show 14 apps instead of 55.
+
+Reading `extra.linearMode` needs no network: the workflow files sit next to the
+index. This writes the answer into the index so the app, the site and anything
+else can filter on a real field.
+
+`linearMode` is only meaningful as "the author chose App Mode". Its absence is a
+normal node-graph workflow, so absent and `false` both write `isApp: false`.
+
+Usage:
+    python scripts/sync/sync_is_app.py
+    python scripts/sync/sync_is_app.py --dry-run
+    python scripts/sync/sync_is_app.py --check    # non-zero exit if stale (CI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+_lib_dir = Path(__file__).resolve().parent.parent / "lib"
+if str(_lib_dir) not in sys.path:
+    sys.path.insert(0, str(_lib_dir))
+
+from paths import TEMPLATES_DIR  # noqa: E402
+
+INDEX_FILENAME = "index.json"
+
+
+def workflow_is_app(templates_dir: Path, name: str) -> bool:
+    """Whether the workflow file for `name` opens in App Mode.
+
+    A missing or unreadable workflow answers False. The index is the thing being
+    corrected here, so a template with no file on disk is a separate problem and
+    `validate_templates.py` is what reports it.
+    """
+    path = templates_dir / f"{name}.json"
+    if not path.is_file():
+        return False
+
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    extra = data.get("extra")
+    if not isinstance(extra, dict):
+        return False
+
+    return extra.get("linearMode") is True
+
+
+def collect_changes(
+    templates_dir: Path, categories: List[Dict[str, Any]]
+) -> List[Tuple[str, bool, bool]]:
+    """Return (name, current, desired) for every entry whose isApp is wrong."""
+    changes: List[Tuple[str, bool, bool]] = []
+    for category in categories:
+        for template in category.get("templates", []):
+            name = template.get("name")
+            if not name:
+                continue
+            desired = workflow_is_app(templates_dir, name)
+            current = bool(template.get("isApp", False))
+            if current != desired:
+                changes.append((name, current, desired))
+    return changes
+
+
+def apply_changes(categories: List[Dict[str, Any]], templates_dir: Path) -> int:
+    """Write isApp onto every entry. Returns the number of entries changed."""
+    changed = 0
+    for category in categories:
+        for template in category.get("templates", []):
+            name = template.get("name")
+            if not name:
+                continue
+            desired = workflow_is_app(templates_dir, name)
+            current = bool(template.get("isApp", False))
+            if desired:
+                # Only written when true, to keep the index diff small and match
+                # how the other optional booleans here behave.
+                if not current:
+                    changed += 1
+                template["isApp"] = True
+            else:
+                if "isApp" in template:
+                    changed += 1
+                    del template["isApp"]
+    return changed
+
+
+def format_index(categories: List[Dict[str, Any]]) -> str:
+    """Serialise index.json the way the other sync scripts do.
+
+    Plain `json.dump(indent=2)` puts every array element on its own line, which
+    rewrites the whole file and buries a small change in thousands of diff lines.
+    This mirrors `sync_custom_nodes.save_index_file` so a one-field edit shows up
+    as a one-field diff. Arrays are joined without a space after the comma, which
+    is how the committed index.json is written; the older script adds one and
+    would rewrite every tag line.
+    """
+    json_str = json.dumps(categories, ensure_ascii=False, indent=2)
+
+    def compact_array(match: "re.Match[str]") -> str:
+        content = match.group(1)
+        try:
+            array_content = json.loads(f"[{content}]")
+        except json.JSONDecodeError:
+            return match.group(0)
+        if all(isinstance(item, str) for item in array_content) and len(content) < 200:
+            return f"[{','.join(json.dumps(item, ensure_ascii=False) for item in array_content)}]"
+        return match.group(0)
+
+    return re.sub(r"\[\s*\n\s*([^[\]]*?)\s*\n\s*\]", compact_array, json_str, flags=re.DOTALL)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Sync isApp from each workflow's extra.linearMode into index.json",
+    )
+    parser.add_argument(
+        "--templates-dir",
+        default=str(TEMPLATES_DIR),
+        help="Directory holding the workflow files and index.json",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report what would change, write nothing"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if index.json is out of date; implies --dry-run",
+    )
+    args = parser.parse_args()
+
+    templates_dir = Path(args.templates_dir)
+    index_path = templates_dir / INDEX_FILENAME
+    if not index_path.is_file():
+        print(f"error: {index_path} not found", file=sys.stderr)
+        return 1
+
+    with index_path.open(encoding="utf-8") as handle:
+        categories = json.load(handle)
+
+    changes = collect_changes(templates_dir, categories)
+
+    if args.check or args.dry_run:
+        for name, current, desired in changes:
+            print(f"  {name}: isApp {current} -> {desired}")
+        if not changes:
+            print("index.json is up to date")
+            return 0
+        print(f"{len(changes)} entr{'y' if len(changes) == 1 else 'ies'} out of date")
+        return 1 if args.check else 0
+
+    changed = apply_changes(categories, templates_dir)
+    if changed == 0:
+        print("index.json is up to date")
+        return 0
+
+    index_path.write_text(format_index(categories), encoding="utf-8")
+
+    print(f"Updated {changed} entr{'y' if changed == 1 else 'ies'} in {index_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync/sync_is_app.py
+++ b/scripts/sync/sync_is_app.py
@@ -41,6 +41,10 @@ from paths import TEMPLATES_DIR  # noqa: E402
 
 INDEX_FILENAME = "index.json"
 
+# Distinguishes "no isApp key" from "isApp: null" when reporting. `.get("isApp")`
+# returns None for both, which would print an explicit null as "absent".
+ABSENT = object()
+
 
 def workflow_is_app(templates_dir: Path, name: str) -> bool:
     """Whether the workflow file for `name` opens in App Mode.
@@ -97,7 +101,9 @@ def plan_changes(
 
     Each change carries the raw stored value rather than a coerced boolean, so a
     stale `false` or an invalid `"yes"` is visible in the report instead of being
-    flattened into the same output as an absent field.
+    flattened into the same output as an absent field. A missing key reports as
+    `ABSENT` rather than None, so an explicit `isApp: null` is not disguised as
+    an absent one.
     """
     changes: List[Tuple[str, Any, bool]] = []
     desired_by_entry: Dict[int, bool] = {}
@@ -109,7 +115,7 @@ def plan_changes(
             desired = workflow_is_app(templates_dir, name)
             desired_by_entry[id(template)] = desired
             if not entry_is_canonical(template, desired):
-                changes.append((name, template.get("isApp"), desired))
+                changes.append((name, template.get("isApp", ABSENT), desired))
     return changes, desired_by_entry
 
 
@@ -188,7 +194,7 @@ def main() -> int:
 
     if args.check or args.dry_run:
         for name, current, desired in changes:
-            stored = "absent" if current is None else json.dumps(current)
+            stored = "absent" if current is ABSENT else json.dumps(current)
             print(f"  {name}: isApp {stored} -> {desired}")
         if not changes:
             print("index.json is up to date")

--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["صوت","استنساخ الصوت"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["صوت","تحويل النص إلى كلام","استنساخ الصوت"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["صوت","استنساخ الصوت"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["صوت","تحويل النص إلى كلام","استنساخ الصوت"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["تحرير صورة"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["Audio","Clonación de Voz"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["Audio","Texto a voz","Clonación de Voz"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["Audio","Clonación de Voz"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["Audio","Texto a voz","Clonación de Voz"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["Edición de imagen"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["ویرایش تصویر"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["صدا","همانندسازی صدا"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["صدا","متن به گفتار","همانندسازی صدا"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["صدا","همانندسازی صدا"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["صدا","متن به گفتار","همانندسازی صدا"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["Édition d'image"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["Audio","Clonage Vocal"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["Audio","Synthèse vocale","Clonage Vocal"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["Audio","Clonage Vocal"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["Audio","Synthèse vocale","Clonage Vocal"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["画像編集"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["オーディオ","音声クローニング"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["オーディオ","テキスト読み上げ","音声クローニング"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["オーディオ","音声クローニング"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["オーディオ","テキスト読み上げ","音声クローニング"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.json
+++ b/templates/index.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["Audio","Voice Cloning"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["Audio","Text to Speech","Voice Cloning"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.json
+++ b/templates/index.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["Audio","Voice Cloning"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["Audio","Text to Speech","Voice Cloning"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.json
+++ b/templates/index.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["Image Edit"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["오디오","음성 복제"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["오디오","텍스트 음성 변환","음성 복제"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["오디오","음성 복제"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["오디오","텍스트 음성 변환","음성 복제"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["이미지 편집"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["Áudio","Clonagem de Voz"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["Áudio","Texto para Fala","Clonagem de Voz"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["Áudio","Clonagem de Voz"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["Áudio","Texto para Fala","Clonagem de Voz"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["Edição de imagem"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["Редактирование изображения"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["Аудио","Клонирование Голоса"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["Аудио","Преобразование текста в речь","Клонирование Голоса"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["Аудио","Клонирование Голоса"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["Аудио","Преобразование текста в речь","Клонирование Голоса"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.schema.json
+++ b/templates/index.schema.json
@@ -55,6 +55,10 @@
           "type": "boolean",
           "description": "Whether the template is Open Source"
         },
+        "isApp": {
+          "type": "boolean",
+          "description": "Whether the template opens in App Mode rather than as a node graph, derived from the workflow's extra.linearMode"
+        },
         "name": {
           "type": "string",
           "description": "Workflow filename without .json extension",

--- a/templates/index.schema.json
+++ b/templates/index.schema.json
@@ -57,7 +57,8 @@
         },
         "isApp": {
           "type": "boolean",
-          "description": "Whether the template opens in App Mode rather than as a node graph, derived from the workflow's extra.linearMode"
+          "enum": [true],
+          "description": "Present and true when the template opens in App Mode rather than as a node graph, derived from the workflow's extra.linearMode. Omitted when false, so `false` is rejected here: sync_is_app.py deletes it, and allowing it would let a schema-valid but sync-stale value through"
         },
         "name": {
           "type": "string",

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["Ses","Ses Klonlama"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["Ses","Metinden Sese","Ses Klonlama"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["Ses","Ses Klonlama"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["Ses","Metinden Sese","Ses Klonlama"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["Görüntü Düzenleme"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["音訊","語音克隆"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["音訊","文字轉語音","語音克隆"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["圖片編輯"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["音訊","語音克隆"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["音訊","文字轉語音","語音克隆"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1164,
+        "usage": 1142,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1154,
+        "usage": 1119,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34425,
+        "usage": 31770,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 592,
+        "usage": 544,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10168,
+        "usage": 10028,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1080,
+        "usage": 1079,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 586,
+        "usage": 558,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 667,
+        "usage": 590,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 255,
+        "usage": 252,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1592,7 +1592,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 64,
+        "usage": 66,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 816,
+        "usage": 794,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 861,
+        "usage": 843,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 85,
+        "usage": 84,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 143,
+        "usage": 144,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 681,
+        "usage": 669,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 35,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 81,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 135,
+        "usage": 132,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 65,
+        "usage": 66,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 187,
+        "usage": 186,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 80,
+        "usage": 74,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2595,7 +2595,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2681,7 +2681,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 12,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 38,
+        "usage": 37,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2775,7 +2775,7 @@
         "openSource": true,
         "size": 103830834381,
         "vram": 103830834381,
-        "usage": 9,
+        "usage": 8,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 170,
+        "usage": 173,
         "io": {
           "inputs": [
             {
@@ -2914,7 +2914,7 @@
         "date": "2025-08-12",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 59,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 74,
+        "usage": 72,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 257,
+        "usage": 249,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 528,
+        "usage": 518,
         "io": {
           "inputs": [
             {
@@ -3154,7 +3154,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 17,
+        "usage": 16,
         "searchRank": 0,
         "openSource": true,
         "username": "ComfyUI"
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 163,
+        "usage": 152,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 174,
+        "usage": 179,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 194,
+        "usage": 193,
         "io": {
           "inputs": [
             {
@@ -3557,7 +3557,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 90,
+        "usage": 89,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 180,
+        "usage": 177,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 54,
+        "usage": 55,
         "io": {
           "inputs": [
             {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 85,
+        "usage": 86,
         "io": {
           "outputs": [
             {
@@ -3816,7 +3816,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -3847,7 +3847,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 120,
+        "usage": 119,
         "io": {
           "inputs": [
             {
@@ -3970,7 +3970,7 @@
         "date": "2026-01-03",
         "openSource": false,
         "models": ["Wan2.6","Wan"],
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -4002,7 +4002,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 43,
+        "usage": 44,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 34,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4173,7 +4173,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 16,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 380,
+        "usage": 383,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 26,
+        "usage": 27,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 23,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 17,
         "io": {
           "inputs": [
             {
@@ -4549,7 +4549,7 @@
         "date": "2025-10-06",
         "size": 22494891213,
         "vram": 22494891213,
-        "usage": 14,
+        "usage": 13,
         "username": "ComfyUI"
       },
       {
@@ -4580,7 +4580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4631,7 +4631,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 27,
         "username": "ComfyUI"
       },
       {
@@ -4679,7 +4679,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 12,
+        "usage": 11,
         "io": {
           "inputs": [
             {
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 28,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -4734,7 +4734,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 24,
+        "usage": 25,
         "username": "ComfyUI"
       },
       {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 31,
+        "usage": 32,
         "io": {
           "inputs": [
             {
@@ -4913,7 +4913,7 @@
         "date": "2025-03-01",
         "size": 35476429865,
         "vram": 35476429865,
-        "usage": 58,
+        "usage": 57,
         "username": "ComfyUI"
       }
     ]
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13435,
+        "usage": 13243,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1634,
+        "usage": 1604,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 184,
+        "usage": 181,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 478,
+        "usage": 467,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5231,7 +5231,7 @@
         "date": "2025-09-25",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 312,
+        "usage": 296,
         "io": {
           "inputs": [
             {
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 817,
+        "usage": 800,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 336,
+        "usage": 321,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 241,
+        "usage": 238,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 524,
+        "usage": 512,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1015,
+        "usage": 994,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 379,
+        "usage": 372,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 113,
+        "usage": 112,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 395,
+        "usage": 387,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 810,
+        "usage": 806,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 238,
+        "usage": 234,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 160,
+        "usage": 159,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6845,7 +6845,7 @@
         "date": "2026-01-16",
         "size": 19112604467,
         "vram": 21045339750,
-        "usage": 150,
+        "usage": 148,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 222,
+        "usage": 214,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -6953,7 +6953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -6982,7 +6982,7 @@
         "openSource": true,
         "size": 35326106010,
         "vram": 35326106010,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 73,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 509,
+        "usage": 507,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7231,7 +7231,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 71,
+        "usage": 70,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 112,
+        "usage": 111,
         "io": {
           "inputs": [
             {
@@ -7368,7 +7368,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 38,
+        "usage": 40,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 101,
         "io": {
           "inputs": [
             {
@@ -7440,7 +7440,7 @@
         "date": "2026-01-16",
         "size": 12455405158,
         "vram": 12455405158,
-        "usage": 107,
+        "usage": 105,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 174,
+        "usage": 166,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 145,
+        "usage": 143,
         "io": {
           "inputs": [
             {
@@ -7583,7 +7583,7 @@
         "date": "2025-08-18",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 127,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -7724,7 +7724,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 13,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/api_quiver_text_to_svg.png"]
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7857,7 +7857,7 @@
         "date": "2025-06-04",
         "size": 23300197581,
         "vram": 15569256448,
-        "usage": 58,
+        "usage": 60,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 104,
+        "usage": 103,
         "io": {
           "outputs": [
             {
@@ -7913,7 +7913,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 172,
+        "usage": 174,
         "io": {
           "outputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 145,
+        "usage": 147,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 124,
+        "usage": 123,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 96,
+        "usage": 97,
         "io": {
           "outputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 81,
+        "usage": 80,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 88,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 246,
+        "usage": 245,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -8654,7 +8654,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 95,
+        "usage": 96,
         "username": "ComfyUI"
       },
       {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 172,
+        "usage": 171,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8926,7 +8926,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 12,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -9021,7 +9021,7 @@
         "date": "2025-03-01",
         "size": 17233556275,
         "vram": 18253611008,
-        "usage": 55,
+        "usage": 54,
         "username": "ComfyUI"
       },
       {
@@ -9036,7 +9036,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "outputs": [
             {
@@ -9169,7 +9169,7 @@
         "date": "2025-07-21",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 47,
+        "usage": 46,
         "io": {
           "inputs": [
             {
@@ -9308,7 +9308,7 @@
         "date": "2025-06-30",
         "size": 15784004813,
         "vram": 15784004813,
-        "usage": 48,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -9344,7 +9344,7 @@
         "date": "2025-03-01",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9586,7 +9586,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 27,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 837,
+        "usage": 832,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 319,
+        "usage": 308,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 617,
+        "usage": 614,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10284,7 +10284,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 236,
+        "usage": 233,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 286,
+        "usage": 289,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 49,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10580,7 +10580,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 59,
+        "usage": 56,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10619,7 +10619,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 12,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 108,
+        "usage": 109,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 559,
+        "usage": 553,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10911,7 +10911,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 40,
         "searchRank": 0,
         "username": "Julien | MJM",
         "io": {
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 106,
+        "usage": 104,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 264,
+        "usage": 262,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 247,
+        "usage": 241,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 71,
+        "usage": 70,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 426,
+        "usage": 422,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 96,
+        "usage": 95,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11618,7 +11618,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 90,
+        "usage": 92,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "logos": [
           {
             "provider": "Google"
@@ -11724,7 +11724,7 @@
         "models": ["Qwen","Qwen-Image-Edit"],
         "date": "2026-01-13",
         "openSource": true,
-        "usage": 30,
+        "usage": 29,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 75,
+        "usage": 73,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 78,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 164,
+        "usage": 163,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 77,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11979,7 +11979,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 38,
+        "usage": 41,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12072,7 +12072,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 114,
+        "usage": 113,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12383,7 +12383,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 60,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 66,
+        "usage": 67,
         "io": {
           "inputs": [
             {
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 201,
+        "usage": 199,
         "logos": [
           {
             "provider": "Google"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 458,
+        "usage": 457,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12672,7 +12672,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 11,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12704,7 +12704,7 @@
         "openSource": false,
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 9,
+        "usage": 10,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12800,7 +12800,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": ["Google","Kling","OpenAI"],
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -13102,7 +13102,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -13141,7 +13141,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 32,
+        "usage": 30,
         "logos": [
           {
             "provider": "Google"
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 42,
+        "usage": 41,
         "logos": [
           {
             "provider": "Google"
@@ -13327,7 +13327,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 9,
+        "usage": 7,
         "logos": [
           {
             "provider": "Google"
@@ -13786,7 +13786,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "username": "ComfyUI",
         "includeOnDistributions": ["local"]
@@ -13803,7 +13803,7 @@
         "openSource": true,
         "size": 19864223744,
         "vram": 19864223744,
-        "usage": 39,
+        "usage": 38,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 130,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14007,7 +14007,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14139,7 +14139,7 @@
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
         "date": "2026-01-22",
         "openSource": true,
-        "usage": 74,
+        "usage": 77,
         "io": {
           "inputs": [
             {
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 93,
+        "usage": 95,
         "searchRank": 0,
         "tags": ["音频","语音克隆"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "searchRank": 0,
         "tags": ["音频","文本转语音","语音克隆"],
         "io": {
@@ -14551,7 +14551,7 @@
         "models": ["Meshy"],
         "date": "2026-01-19",
         "openSource": false,
-        "usage": 48,
+        "usage": 49,
         "io": {
           "inputs": [
             {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14654,7 +14654,7 @@
         "models": ["Hunyuan3D"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 44,
+        "usage": 43,
         "username": "ComfyUI"
       },
       {
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 156,
+        "usage": 159,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14825,7 +14825,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 14,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14931,7 +14931,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14957,7 +14957,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 15,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 126,
+        "usage": 128,
         "io": {
           "inputs": [
             {
@@ -15164,7 +15164,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 40,
+        "usage": 41,
         "searchRank": 0,
         "username": "shane"
       },
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 31,
+        "usage": 32,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 213,
+        "usage": 212,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 674,
+        "usage": 671,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 117,
+        "usage": 115,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 105,
+        "usage": 109,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 129,
+        "usage": 126,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 249,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 99,
+        "usage": 97,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 53,
+        "usage": 52,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 27,
         "searchRank": 0,
         "logos": [
           {
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 33,
         "searchRank": 0,
         "logos": [
           {
@@ -17664,7 +17664,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 27,
+        "usage": 24,
         "searchRank": 0,
         "logos": [
           {
@@ -17777,7 +17777,7 @@
         "date": "2025-12-22",
         "size": 50465865728,
         "vram": 50465865728,
-        "usage": 35,
+        "usage": 34,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 28,
+        "usage": 30,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 118,
+        "usage": 119,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 63,
+        "usage": 64,
         "io": {
           "inputs": [
             {
@@ -17973,7 +17973,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 18,
+        "usage": 17,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 687,
+        "usage": 717,
         "io": {
           "inputs": [
             {
@@ -18120,7 +18120,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 166,
+        "usage": 167,
         "io": {
           "inputs": [
             {
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 64,
+        "usage": 65,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -278,7 +278,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 1179,
+        "usage": 1164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -304,7 +304,7 @@
         "openSource": true,
         "size": 42949672960,
         "vram": 42949672960,
-        "usage": 1181,
+        "usage": 1154,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -350,7 +350,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38255,
+        "usage": 34425,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -390,7 +390,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 641,
+        "usage": 592,
         "searchRank": 500,
         "username": "ComfyUI",
         "io": {
@@ -507,7 +507,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 10295,
+        "usage": 10168,
         "io": {
           "inputs": [
             {
@@ -773,7 +773,7 @@
         "date": "2025-07-29",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 1091,
+        "usage": 1080,
         "io": {
           "inputs": [
             {
@@ -889,7 +889,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 623,
+        "usage": 586,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -929,7 +929,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 729,
+        "usage": 667,
         "searchRank": 1000,
         "username": "ComfyUI",
         "io": {
@@ -1042,7 +1042,7 @@
         "openSource": true,
         "size": 38976828211,
         "vram": 38976828211,
-        "usage": 109,
+        "usage": 106,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -1322,7 +1322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 266,
+        "usage": 255,
         "io": {
           "inputs": [
             {
@@ -1353,7 +1353,7 @@
         "openSource": true,
         "size": 43486543872,
         "vram": 43486543872,
-        "usage": 133,
+        "usage": 130,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1632,7 +1632,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 63,
+        "usage": 64,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -1746,7 +1746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 52,
+        "usage": 51,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1781,7 +1781,7 @@
         "openSource": true,
         "size": 47244640256,
         "vram": 47244640256,
-        "usage": 846,
+        "usage": 816,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -1808,7 +1808,7 @@
         "date": "2025-07-29",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 892,
+        "usage": 861,
         "username": "ComfyUI"
       },
       {
@@ -1857,7 +1857,7 @@
         "date": "2026-01-06",
         "size": 45526653338,
         "vram": 45526653338,
-        "usage": 87,
+        "usage": 85,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -1890,7 +1890,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 144,
+        "usage": 143,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -1930,7 +1930,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 709,
+        "usage": 681,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2250,7 +2250,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 70,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2296,7 +2296,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 73,
+        "usage": 74,
         "searchRank": 0,
         "username": "ComfyUI",
         "logos": [
@@ -2322,7 +2322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 34,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -2367,7 +2367,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 87,
+        "usage": 84,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2409,7 +2409,7 @@
         "date": "2025-05-21",
         "size": 57756572713,
         "vram": 57756572713,
-        "usage": 140,
+        "usage": 135,
         "io": {
           "inputs": [
             {
@@ -2449,7 +2449,7 @@
         "openSource": true,
         "size": 53794465382,
         "vram": 53794465382,
-        "usage": 66,
+        "usage": 65,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2491,7 +2491,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 192,
+        "usage": 187,
         "io": {
           "inputs": [
             {
@@ -2522,7 +2522,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 79,
+        "usage": 80,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2707,7 +2707,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-10",
         "openSource": false,
-        "usage": 39,
+        "usage": 38,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -2741,7 +2741,7 @@
         "date": "2025-09-22",
         "size": 27380416512,
         "vram": 27380416512,
-        "usage": 208,
+        "usage": 211,
         "requiresCustomNodes": ["ComfyUI-segment-anything-2","comfyui-kjnodes","comfyui_controlnet_aux"],
         "io": {
           "inputs": [
@@ -2815,7 +2815,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 48,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -2883,7 +2883,7 @@
         "date": "2025-08-02",
         "size": 38031935406,
         "vram": 38031935406,
-        "usage": 171,
+        "usage": 170,
         "io": {
           "inputs": [
             {
@@ -2945,7 +2945,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 24,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -2959,7 +2959,7 @@
         "models": ["Vidu","Vidu Q3"],
         "date": "2026-02-02",
         "openSource": false,
-        "usage": 73,
+        "usage": 74,
         "size": 0,
         "vram": 0,
         "logos": [
@@ -2993,7 +2993,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 256,
+        "usage": 257,
         "io": {
           "inputs": [
             {
@@ -3016,7 +3016,7 @@
         "models": ["Kling 2.6","Kling"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 552,
+        "usage": 528,
         "io": {
           "inputs": [
             {
@@ -3047,7 +3047,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -3070,7 +3070,7 @@
         "models": ["Vidu Q2","Vidu"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 17,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -3094,7 +3094,7 @@
         "date": "2026-01-06",
         "size": 38010460570,
         "vram": 38010460570,
-        "usage": 79,
+        "usage": 78,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -3236,7 +3236,7 @@
         "date": "2026-01-19",
         "openSource": true,
         "requiresCustomNodes": ["ComfyUI-WanAnimatePreprocess","ComfyUI-WanVideoWrapper","comfyui-kjnodes","comfyui-scail-pose","comfyui-videohelpersuite","comfyui_essentials"],
-        "usage": 165,
+        "usage": 163,
         "io": {
           "inputs": [
             {
@@ -3269,7 +3269,7 @@
         "date": "2025-11-21",
         "size": 45384919416,
         "vram": 45384919416,
-        "usage": 214,
+        "usage": 212,
         "io": {
           "inputs": [
             {
@@ -3325,7 +3325,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-12",
         "openSource": false,
-        "usage": 13,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -3363,7 +3363,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 176,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -3500,7 +3500,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 195,
+        "usage": 194,
         "io": {
           "inputs": [
             {
@@ -3525,7 +3525,7 @@
         "date": "2025-08-02",
         "size": 25254407700,
         "vram": 25254407700,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3591,7 +3591,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 9,
         "io": {
           "inputs": [
             {
@@ -3665,7 +3665,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 184,
+        "usage": 180,
         "io": {
           "inputs": [
             {
@@ -3722,7 +3722,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 14,
+        "usage": 13,
         "io": {
           "inputs": [
             {
@@ -3747,7 +3747,7 @@
         "date": "2025-03-01",
         "size": 19155554140,
         "vram": 19155554140,
-        "usage": 53,
+        "usage": 54,
         "io": {
           "inputs": [
             {
@@ -3773,7 +3773,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 22,
+        "usage": 23,
         "username": "ComfyUI"
       },
       {
@@ -3787,7 +3787,7 @@
         "date": "2025-11-21",
         "size": 45419279155,
         "vram": 45419279155,
-        "usage": 86,
+        "usage": 85,
         "io": {
           "outputs": [
             {
@@ -3918,7 +3918,7 @@
         "date": "2025-12-15",
         "size": 25447681229,
         "vram": 25447681229,
-        "usage": 121,
+        "usage": 120,
         "io": {
           "inputs": [
             {
@@ -4026,7 +4026,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -4100,7 +4100,7 @@
         "date": "2025-03-01",
         "size": 9824737690,
         "vram": 9824737690,
-        "usage": 99,
+        "usage": 98,
         "username": "ComfyUI"
       },
       {
@@ -4210,7 +4210,7 @@
         "date": "2025-03-01",
         "size": 41049149932,
         "vram": 41049149932,
-        "usage": 370,
+        "usage": 380,
         "io": {
           "inputs": [
             {
@@ -4235,7 +4235,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 28,
+        "usage": 26,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -4322,7 +4322,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 24,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -4374,7 +4374,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4405,7 +4405,7 @@
         "date": "2025-05-21",
         "size": 57767310131,
         "vram": 57767310131,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -4464,7 +4464,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 10,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -4703,7 +4703,7 @@
         "date": "2025-07-29",
         "size": 18146236826,
         "vram": 18146236826,
-        "usage": 29,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -4857,7 +4857,7 @@
         "date": "2025-04-15",
         "size": 11489037517,
         "vram": 11489037517,
-        "usage": 22,
+        "usage": 19,
         "io": {
           "inputs": [
             {
@@ -4882,7 +4882,7 @@
         "date": "2025-04-15",
         "size": 11381663334,
         "vram": 11381663334,
-        "usage": 30,
+        "usage": 31,
         "io": {
           "inputs": [
             {
@@ -4937,7 +4937,7 @@
         "date": "2025-11-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 13603,
+        "usage": 13435,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -4997,7 +4997,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 1681,
+        "usage": 1634,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5032,7 +5032,7 @@
         "date": "2025-12-23",
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 185,
+        "usage": 184,
         "io": {
           "inputs": [
             {
@@ -5075,7 +5075,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 492,
+        "usage": 478,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5293,7 +5293,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 839,
+        "usage": 817,
         "io": {
           "inputs": [
             {
@@ -5476,7 +5476,7 @@
         "models": ["Grok"],
         "date": "2026-01-28",
         "openSource": false,
-        "usage": 342,
+        "usage": 336,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -5542,7 +5542,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 247,
+        "usage": 241,
         "io": {
           "inputs": [
             {
@@ -5588,7 +5588,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 538,
+        "usage": 524,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -5807,7 +5807,7 @@
         "date": "2025-11-26",
         "size": 74088185856,
         "vram": 74088185856,
-        "usage": 1031,
+        "usage": 1015,
         "io": {
           "inputs": [
             {
@@ -5874,7 +5874,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 384,
+        "usage": 379,
         "io": {
           "inputs": [
             {
@@ -6102,7 +6102,7 @@
         "date": "2025-11-26",
         "size": 71403831296,
         "vram": 71403831296,
-        "usage": 115,
+        "usage": 113,
         "io": {
           "outputs": [
             {
@@ -6206,7 +6206,7 @@
         "date": "2026-01-27",
         "size": 20830591386,
         "vram": 20830591386,
-        "usage": 398,
+        "usage": 395,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/z-image/z-image",
         "searchRank": 0,
         "openSource": true,
@@ -6370,7 +6370,7 @@
         "models": ["Anima"],
         "date": "2025-05-07",
         "openSource": true,
-        "usage": 814,
+        "usage": 810,
         "size": 5583457485,
         "vram": 5583457485,
         "searchRank": 0,
@@ -6480,7 +6480,7 @@
         "date": "2025-12-31",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 242,
+        "usage": 238,
         "searchRank": 0,
         "openSource": true,
         "io": {
@@ -6742,7 +6742,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 50,
+        "usage": 47,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -6826,7 +6826,7 @@
         "date": "2026-01-16",
         "size": 19219978650,
         "vram": 19219978650,
-        "usage": 156,
+        "usage": 160,
         "openSource": true,
         "searchRank": 0,
         "username": "ComfyUI",
@@ -6887,7 +6887,7 @@
         "date": "2026-01-16",
         "size": 17072495002,
         "vram": 9878424781,
-        "usage": 225,
+        "usage": 222,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
         "searchRank": 0,
         "openSource": true,
@@ -7016,7 +7016,7 @@
         "openSource": true,
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 26,
+        "usage": 25,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7045,7 +7045,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 85,
+        "usage": 79,
         "io": {
           "inputs": [
             {
@@ -7101,7 +7101,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 35,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -7127,7 +7127,7 @@
         "date": "2026-01-16",
         "size": 19327352832,
         "vram": 23300197581,
-        "usage": 508,
+        "usage": 509,
         "openSource": true,
         "searchRank": 0,
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-2-klein",
@@ -7163,7 +7163,7 @@
         "date": "2025-12-02",
         "size": 23837068493,
         "vram": 23837068493,
-        "usage": 114,
+        "usage": 115,
         "io": {
           "inputs": [
             {
@@ -7304,7 +7304,7 @@
         "models": ["Qwen-Image 2512"],
         "date": "2026-01-30",
         "openSource": true,
-        "usage": 72,
+        "usage": 71,
         "username": "ComfyUI",
         "size": 32427003085,
         "vram": 32427003085,
@@ -7334,7 +7334,7 @@
         "date": "2025-06-26",
         "size": 17609365914,
         "vram": 17609365914,
-        "usage": 111,
+        "usage": 112,
         "io": {
           "inputs": [
             {
@@ -7397,7 +7397,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 101,
+        "usage": 100,
         "io": {
           "inputs": [
             {
@@ -7483,7 +7483,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 34144990003,
-        "usage": 173,
+        "usage": 174,
         "io": {
           "inputs": [
             {
@@ -7520,7 +7520,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/flux/flux-1-uso",
         "size": 18575733555,
         "vram": 19864223744,
-        "usage": 148,
+        "usage": 145,
         "io": {
           "inputs": [
             {
@@ -7620,7 +7620,7 @@
         "openSource": true,
         "size": 37044092928,
         "vram": 37044092928,
-        "usage": 22,
+        "usage": 21,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -7746,7 +7746,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 34,
+        "usage": 37,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -7771,7 +7771,7 @@
         "models": ["Kling O1"],
         "date": "2026-01-05",
         "openSource": false,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "outputs": [
             {
@@ -7885,7 +7885,7 @@
         "date": "2025-07-31",
         "size": 22226455757,
         "vram": 22226455757,
-        "usage": 105,
+        "usage": 104,
         "io": {
           "outputs": [
             {
@@ -7940,7 +7940,7 @@
         "date": "2025-11-26",
         "size": 56586194125,
         "vram": 56586194125,
-        "usage": 33,
+        "usage": 34,
         "io": {
           "inputs": [
             {
@@ -7981,7 +7981,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 149,
+        "usage": 145,
         "username": "ComfyUI"
       },
       {
@@ -7996,7 +7996,7 @@
         "date": "2025-03-01",
         "size": 34144990003,
         "vram": 23622320128,
-        "usage": 126,
+        "usage": 124,
         "io": {
           "outputs": [
             {
@@ -8025,7 +8025,7 @@
         "date": "2025-03-01",
         "size": 10372346020,
         "vram": 10372346020,
-        "usage": 55,
+        "usage": 53,
         "io": {
           "inputs": [
             {
@@ -8076,7 +8076,7 @@
         "date": "2025-08-05",
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 100,
+        "usage": 96,
         "io": {
           "outputs": [
             {
@@ -8268,7 +8268,7 @@
         "date": "2025-12-15",
         "size": 31772020572,
         "vram": 31772020572,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8294,7 +8294,7 @@
         "date": "2025-09-12",
         "size": 36013300777,
         "vram": 36013300777,
-        "usage": 80,
+        "usage": 81,
         "io": {
           "inputs": [
             {
@@ -8319,7 +8319,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 84,
+        "usage": 85,
         "io": {
           "inputs": [
             {
@@ -8343,7 +8343,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 15,
+        "usage": 12,
         "io": {
           "inputs": [
             {
@@ -8384,7 +8384,7 @@
         "models": ["BRIA"],
         "date": "2026-01-20",
         "openSource": false,
-        "usage": 6,
+        "usage": 5,
         "io": {
           "inputs": [
             {
@@ -8419,7 +8419,7 @@
         "date": "2025-03-01",
         "size": 23590107873,
         "vram": 23590107873,
-        "usage": 15,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -8444,7 +8444,7 @@
         "date": "2025-11-03",
         "size": 41446434406,
         "vram": 41446434406,
-        "usage": 22,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8516,7 +8516,7 @@
         "date": "2025-03-01",
         "size": 14935748772,
         "vram": 14935748772,
-        "usage": 37,
+        "usage": 38,
         "username": "ComfyUI"
       },
       {
@@ -8531,7 +8531,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 20,
+        "usage": 19,
         "username": "ComfyUI"
       },
       {
@@ -8547,7 +8547,7 @@
         "date": "2025-03-01",
         "size": 34177202258,
         "vram": 34177202258,
-        "usage": 13,
+        "usage": 14,
         "io": {
           "inputs": [
             {
@@ -8571,7 +8571,7 @@
         "date": "2025-10-10",
         "size": 10630044058,
         "vram": 10630044058,
-        "usage": 249,
+        "usage": 246,
         "tutorialUrl": "https://docs.comfy.org/tutorials/image/newbie-image/newbie-image-exp-0-1",
         "searchRank": 0,
         "openSource": true,
@@ -8601,7 +8601,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 11,
+        "usage": 10,
         "io": {
           "inputs": [
             {
@@ -8627,7 +8627,7 @@
         "date": "2025-03-01",
         "size": 35433480192,
         "vram": 35433480192,
-        "usage": 49,
+        "usage": 47,
         "io": {
           "inputs": [
             {
@@ -8680,7 +8680,7 @@
         "date": "2025-03-01",
         "size": 6936372183,
         "vram": 6936372183,
-        "usage": 96,
+        "usage": 95,
         "username": "ComfyUI"
       },
       {
@@ -8696,7 +8696,7 @@
         "date": "2025-08-23",
         "size": 32749125632,
         "vram": 32749125632,
-        "usage": 18,
+        "usage": 20,
         "io": {
           "inputs": [
             {
@@ -8732,7 +8732,7 @@
         "date": "2025-08-24",
         "size": 34037615821,
         "vram": 34037615821,
-        "usage": 20,
+        "usage": 21,
         "io": {
           "inputs": [
             {
@@ -8799,7 +8799,7 @@
         "date": "2025-12-19",
         "size": 16213501542,
         "vram": 16213501542,
-        "usage": 173,
+        "usage": 172,
         "openSource": true,
         "searchRank": 0,
         "io": {
@@ -8953,7 +8953,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 62,
+        "usage": 61,
         "io": {
           "inputs": [
             {
@@ -8990,7 +8990,7 @@
         "date": "2025-03-01",
         "size": 35154307318,
         "vram": 35154307318,
-        "usage": 37,
+        "usage": 38,
         "io": {
           "inputs": [
             {
@@ -9132,7 +9132,7 @@
         "date": "2025-05-01",
         "size": 34252364186,
         "vram": 34252364186,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -9282,7 +9282,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "io": {
           "inputs": [
             {
@@ -9509,7 +9509,7 @@
         "date": "2025-12-02",
         "size": 20228222222,
         "vram": 20228222222,
-        "usage": 33,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9569,7 +9569,7 @@
         "date": "2025-03-01",
         "size": 13013750907,
         "vram": 13013750907,
-        "usage": 30,
+        "usage": 31,
         "username": "ComfyUI"
       },
       {
@@ -9699,7 +9699,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 4,
+        "usage": 3,
         "io": {
           "inputs": [
             {
@@ -9789,7 +9789,7 @@
         "openSource": true,
         "size": 51324859187,
         "vram": 51324859187,
-        "usage": 858,
+        "usage": 837,
         "io": {
           "inputs": [
             {
@@ -10143,7 +10143,7 @@
         "searchRank": 8,
         "size": 31245887078,
         "vram": 31245887078,
-        "usage": 327,
+        "usage": 319,
         "io": {
           "inputs": [
             {
@@ -10242,7 +10242,7 @@
         "openSource": true,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 627,
+        "usage": 617,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -10332,7 +10332,7 @@
         "openSource": false,
         "size": 28776280883,
         "vram": 28776280883,
-        "usage": 282,
+        "usage": 286,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -10534,7 +10534,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 49,
+        "usage": 50,
         "searchRank": 0,
         "username": "hellorob",
         "io": {
@@ -10802,7 +10802,7 @@
         "openSource": false,
         "size": 48962627174,
         "vram": 48962627174,
-        "usage": 110,
+        "usage": 108,
         "searchRank": 0,
         "username": "sirolim",
         "io": {
@@ -10843,7 +10843,7 @@
         "openSource": true,
         "size": 21474836480,
         "vram": 21474836480,
-        "usage": 568,
+        "usage": 559,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11093,7 +11093,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 108,
+        "usage": 106,
         "searchRank": 0,
         "username": "ohneis652",
         "thumbnail": ["thumbnail/templates_ohneis_i2v-1.png","thumbnail/templates_ohneis_i2v-2.png"]
@@ -11157,7 +11157,7 @@
         "includeOnDistributions": ["cloud"],
         "size": 0,
         "vram": 0,
-        "usage": 262,
+        "usage": 264,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11197,7 +11197,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 37,
+        "usage": 36,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11249,7 +11249,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 246,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11276,7 +11276,7 @@
         "date": "2026-01-26",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 86,
+        "usage": 85,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -11311,7 +11311,7 @@
         "openSource": true,
         "size": 31138512896,
         "vram": 31138512896,
-        "usage": 51,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11358,7 +11358,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 72,
+        "usage": 71,
         "searchRank": 0,
         "username": "sferro21",
         "io": {
@@ -11402,7 +11402,7 @@
         "openSource": true,
         "size": 27809913242,
         "vram": 27809913242,
-        "usage": 428,
+        "usage": 426,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11478,7 +11478,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 98,
+        "usage": 96,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11527,7 +11527,7 @@
         "openSource": true,
         "size": 31782757990,
         "vram": 31782757990,
-        "usage": 61,
+        "usage": 63,
         "searchRank": 0,
         "username": "shane",
         "isApp": true
@@ -11659,7 +11659,7 @@
         "openSource": false,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 95,
+        "usage": 90,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11692,7 +11692,7 @@
         "models": ["Gemini3 Pro Image Preview","Google","Nano Banana Pro"],
         "date": "2026-01-13",
         "openSource": false,
-        "usage": 64,
+        "usage": 63,
         "logos": [
           {
             "provider": "Google"
@@ -11759,7 +11759,7 @@
         "date": "2025-12-20",
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 59,
         "io": {
           "inputs": [
             {
@@ -11830,7 +11830,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 76,
+        "usage": 75,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -11868,7 +11868,7 @@
         "openSource": false,
         "size": 41983305318,
         "vram": 41983305318,
-        "usage": 77,
+        "usage": 78,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11910,7 +11910,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 163,
+        "usage": 164,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -11938,7 +11938,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 79,
+        "usage": 77,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12112,7 +12112,7 @@
         "openSource": false,
         "size": 58841051955,
         "vram": 58841051955,
-        "usage": 115,
+        "usage": 114,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12323,7 +12323,7 @@
         "searchRank": 8,
         "size": 31198642438,
         "vram": 31198642438,
-        "usage": 34,
+        "usage": 33,
         "io": {
           "inputs": [
             {
@@ -12409,7 +12409,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 68,
+        "usage": 66,
         "io": {
           "inputs": [
             {
@@ -12472,7 +12472,7 @@
         "openSource": false,
         "size": 134002979635,
         "vram": 134002979635,
-        "usage": 30,
+        "usage": 29,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12498,7 +12498,7 @@
         "date": "2026-01-13",
         "openSource": false,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 33,
+        "usage": 34,
         "logos": [
           {
             "provider": "Google"
@@ -12542,7 +12542,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 205,
+        "usage": 201,
         "logos": [
           {
             "provider": "Google"
@@ -12582,7 +12582,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 38,
+        "usage": 39,
         "logos": [
           {
             "provider": "ByteDance"
@@ -12633,7 +12633,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 456,
+        "usage": 458,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -12767,7 +12767,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 30,
+        "usage": 29,
         "logos": [
           {
             "provider": ["ByteDance","Google"]
@@ -12845,7 +12845,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "io": {
           "inputs": [
             {
@@ -13287,7 +13287,7 @@
         "searchRank": 8,
         "size": 0,
         "vram": 0,
-        "usage": 41,
+        "usage": 42,
         "logos": [
           {
             "provider": "Google"
@@ -13413,7 +13413,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui-kjnodes","comfyui_essentials"],
-        "usage": 11,
+        "usage": 10,
         "logos": [
           {
             "provider": "Google"
@@ -13840,7 +13840,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 130,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13904,7 +13904,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 29,
+        "usage": 28,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -13975,7 +13975,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 25,
+        "usage": 26,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14066,7 +14066,7 @@
         "openSource": false,
         "size": 9985798963,
         "vram": 9985798963,
-        "usage": 12,
+        "usage": 11,
         "searchRank": 0,
         "io": {
           "outputs": [
@@ -14092,7 +14092,7 @@
         "openSource": true,
         "size": 14710262989,
         "vram": 14710262989,
-        "usage": 48,
+        "usage": 45,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14164,7 +14164,7 @@
         "size": 0,
         "vram": 0,
         "requiresCustomNodes": ["comfyui_fill-chatterbox"],
-        "usage": 96,
+        "usage": 93,
         "searchRank": 0,
         "tags": ["音频","语音克隆"],
         "io": {
@@ -14191,7 +14191,7 @@
         "models": ["Chatter Box"],
         "size": 0,
         "vram": 0,
-        "usage": 36,
+        "usage": 38,
         "searchRank": 0,
         "tags": ["音频","文本转语音","语音克隆"],
         "io": {
@@ -14274,7 +14274,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 17,
+        "usage": 16,
         "io": {
           "inputs": [
             {
@@ -14299,7 +14299,7 @@
         "tutorialUrl": "https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1",
         "size": 7698728878,
         "vram": 7698728878,
-        "usage": 3,
+        "usage": 2,
         "username": "ComfyUI"
       },
       {
@@ -14597,7 +14597,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 47,
+        "usage": 46,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14640,7 +14640,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 46,
+        "usage": 47,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -14798,7 +14798,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 158,
+        "usage": 156,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -14873,7 +14873,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 21,
+        "usage": 22,
         "io": {
           "inputs": [
             {
@@ -14899,7 +14899,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 51,
+        "usage": 50,
         "io": {
           "inputs": [
             {
@@ -15020,7 +15020,7 @@
         "tutorialUrl": "",
         "size": 4928474972,
         "vram": 4928474972,
-        "usage": 123,
+        "usage": 126,
         "io": {
           "inputs": [
             {
@@ -15669,7 +15669,7 @@
         "openSource": true,
         "size": 8053063680,
         "vram": 8053063680,
-        "usage": 30,
+        "usage": 31,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/llm_qwen3_text_gen.png"]
@@ -15899,7 +15899,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 211,
+        "usage": 213,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15938,7 +15938,7 @@
         "openSource": true,
         "size": 17716740096,
         "vram": 17716740096,
-        "usage": 675,
+        "usage": 674,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -15974,7 +15974,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 121,
+        "usage": 117,
         "searchRank": 0,
         "logos": [
           {
@@ -16019,7 +16019,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 106,
+        "usage": 105,
         "searchRank": 0,
         "username": "ComfyUI",
         "io": {
@@ -16060,7 +16060,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 131,
+        "usage": 129,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16206,7 +16206,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 250,
+        "usage": 247,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16280,7 +16280,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 100,
+        "usage": 99,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -16985,7 +16985,7 @@
         "openSource": true,
         "size": 1932735283,
         "vram": 1932735283,
-        "usage": 32,
+        "usage": 34,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17078,7 +17078,7 @@
         "openSource": true,
         "size": 10737418240,
         "vram": 10737418240,
-        "usage": 21,
+        "usage": 20,
         "searchRank": 0,
         "username": "PurzBeats",
         "io": {
@@ -17111,7 +17111,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 54,
+        "usage": 53,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17183,7 +17183,7 @@
         "openSource": true,
         "size": 16750372454,
         "vram": 16750372454,
-        "usage": 151,
+        "usage": 149,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17298,7 +17298,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 31,
+        "usage": 30,
         "searchRank": 0,
         "logos": [
           {
@@ -17362,7 +17362,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 74,
+        "usage": 76,
         "searchRank": 0,
         "logos": [
           {
@@ -17450,7 +17450,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 56,
+        "usage": 54,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -17509,7 +17509,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 33,
+        "usage": 34,
         "searchRank": 0,
         "logos": [
           {
@@ -17623,7 +17623,7 @@
         "openSource": false,
         "size": 0,
         "vram": 0,
-        "usage": 61,
+        "usage": 62,
         "searchRank": 0,
         "logos": [
           {
@@ -17744,7 +17744,7 @@
         "models": ["FlashVSR","WaveSpeed"],
         "date": "2026-01-23",
         "openSource": false,
-        "usage": 51,
+        "usage": 50,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17803,7 +17803,7 @@
         "models": ["Qwen-Image-Layered"],
         "date": "2026-01-15",
         "openSource": true,
-        "usage": 22,
+        "usage": 23,
         "io": {
           "inputs": [
             {
@@ -17831,7 +17831,7 @@
             "provider": "Vidu"
           }
         ],
-        "usage": 27,
+        "usage": 28,
         "io": {
           "inputs": [
             {
@@ -17902,7 +17902,7 @@
         "models": ["Magnific"],
         "date": "2026-01-26",
         "openSource": false,
-        "usage": 117,
+        "usage": 118,
         "size": 0,
         "vram": 0,
         "searchRank": 0,
@@ -17943,7 +17943,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 65,
+        "usage": 63,
         "io": {
           "inputs": [
             {
@@ -18008,7 +18008,7 @@
         "models": ["Real-ESRGAN"],
         "date": "2026-01-26",
         "openSource": true,
-        "usage": 57,
+        "usage": 58,
         "io": {
           "inputs": [
             {
@@ -18034,7 +18034,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 626,
+        "usage": 687,
         "io": {
           "inputs": [
             {
@@ -18143,7 +18143,7 @@
         "date": "2026-01-12",
         "openSource": true,
         "requiresCustomNodes": ["comfyui-videohelpersuite","comfyui_controlnet_aux"],
-        "usage": 44,
+        "usage": 45,
         "io": {
           "inputs": [
             {
@@ -18207,7 +18207,7 @@
         "openSource": true,
         "size": 0,
         "vram": 0,
-        "usage": 19,
+        "usage": 18,
         "searchRank": 0,
         "io": {
           "inputs": [
@@ -18321,7 +18321,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 62,
         "searchRank": 0,
         "username": "ComfyUI"
       },
@@ -18408,7 +18408,7 @@
         "openSource": true,
         "size": 20723217203,
         "vram": 20723217203,
-        "usage": 63,
+        "usage": 64,
         "searchRank": 0,
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates_purz_batch_generation.mp4"],

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -9811,7 +9811,8 @@
         "username": "ComfyUI",
         "thumbnail": ["thumbnail/templates-qwen_multiangle.png"],
         "tags": ["图片编辑"],
-        "searchRank": 0
+        "searchRank": 0,
+        "isApp": true
       },
       {
         "name": "template_seedance2_storyboard_to_video",
@@ -10395,7 +10396,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"]
+        "thumbnail": ["input/templates_rob_image_to_real-input.png","output/templates_rob_image_to_real.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_wan_ati_motion_control",
@@ -10557,7 +10559,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_1.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_2.app",
@@ -10596,7 +10599,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_2.png"],
+        "isApp": true
       },
       {
         "name": "template_contact_sheet-step_3.app",
@@ -10664,7 +10668,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"]
+        "thumbnail": ["thumbnail/template_contact_sheet-step_3.mp4"],
+        "isApp": true
       },
       {
         "name": "template_character_portrait_relighting",
@@ -10999,7 +11004,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_qwen_image_illustration_lora.png"]
+        "thumbnail": ["output/template_qwen_image_illustration_lora.png"],
+        "isApp": true
       },
       {
         "name": "template_sugar_coated_gummy_style_qwen",
@@ -11026,7 +11032,8 @@
             }
           ]
         },
-        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"]
+        "thumbnail": ["output/template_sugar_coated_gummy_style_qwen.png"],
+        "isApp": true
       },
       {
         "name": "template_eric_thumbnail_generator",
@@ -11169,7 +11176,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"]
+        "thumbnail": ["thumbnail/templates_rob_fashion_shoot_vton-4in1_app.png"],
+        "isApp": true
       },
       {
         "name": "templates_rob_kling3_0_multishot_llm_product",
@@ -11254,7 +11262,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"]
+        "thumbnail": ["thumbnail/templates_rob_realistic_2k_images_quick_variations_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-multiple_consistent_shots-nb_pro",
@@ -11329,7 +11338,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"]
+        "thumbnail": ["input/input_1-relight.png","output/templates_rob_portrait_light_migration_app.png"],
+        "isApp": true
       },
       {
         "name": "template_sferro21_product_ad.app",
@@ -11375,7 +11385,8 @@
             }
           ]
         },
-        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"]
+        "thumbnail": ["thumbnail/template_sferro21_product_ad.png"],
+        "isApp": true
       },
       {
         "name": "templates_hellorob_facegen_skindetail_upscale",
@@ -11500,7 +11511,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"]
+        "thumbnail": ["input/gas_lamp.png","output/templates_3d_match_game_art_style-1.png"],
+        "isApp": true
       },
       {
         "name": "templates_text_prompt_to_360hdr.app",
@@ -11517,7 +11529,8 @@
         "vram": 31782757990,
         "usage": 61,
         "searchRank": 0,
-        "username": "shane"
+        "username": "shane",
+        "isApp": true
       },
       {
         "name": "template_graphic_color_remixer",
@@ -11585,7 +11598,8 @@
           ]
         },
         "username": "shane",
-        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"]
+        "thumbnail": ["input/live_portrait_expression.mp4","output/templates_liveportrait.mp4"],
+        "isApp": true
       },
       {
         "name": "template_sirolim_image_script_video",
@@ -12353,7 +12367,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"]
+        "thumbnail": ["thumbnail/templates-1_input-multiple_styles_prompt_app.mp4"],
+        "isApp": true
       },
       {
         "name": "templates-photo_to_product_vid",
@@ -12550,7 +12565,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_product_swap_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-product_scene_relight",
@@ -13070,7 +13086,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"]
+        "thumbnail": ["thumbnail/templates-subject_holding_product_app.png"],
+        "isApp": true
       },
       {
         "name": "templates-textured_logotype-v2.1",
@@ -15903,7 +15920,8 @@
           ]
         },
         "username": "hellorob",
-        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"]
+        "thumbnail": ["input/fighter_jet.png","output/utility_z_image_turbo_2k_upscaler.png"],
+        "isApp": true
       },
       {
         "name": "utility_seedvr2_image_upscale",


### PR DESCRIPTION
Adds `isApp` to `templates/index.json`, derived from each workflow's own `extra.linearMode`.

Raised by @ChristianByrne in #frontend: *"putting the 'is app' on the index file. Then we can add filter anywhere."*

## Why

Whether a workflow opens as an App or as a node graph is the author's choice, stored in the workflow itself as `extra.linearMode`. `index.json` never carried it, so consumers guessed from the filename and treated anything ending in `.app` as an App.

**That guess is wrong in both directions.** Measured against the 574 entries:

| | |
| --- | --- |
| Names ending `.app` | 17 |
| Actually App Mode | 18 |
| `.app` but **not** App Mode | `templates_all_in_one_image_edit_models.app` |
| App Mode but **not** `.app` | `template_qwen_image_illustration_lora`, `template_sugar_coated_gummy_style_qwen` |

So the in-app template browser, which does `template.name.endsWith('.app')` in `WorkflowTemplateSelectorDialog.vue`, mislabels three workflows today. The same guess is what showed 14 apps instead of 55 on the hub site.

Renaming files would not fix it: the filename is a side effect of how a workflow was saved, not a record of what it is.

## How

`scripts/sync/sync_is_app.py` reads each workflow file sitting next to the index, so it needs no network and no hub call.

```
python scripts/sync/sync_is_app.py            # write
python scripts/sync/sync_is_app.py --dry-run  # report
python scripts/sync/sync_is_app.py --check    # non-zero exit when stale (CI gate)
```

`isApp` is written only when true, matching how the other optional booleans in this file behave and keeping the diff to the 18 entries that changed.

Two details worth knowing:

- Absent and `false` both mean node graph. `linearMode` only carries meaning as "the author chose App Mode".
- The serialiser joins arrays without a space after the comma, which is how the committed `index.json` is written. `sync_custom_nodes.py` adds one, and using its formatter here rewrote every tag line for a 5,883-line diff.

## What this unblocks

The in-app template browser can read a real field instead of the filename, and gain the Apps filter it does not have today (its filters are Model, Use Case and Runs On only). That is a separate PR in `ComfyUI_frontend` and depends on this landing first.

It does **not** cover the 37 apps published through the hub admin panel that never entered this repo. Christian noted the single-source-of-truth problem is already a tracked project.

## Verification

- `--check` clean and idempotent after writing
- `index.json` still parses: 8 categories, 574 templates, 18 with `isApp: true`
- Diff is 18 `isApp` lines plus their trailing commas, no reformatting
- `docs/SPEC.md` updated with the field and an explicit note not to infer it from the filename

Note: `validate_templates.py` could not run locally (`jsonschema` not installed); CI will cover it.
