### PR TITLE
fix(site): show portrait video heroes uncropped

### DIFF
--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -13,6 +13,7 @@ import { slugify } from '../../lib/slugify';
 import { creatorPath } from '../../lib/routes';
 import { tagSlug, tagDisplayName } from '../../lib/tag-aliases';
 import { getProfileCache, type MediaType, type ThumbnailVariant } from '../../lib/hub-api';
+import { isVideoFile } from '../../lib/media-utils';
 import { featureFlags } from '../../config/featureFlags';
 import { buttonVariants } from '../ui/button';
 import { cn } from '../../lib/utils';
@@ -51,6 +52,9 @@ const authorName = profile?.display_name || data.username || 'ComfyUI';
 const authorAvatarUrl = profile?.avatar_url || null;
 const authorProfileUrl = data.username ? creatorPath(data.username, locale) : null;
 const thumbnails = data.detailImages?.length ? data.detailImages : data.thumbnails || [];
+// Only video heroes can turn out to be portrait; the client script below measures
+// the loaded file and opts those pages out of the cover crop.
+const heroIsVideo = thumbnails.length > 0 && isVideoFile(thumbnails[0]);
 const showCloudCta = !data.includeOnDistributions || data.includeOnDistributions.includes('cloud');
 const isApiTemplate = data.tags?.includes('API') ?? false;
 const cloudTemplateId = data.shareId || data.name;
