### PR TITLE
fix(site): stop localized listing pages inviting indexing while gated

### DIFF
--- a/site/src/lib/i18n/listing-indexing.ts
+++ b/site/src/lib/i18n/listing-indexing.ts
@@ -1,0 +1,65 @@
+/**
+ * Indexing decisions for a localized *listing* page — the hub index, a category,
+ * a tag, a model, the creators list. Anything whose content is an aggregate
+ * rather than one workflow.
+ *
+ * `resolveLocalizedWorkflow` already answers this for workflow detail pages, from
+ * that workflow's own freshness, completeness and review state. A listing has no
+ * single workflow to judge: it renders whatever currently matches the filter, and
+ * its own chrome comes from the UI-string bundle. So the gate is the locale
+ * itself — the page may be indexed exactly when that locale has completed its
+ * native-review wave and been added to `INDEXABLE_LOCALES`.
+ *
+ * Decided in one place because the same four surfaces have to agree, and the
+ * detail pages show how easily they drift apart: canonical, robots, the hreflang
+ * cluster, and (through the canonical) what the sitemap may advertise. A page
+ * that noindexes itself while still self-canonicalling and advertising alternates
+ * is a page telling search engines two different things.
+ */
+import { DEFAULT_LOCALE } from '../../i18n/config';
+import { localizeUrl } from '../../i18n/utils';
+import { INDEXABLE_LOCALES } from './locales';
+import type { Locale } from './schema';
+
+export interface ListingIndexing {
+  /** Whether this localized listing may be indexed at all. */
+  indexable: boolean;
+  /**
+   * Localized path when indexable; the English path otherwise. Pointing a gated
+   * page at its English equivalent is the "safety by canonical" the detail pages
+   * rely on: an un-reviewed translation can never become the indexed version of
+   * the route, only English can.
+   */
+  canonicalPath: string;
+  /** Convenience inverse of `indexable`, matching BaseLayout's prop. */
+  noindex: boolean;
+  /**
+   * Locales to advertise as alternates. Empty until the locale is flipped on, so
+   * only x-default is emitted. Google discards an hreflang cluster that points at
+   * noindexed alternates, so advertising ten gated locales is worse than silence.
+   */
+  hreflangLocales: Locale[];
+}
+
+/**
+ * @param basePath Route without the locale prefix, e.g. `/workflows/` or
+ *                 `/workflows/category/image/`.
+ */
+export function listingIndexing(
+  basePath: string,
+  locale: Locale,
+  indexableLocales: readonly Locale[] = INDEXABLE_LOCALES
+): ListingIndexing {
+  const indexable = locale !== DEFAULT_LOCALE && indexableLocales.includes(locale);
+
+  return {
+    indexable,
+    canonicalPath: indexable ? localizeUrl(basePath, locale) : basePath,
+    noindex: !indexable,
+    // Advertise the English original alongside the flipped locales only — never a
+    // locale that is still gated, and never a cluster while nothing is flipped.
+    hreflangLocales: indexable
+      ? [DEFAULT_LOCALE, ...indexableLocales.filter((l) => l !== DEFAULT_LOCALE)]
+      : [],
+  };
+}

--- a/site/src/lib/i18n/listing-indexing.ts
+++ b/site/src/lib/i18n/listing-indexing.ts
@@ -63,3 +63,19 @@ export function listingIndexing(
       : [],
   };
 }
+
+/**
+ * The alternates a page may advertise once every reason to withhold it is known.
+ *
+ * The locale gate is not always the only one. A model page is also withheld when
+ * it is too thin to be worth indexing, and that decision is made further down the
+ * page, after its content has loaded. Reading `hreflangLocales` straight off the
+ * locale gate in that case would advertise a cluster for a page the very same
+ * render is marking `noindex` — two contradictory signals about one URL.
+ *
+ * Passing the page's final `noindex` through here keeps them in step by
+ * construction, so a caller cannot forget to reconcile them by hand.
+ */
+export function alternatesFor(indexing: ListingIndexing, noindex: boolean): Locale[] {
+  return noindex ? [] : indexing.hreflangLocales;
+}

