### PR TITLE
fix(templates): replace leaked internal note in Seedance 2.5 FLF2V default prompt

### DIFF
--- a/packages/core/src/comfyui_workflow_templates_core/manifest.json
+++ b/packages/core/src/comfyui_workflow_templates_core/manifest.json
@@ -9217,7 +9217,7 @@
       "assets": [
         {
           "filename": "api_seedance2_5_flf2v.json",
-          "sha256": "59dbc7274dd7b30155edec9ff60dffea65078ee5c10cb380a7efb05009ad3554"
+          "sha256": "96ce26ce40cdf5878f740469f0d07bda5e6e225bbfbe0dd8215ceba1182bd587"
         },
         {
           "filename": "api_seedance2_5_flf2v-1.webp",

--- a/templates/api_seedance2_5_flf2v.json
+++ b/templates/api_seedance2_5_flf2v.json
@@ -81,7 +81,7 @@
       },
       "widgets_values": [
         "Seedance 2.5",
-        "Hi  @Alexis , we plan to open weight a new music model next week at 8.12. Your access has been enabled. Let’s aim for Day‑0 ComfyUI integration.",
+        "Cinematic aerial shot, smooth continuous camera movement: the drone slowly descends and pushes in toward the pool below. First frame: high wide aerial view of a sunlit pastel resort, a large empty turquoise pool with a crowd gathered along its edge. Last frame: overhead close-up of the same pool now packed with people celebrating in the water, arms raised and drinks in hand, parasols and inflatables around the deck. Bright midday sunlight, sparkling water reflections, warm summer color grading, photorealistic, hyper-detailed 8K, no text overlays.",
         "720p",
         5,
         true,


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Problem

The `api_seedance2_5_flf2v` template ("Seedance 2.5: FLF2V") shipped with an internal message baked in as the default `prompt` value on the `ByteDance2FirstLastFrameNode`:

Anyone opening the default template in ComfyUI saw this text in the node UI. Introduced in #1101 (`Wan Animate 2 and Seedance2.5 templates`).

Fixes PN-825 — https://linear.app/comfyorg/issue/PN-825

## Fix

Replaced the leaked text with a generic cinematic prompt. The replacement describes the transition actually shown by the template's own bundled assets (`pool_start_frame.png` → `pool_end_frame.png`: an aerial wide of an empty resort pool ringed by a crowd → an overhead close-up of that pool packed with partiers), which also matches the "empty-to-packed" example called out in this template's `index.json` description:

> Cinematic aerial shot, smooth continuous camera movement: the drone slowly descends and pushes in toward the pool below. First frame: high wide aerial view of a sunlit pastel resort, a large empty turquoise pool with a crowd gathered along its edge. Last frame: overhead close-up of the same pool now packed with people celebrating in the water, arms raised and drinks in hand, parasols and inflatables around the deck. Bright midday sunlight, sparkling water reflections, warm summer color grading, photorealistic, hyper-detailed 8K, no text overlays.

The style follows the sibling FLF2V templates (`api_seedance2_0_flf2v`, `api_bytedance_seedance1_5_flf2v`), which use the same "first frame: … last frame: …" camera-move phrasing.

`packages/core/.../manifest.json` is regenerated (`npm run sync:bundles`) for the new asset SHA256 — required, or `validate:manifests` fails.

## Scope

Two lines, one string value. No other widget values changed — verified in a live graph that every widget still maps to its original value (`720p`, duration `5`, `generate_audio` true, `mp4`, seed `0`, `randomize`, watermark false, empty asset ids), so no `widgets_values` array shift.

Grepped every repo in the workspace for the leaked string — this template JSON was the only source occurrence. The copy under `packages/json/.../templates/` is gitignored and build-generated; it regenerates correctly from this change.

## Verification

- `npm run validate:templates` — ✅ all validations passed
- `npm run validate:manifests` — ✅ no errors (82 pre-existing unrelated warnings about unreferenced template files)
- `pytest packages/core/tests` — ✅ 38 passed
- Spellcheck unaffected — CI only spellchecks `MarkdownNote`/`Note` nodes and `index.json` title/description; confirmed via `extract_workflow_text.py` that this prompt is not in the spellcheck corpus
- **End-to-end**: started ComfyUI (`--cpu`) + frontend dev server, confirmed the backend serves the corrected prompt from `/templates/api_seedance2_5_flf2v.json`, then loaded the template into a real graph and inspected the node

The screenshot below is the same node from the bug report, now showing a normal prompt, with both input frames loading and no errors.


## Screenshots

![Seedance 2.5 FLF2V template loaded in ComfyUI: the ByteDance Seedance 2.5 First-Last-Frame to Video node now shows a generic cinematic pool-party prompt, with pool_start_frame.png and pool_end_frame.png loading correctly and no errors](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ee665bf158b74579b033680f36a558552013b335189fa772fc43a804bc4f6053/pr-images/1786153047499-54421465-9b2b-4bc6-a0ed-f913ddf3c4d6.png)

![Close-up of the node with the prompt field expanded, showing the full replacement prompt text](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/ee665bf158b74579b033680f36a558552013b335189fa772fc43a804bc4f6053/pr-images/1786153047875-b4a9c943-4358-4c72-9208-0433083d362c.png)