@@ -245,7 +249,10 @@ function formatRelativeDate(dateStr: string): string {
 
       {
         thumbnails.length > 0 && (
-          <div class="order-1 lg:order-2 lg:col-start-2 media-frame relative aspect-4/3 w-full max-w-full overflow-hidden rounded-lg">
+          <div
+            class="order-1 lg:order-2 lg:col-start-2 media-frame relative aspect-4/3 w-full max-w-full overflow-hidden rounded-lg"
+            data-portrait-aware={heroIsVideo ? '' : undefined}
+          >
             <ThumbnailDisplay
               thumbnails={thumbnails}
               title={data.title || data.name}
@@ -378,4 +385,67 @@ function formatRelativeDate(dateStr: string): string {
     height: 100%;
     object-fit: cover;
   }
+  /* Portrait videos only: a 4:3 cover crop would discard most of a 9:16 frame,
+     so the sharp video is contained over a blurred ambient copy of itself.
+     Landscape and square videos keep the cover crop above. */
+  .media-frame[data-portrait] :global(video:not(.video-backdrop)) {
+    position: relative;
+    z-index: 1;
+    object-fit: contain;
+  }
+  .media-frame[data-portrait] :global(.video-backdrop) {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    object-fit: cover;
+    filter: blur(48px) brightness(0.55);
+    transform: scale(1.2);
+  }
+  @media (max-width: 1023px) {
+    .media-frame[data-portrait] {
+      aspect-ratio: auto;
+    }
+    .media-frame[data-portrait] :global(.video-thumb) {
+      position: static;
+      height: auto;
+    }
+    .media-frame[data-portrait] :global(video:not(.video-backdrop)) {
+      height: auto;
+      max-height: min(70vh, 42rem);
+      margin-inline: auto;
+    }
+    .media-frame[data-portrait] :global(.video-backdrop) {
+      display: none;
+    }
+  }
 </style>
+
+<script>
+  // The hub index carries no video dimensions, so portrait heroes can only be
+  // identified once metadata loads. Landscape and square videos are left alone.
+  document.querySelectorAll<HTMLElement>('.media-frame[data-portrait-aware]').forEach((frame) => {
+    const video = frame.querySelector<HTMLVideoElement>('video:not(.video-backdrop)');
+    if (!video) return;
+
+    function applyIfPortrait() {
+      if (!video!.videoWidth || video!.videoHeight <= video!.videoWidth) return;
+      frame.setAttribute('data-portrait', '');
+
+      const backdrop = document.createElement('video');
+      backdrop.src = video!.currentSrc || video!.src;
+      backdrop.className = 'video-backdrop';
+      backdrop.muted = true;
+      backdrop.loop = true;
+      backdrop.autoplay = true;
+      backdrop.playsInline = true;
+      backdrop.setAttribute('aria-hidden', 'true');
+      backdrop.tabIndex = -1;
+      video!.parentElement?.prepend(backdrop);
+      void backdrop.play().catch(() => backdrop.remove());
+    }
+
+    if (video.readyState >= 1) applyIfPortrait();
+    else video.addEventListener('loadedmetadata', applyIfPortrait, { once: true });
+  });
+</script>

--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -442,7 +442,23 @@ function formatRelativeDate(dateStr: string): string {
       backdrop.setAttribute('aria-hidden', 'true');
       backdrop.tabIndex = -1;
       video!.parentElement?.prepend(backdrop);
-      void backdrop.play().catch(() => backdrop.remove());
+
+      // A backdrop that cannot play is dropped, but the foreground is still a
+      // portrait video, so `contain` remains the right treatment for it.
+      const dropBackdrop = () => backdrop.remove();
+
+      // If the foreground fails, ThumbnailDisplay swaps in its fallback image.
+      // The ambient copy would otherwise keep playing behind it, and
+      // `data-portrait` also restyles the frame and `.video-thumb` on mobile, so
+      // the whole portrait treatment has to come off, not just the backdrop.
+      const revertPortrait = () => {
+        backdrop.remove();
+        frame.removeAttribute('data-portrait');
+      };
+
+      video!.addEventListener('error', revertPortrait, { once: true });
+      backdrop.addEventListener('error', dropBackdrop, { once: true });
+      void backdrop.play().catch(dropBackdrop);
     }
 
     if (video.readyState >= 1) applyIfPortrait();


### PR DESCRIPTION
## Problem

The workflow view page (`/workflows/[slug]`) renders its hero in a 4:3 frame with `object-fit: cover`. That is fine for landscape and square videos, but a portrait upload loses most of the frame. The reported page ([/workflows/f4e29143100c-f4e29143100c/](https://comfy.org/workflows/f4e29143100c-f4e29143100c/)) is a 1080x1920 asset: ~65% of every frame was cut off, and because it stacks a clip above storyboard panels, the crop cut through content rather than trimming edges.

Linear: GTM-412 (its duplicate GTM-378 covers the publish-flow previews separately).

## Fix

Scoped to portrait videos only. Everything else renders exactly as it does today.

- Portrait video heroes: sharp video `object-fit: contain` over a blurred ambient copy of itself, and below `lg` the frame drops the fixed ratio so the video presents at its natural height.
- Landscape videos, square videos, and all image heroes: unchanged markup and unchanged 4:3 cover crop.
- The hub index carries no video dimensions, so orientation is measured client-side on `loadedmetadata`; only a file reporting `videoHeight > videoWidth` opts in, and the ambient backdrop element is created at that point. A poster-based backdrop is not possible here because `getVideoFrameUrl` only supports the legacy engcomfy.com CDN and hub uploads on comfy-hub-assets.comfy.org have no poster frames.

## Verification

Playwright against a local build, desktop and mobile:

| Page | Video | Result |
| --- | --- | --- |
| f4e29143100c (reported) | 1080x1920 portrait | Full frame visible; 901x676 contained over ambient fill, 342x591 natural on mobile |
| 40a427168ef7 | 1080x1080 square | 901x676 cover, identical to production |
| 9ed4f6b88b6a | 1280x720 landscape | 901x676 cover, identical to production |
| 0309de53eb52 | image compare-slider | Unchanged |

Prettier and ESLint clean. Full e2e runs in site CI.

## Notes for review

- No design-blessed spec exists for non-4:3 heroes (GTM-378's confirm-with-design step never happened); the ambient-fill pattern follows TikTok/YouTube portrait handling.
- Follow-up candidates: store video dimensions at publish time (removes the client-side measurement and the brief pre-metadata state), and generate poster frames for comfy-hub-assets uploads, which currently have none at all.

Desktop and mobile screenshots to be attached in a comment below.