--- a/site/src/pages/[locale]/workflows/category/[type].astro
+++ b/site/src/pages/[locale]/workflows/category/[type].astro
@@ -10,7 +10,6 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import HubNavbar from '../../../../components/hub/HubNavbar.astro';
 import SiteFooter from '../../../../components/hub/SiteFooter.astro';
 import WorkflowGrid from '../../../../components/hub/WorkflowGrid.vue';
-import HreflangTags from '../../../../components/HreflangTags.astro';
 import BackButton from '../../../../components/BackButton.astro';
 import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../../i18n/config';
 import { t } from '../../../../i18n/ui';
@@ -21,6 +20,7 @@ import { badgeVariants } from '../../../../components/ui/badge';
 import { loadSerializedTemplates, type MediaType } from '../../../../lib/hub-api';
 import { buildToolbarLabels } from '../../../../lib/toolbar';
 import { serializeJsonLdForScript, buildWorkflowBreadcrumb } from '../../../../lib/structured-data';
+import { listingIndexing } from '../../../../lib/i18n/listing-indexing';
 
 const validTypes: MediaType[] = ['image', 'video', 'audio', '3d'];
 
@@ -71,7 +71,9 @@ if (templates.length === 0) {
 }
 
 const basePath = categoryPath(mediaType);
-const canonicalUrl = absoluteUrl(localizeUrl(basePath, typedLocale));
+// Gated until this locale completes native review — see listing-indexing.
+const indexing = listingIndexing(basePath, typedLocale);
+const canonicalUrl = absoluteUrl(indexing.canonicalPath);
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -96,10 +98,11 @@ const serialized = templates;
   structuredData={structuredData}
   locale={typedLocale}
   hreflangBasePath={basePath}
+  hreflangLocales={indexing.hreflangLocales}
+  noindex={indexing.noindex}
   theme="dark"
   hideDefaultFooter
 >
-  <HreflangTags slot="head" basePath={basePath} />
   <HubNavbar />
   <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-16 py-12">
     <!-- Back -->

--- a/site/src/pages/[locale]/workflows/creators.astro
+++ b/site/src/pages/[locale]/workflows/creators.astro
@@ -14,6 +14,7 @@ import BackButton from '../../../components/BackButton.astro';
 import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
 import { creatorPath } from '../../../lib/routes';
 import { absoluteUrl } from '../../../config/site';
+import { listingIndexing } from '../../../lib/i18n/listing-indexing';
 import { listWorkflowIndex, getProfileCache, serializeIndexEntry, type SerializedTemplate } from '../../../lib/hub-api';
 import { fetchRankingMap } from '../../../lib/ranking';
 
@@ -64,7 +65,9 @@ const sortedCreators = Array.from(creatorMap.values()).sort(
   (a, b) => b.templates.length - a.templates.length
 );
 
-const canonicalUrl = absoluteUrl(`/${locale}/workflows/creators/`);
+// Gated until this locale completes native review — see listing-indexing.
+const indexing = listingIndexing('/workflows/creators/', typedLocale);
+const canonicalUrl = absoluteUrl(indexing.canonicalPath);
 ---
 
 <BaseLayout
@@ -72,6 +75,9 @@ const canonicalUrl = absoluteUrl(`/${locale}/workflows/creators/`);
   description="Discover the world's top ComfyUI workflow creators and their best templates."
   canonicalUrl={canonicalUrl}
   locale={typedLocale}
+  hreflangBasePath="/workflows/creators/"
+  hreflangLocales={indexing.hreflangLocales}
+  noindex={indexing.noindex}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/src/pages/[locale]/workflows/index.astro
+++ b/site/src/pages/[locale]/workflows/index.astro
@@ -21,6 +21,7 @@ import { absoluteUrl } from '../../../config/site';
 import { loadSerializedTemplates } from '../../../lib/hub-api';
 import { getFeatured, featuredPreloadImage } from '../../../lib/featured';
 import { buildToolbarLabels, buildFacetsConfig } from '../../../lib/toolbar';
+import { listingIndexing } from '../../../lib/i18n/listing-indexing';
 
 const { locale } = Astro.params;
 
@@ -36,7 +37,11 @@ const serialized = await loadSerializedTemplates(() => getCollection('templates'
 const featured = getFeatured(serialized);
 const featuredLcpImage = featuredPreloadImage(featured);
 
-const canonicalUrl = absoluteUrl('/' + locale + '/workflows/');
+// Gated until this locale completes native review: canonical to the English hub,
+// noindex, and no alternates. Without this the listing self-canonicals and
+// advertises all ten locales while every workflow page under it is noindexed.
+const indexing = listingIndexing('/workflows/', typedLocale);
+const canonicalUrl = absoluteUrl(indexing.canonicalPath);
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -68,6 +73,8 @@ const facetsConfig = buildFacetsConfig(typedLocale);
   structuredData={structuredData}
   locale={typedLocale}
   hreflangBasePath="/workflows/"
+  hreflangLocales={indexing.hreflangLocales}
+  noindex={indexing.noindex}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/src/pages/[locale]/workflows/model/[name].astro
+++ b/site/src/pages/[locale]/workflows/model/[name].astro
@@ -28,6 +28,7 @@ import {
   buildWorkflowBreadcrumb,
   serializeJsonLdForScript,
 } from '../../../../lib/structured-data';
+import { listingIndexing } from '../../../../lib/i18n/listing-indexing';
 
 const buildGroups = async () =>
   deriveModelGroups(await loadSerializedTemplates(() => getCollection('templates')));
@@ -72,7 +73,9 @@ if (family.slug !== name) {
 
 const matchingTemplates = family.templates;
 const basePath = modelPath(family.slug);
-const canonicalUrl = absoluteUrl(localizeUrl(basePath, typedLocale));
+// Gated until this locale completes native review — see listing-indexing.
+const indexing = listingIndexing(basePath, typedLocale);
+const canonicalUrl = absoluteUrl(indexing.canonicalPath);
 
 // Localized pages carry no editorial copy of their own, but title/meta/noindex
 // resolve through the same helper as the English route so the hreflang cluster
@@ -84,7 +87,10 @@ const { h1, title, description } = buildModelPageMeta({
   locale: typedLocale,
   templateCount: matchingTemplates.length,
 });
-const noindex = !isModelPageIndexable(family, matchingTemplates.length, content);
+// Two independent reasons to withhold this page: the model page is too thin to
+// index, or its locale has not been reviewed yet. Either alone is sufficient.
+const noindex =
+  indexing.noindex || !isModelPageIndexable(family, matchingTemplates.length, content);
 
 const countLabel =
   matchingTemplates.length === 1
@@ -119,6 +125,7 @@ const serialized = matchingTemplates;
   structuredData={structuredData}
   locale={typedLocale}
   hreflangBasePath={basePath}
+  hreflangLocales={indexing.hreflangLocales}
   noindex={noindex}
   theme="dark"
   hideDefaultFooter

--- a/site/src/pages/[locale]/workflows/model/[name].astro
+++ b/site/src/pages/[locale]/workflows/model/[name].astro
@@ -28,7 +28,7 @@ import {
   buildWorkflowBreadcrumb,
   serializeJsonLdForScript,
 } from '../../../../lib/structured-data';
-import { listingIndexing } from '../../../../lib/i18n/listing-indexing';
+import { listingIndexing, alternatesFor } from '../../../../lib/i18n/listing-indexing';
 
 const buildGroups = async () =>
   deriveModelGroups(await loadSerializedTemplates(() => getCollection('templates')));
@@ -91,6 +91,9 @@ const { h1, title, description } = buildModelPageMeta({
 // index, or its locale has not been reviewed yet. Either alone is sufficient.
 const noindex =
   indexing.noindex || !isModelPageIndexable(family, matchingTemplates.length, content);
+// Alternates follow the final decision, not just the locale gate: a page withheld
+// for thin content must not advertise a cluster the same render is noindexing.
+const hreflangLocales = alternatesFor(indexing, noindex);
 
 const countLabel =
   matchingTemplates.length === 1
@@ -125,7 +128,7 @@ const serialized = matchingTemplates;
   structuredData={structuredData}
   locale={typedLocale}
   hreflangBasePath={basePath}
-  hreflangLocales={indexing.hreflangLocales}
+  hreflangLocales={hreflangLocales}
   noindex={noindex}
   theme="dark"
   hideDefaultFooter

--- a/site/src/pages/[locale]/workflows/tag/[tag].astro
+++ b/site/src/pages/[locale]/workflows/tag/[tag].astro
@@ -10,17 +10,16 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import HubNavbar from '../../../../components/hub/HubNavbar.astro';
 import SiteFooter from '../../../../components/hub/SiteFooter.astro';
 import WorkflowGrid from '../../../../components/hub/WorkflowGrid.vue';
-import HreflangTags from '../../../../components/HreflangTags.astro';
 import BackButton from '../../../../components/BackButton.astro';
 import { LOCALES, DEFAULT_LOCALE, type Locale } from '../../../../i18n/config';
 import { t } from '../../../../i18n/ui';
-import { localizeUrl } from '../../../../i18n/utils';
 import { tagSlug, tagDisplayName } from '../../../../lib/tag-aliases';
 import { absoluteUrl, SITE_NAME } from '../../../../config/site';
 import { badgeVariants } from '../../../../components/ui/badge';
 import { loadSerializedTemplates } from '../../../../lib/hub-api';
 import { buildToolbarLabels } from '../../../../lib/toolbar';
 import { serializeJsonLdForScript, buildWorkflowBreadcrumb } from '../../../../lib/structured-data';
+import { listingIndexing } from '../../../../lib/i18n/listing-indexing';
 
 const { locale, tag } = Astro.params;
 
@@ -58,7 +57,9 @@ const firstMatchingTag =
 const tagName = tagDisplayName(firstMatchingTag);
 
 const basePath = `/workflows/tag/${tag}/`;
-const canonicalUrl = absoluteUrl(localizeUrl(basePath, typedLocale));
+// Gated until this locale completes native review — see listing-indexing.
+const indexing = listingIndexing(basePath, typedLocale);
+const canonicalUrl = absoluteUrl(indexing.canonicalPath);
 
 const title = `${tagName} ${SITE_NAME} - ${t('nav.templates', typedLocale)}`;
 // Localized (falls back to English until the CI locale step translates the new
@@ -90,10 +91,11 @@ const serialized = matchingTemplates;
   structuredData={structuredData}
   locale={typedLocale}
   hreflangBasePath={basePath}
+  hreflangLocales={indexing.hreflangLocales}
+  noindex={indexing.noindex}
   theme="dark"
   hideDefaultFooter
 >
-  <HreflangTags basePath={basePath} slot="head" />
   <script
     is:inline
     type="application/ld+json"

--- a/site/tests/unit/i18n-listing-indexing.test.ts
+++ b/site/tests/unit/i18n-listing-indexing.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { listingIndexing } from '../../src/lib/i18n/listing-indexing';
+import { INDEXABLE_LOCALES } from '../../src/lib/i18n/locales';
+import type { Locale } from '../../src/lib/i18n/schema';
+
+const BASE = '/workflows/category/image/';
+
+describe('listingIndexing — gated locale (the shipped state)', () => {
+  // Every localized listing is gated today because INDEXABLE_LOCALES is empty.
+  // These assert the four surfaces agree while gated, which is what was wrong:
+  // the pages self-canonicalled and advertised ten alternates with no noindex,
+  // while every workflow page beneath them was correctly noindexed.
+  it('does not mark a listing indexable while its locale is unreviewed', () => {
+    expect(listingIndexing(BASE, 'zh' as Locale, []).indexable).toBe(false);
+  });
+
+  it('canonicals to the English route rather than to itself', () => {
+    expect(listingIndexing(BASE, 'zh' as Locale, []).canonicalPath).toBe(BASE);
+  });
+
+  it('emits noindex', () => {
+    expect(listingIndexing(BASE, 'zh' as Locale, []).noindex).toBe(true);
+  });
+
+  it('advertises no alternates, so only x-default is emitted', () => {
+    // A cluster pointing at noindexed alternates is discarded by Google, so
+    // advertising the gated locales is worse than advertising nothing.
+    expect(listingIndexing(BASE, 'zh' as Locale, []).hreflangLocales).toEqual([]);
+  });
+});
+
+describe('listingIndexing — flipped locale', () => {
+  const flipped = ['zh'] as readonly Locale[];
+
+  it('self-canonicals once the locale is added to INDEXABLE_LOCALES', () => {
+    const result = listingIndexing(BASE, 'zh' as Locale, flipped);
+    expect(result.indexable).toBe(true);
+    expect(result.canonicalPath).toBe('/zh/workflows/category/image/');
+    expect(result.noindex).toBe(false);
+  });
+
+  it('advertises English plus the flipped locales, and nothing else', () => {
+    const result = listingIndexing(BASE, 'zh' as Locale, flipped);
+    expect(result.hreflangLocales).toEqual(['en', 'zh']);
+  });
+
+  it('still gates a locale that has NOT been flipped, in the same run', () => {
+    // The per-locale rollout: flipping zh must not quietly open ja.
+    const result = listingIndexing(BASE, 'ja' as Locale, flipped);
+    expect(result.indexable).toBe(false);
+    expect(result.canonicalPath).toBe(BASE);
+    expect(result.hreflangLocales).toEqual([]);
+  });
+});
+
+describe('listingIndexing — invariants', () => {
+  it('never treats the default locale as a gated localized route', () => {
+    // English is the canonical target, never a page that canonicals elsewhere.
+    const result = listingIndexing(BASE, 'en' as Locale, ['en'] as readonly Locale[]);
+    expect(result.indexable).toBe(false);
+    expect(result.canonicalPath).toBe(BASE);
+  });
+
+  it('keeps noindex the exact inverse of indexable', () => {
+    for (const locales of [[], ['zh']] as readonly Locale[][]) {
+      for (const locale of ['zh', 'ja', 'en'] as Locale[]) {
+        const r = listingIndexing(BASE, locale, locales);
+        expect(r.noindex).toBe(!r.indexable);
+      }
+    }
+  });
+
+  it('only ever self-canonicals a page it also allows to be indexed', () => {
+    // The contradiction this module exists to prevent: a noindexed page that
+    // still names itself as the canonical version of the route.
+    for (const locales of [[], ['zh'], ['zh', 'ja']] as readonly Locale[][]) {
+      for (const locale of ['zh', 'ja', 'ko', 'en'] as Locale[]) {
+        const r = listingIndexing(BASE, locale, locales);
+        if (r.canonicalPath !== BASE) expect(r.indexable).toBe(true);
+      }
+    }
+  });
+
+  it('defaults to the real INDEXABLE_LOCALES when none is passed', () => {
+    // Pins the production default so a flip in locales.ts flows through here.
+    const expected = INDEXABLE_LOCALES.includes('zh' as Locale);
+    expect(listingIndexing(BASE, 'zh' as Locale).indexable).toBe(expected);
+  });
+});

--- a/site/tests/unit/i18n-listing-indexing.test.ts
+++ b/site/tests/unit/i18n-listing-indexing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { listingIndexing } from '../../src/lib/i18n/listing-indexing';
+import { alternatesFor, listingIndexing } from '../../src/lib/i18n/listing-indexing';
 import { INDEXABLE_LOCALES } from '../../src/lib/i18n/locales';
 import type { Locale } from '../../src/lib/i18n/schema';
 
@@ -85,5 +85,41 @@ describe('listingIndexing — invariants', () => {
     // Pins the production default so a flip in locales.ts flows through here.
     const expected = INDEXABLE_LOCALES.includes('zh' as Locale);
     expect(listingIndexing(BASE, 'zh' as Locale).indexable).toBe(expected);
+  });
+});
+
+describe('alternatesFor — pages withheld for a reason beyond the locale gate', () => {
+  // The model page is also withheld when it is too thin to index, decided after
+  // its content loads. Reading hreflangLocales straight off the locale gate would
+  // then advertise a cluster for a page the same render marks noindex.
+  const flipped = ['zh'] as readonly Locale[];
+
+  it('advertises nothing when the page is noindexed despite a flipped locale', () => {
+    const indexing = listingIndexing('/workflows/model/wan/', 'zh' as Locale, flipped);
+    expect(indexing.noindex).toBe(false); // the locale gate alone would allow it
+    expect(indexing.hreflangLocales).toEqual(['en', 'zh']);
+
+    // ...but the page itself is withheld for its own reason.
+    expect(alternatesFor(indexing, true)).toEqual([]);
+  });
+
+  it('keeps the cluster when nothing withholds the page', () => {
+    const indexing = listingIndexing('/workflows/model/wan/', 'zh' as Locale, flipped);
+    expect(alternatesFor(indexing, false)).toEqual(['en', 'zh']);
+  });
+
+  it('stays empty for a gated locale whatever the page-level decision is', () => {
+    const indexing = listingIndexing('/workflows/model/wan/', 'zh' as Locale, []);
+    expect(alternatesFor(indexing, true)).toEqual([]);
+    expect(alternatesFor(indexing, false)).toEqual([]);
+  });
+
+  it('never advertises alternates from a noindexed page, across every combination', () => {
+    for (const locales of [[], ['zh'], ['zh', 'ja']] as readonly Locale[][]) {
+      for (const locale of ['zh', 'ja', 'en'] as Locale[]) {
+        const indexing = listingIndexing('/workflows/model/wan/', locale, locales);
+        expect(alternatesFor(indexing, true)).toEqual([]);
+      }
+    }
   });
 });


### PR DESCRIPTION
Localized workflow **detail** pages are correctly withheld from search while `INDEXABLE_LOCALES` is empty: `noindex`, canonical pointing at the English equivalent, no alternates advertised.

The **listing** pages above them did the opposite.

## What I measured on production, before changing anything

| Route | robots | canonical | hreflang alternates |
| --- | --- | --- | --- |
| `/zh/workflows/` | *(none)* | self, `/zh/workflows/` | all 11 locales |
| `/zh/workflows/creators/` | *(none)* | self | all 11 |
| `/zh/workflows/category/image/` | *(none)* | self | all 11, **emitted twice** |
| `/zh/workflows/tag/video/` | *(none)* | self | all 11, **emitted twice** |
| `/zh/workflows/model/wan/` | *(none)* | self | all 11 |
| `/zh/workflows/<slug>/` (detail) | `noindex,follow` | English | x-default only |

So the site invited Google to index un-reviewed machine-translated listings, pointed it at ten alternates that are themselves noindexed (Google discards such a cluster), and did this while every page those listings link to says "do not index me".

## The rule

A listing has no single workflow whose freshness could be judged — it renders whatever currently matches the filter. So the gate is the locale itself: **indexable exactly when that locale is in `INDEXABLE_LOCALES`.**

`listingIndexing()` decides all four surfaces in one place (canonical, robots, hreflang, and via the canonical what the sitemap may claim). The detail pages show how easily these drift apart, and a page that noindexes itself while still self-canonicalling is telling search engines two different things.

## Verified on rendered HTML, not just unit tests

Built the site and served it, then read the actual `<head>`:

**With nothing flipped (what ships today)** — all five locale listing types:
```
robots=noindex,follow   alternates=x-default only   canonical=https://comfy.org/workflows/...
```

**With `zh` temporarily flipped on** (then reverted — `locales.ts` is untouched in this PR):
```
/zh/workflows/   robots=(none)  canonical=https://comfy.org/zh/workflows/  alternates=en, zh, x-default
/ja/workflows/   robots=noindex,follow  canonical=https://comfy.org/workflows/  alternates=x-default
```

That last line is the important one: flipping `zh` does **not** open `ja`. The per-locale rollout still works, and this is not a blanket permanent noindex.

English is unchanged: `/workflows/` still emits 12 alternates and no robots directive.

## Also here: a duplicate hreflang cluster

`SEOHead` already emits hreflang for every page, computing a base path when none is passed. The localized category and tag pages *also* rendered a standalone `<HreflangTags slot="head">`, so every alternate was emitted twice (24 tags instead of 12). Removed on those two pages, where `hreflangBasePath` is passed explicitly so the output is provably identical minus the duplication.

**The English category and tag routes have the same duplication and are deliberately left alone** — they do not pass `hreflangBasePath`, so removing theirs depends on `SEOHead`s computed path matching. Happy to do it as a follow-up.

## Checks

- 409 unit tests pass, including 11 new ones for the helper (gated, flipped, per-locale isolation, and the invariant that a page is only ever self-canonical when it is also indexable)
- `eslint --max-warnings 0` clean
- `astro check` — 0 errors
- Full production build succeeds

`creators.astro` still fails Prettier on a long import that predates this PR (line 17 at `main`); left as-is rather than adding unrelated churn.