### PR TITLE
fix(packages): regenerate the core manifest after the isApp index change

### DIFF
--- a/packages/core/src/comfyui_workflow_templates_core/manifest.json
+++ b/packages/core/src/comfyui_workflow_templates_core/manifest.json
@@ -6353,7 +6353,7 @@
       "assets": [
         {
           "filename": "index.json",
-          "sha256": "5325ec3cd1be74197e9b28039abe1a2ac44220256dd84f13896d5a06f086ef8f"
+          "sha256": "92e649e733a1667e5e5fa26795ebfc0210ecbfc58d56890f11aef83c4380466e"
         }
       ],
       "cdn": {
@@ -6367,7 +6367,7 @@
       "assets": [
         {
           "filename": "index.ar.json",
-          "sha256": "a28d0045d4fa8915e82a130117b1d19b912fedf28d617be325ee855cdc49f76f"
+          "sha256": "73ea3d016bad6dfd398c7fb0d080717957a56870c6809a6aafeb941877045a90"
         }
       ],
       "cdn": {
@@ -6381,7 +6381,7 @@
       "assets": [
         {
           "filename": "index.es.json",
-          "sha256": "1ffbe847f7cd80f7e851a41aea137e5305abefd84ffb11cc8945553440b65c42"
+          "sha256": "95761b94cc8aa721931f357be9049a0c3c3cb0adc935f85f711333a4f5a78969"
         }
       ],
       "cdn": {
@@ -6395,7 +6395,7 @@
       "assets": [
         {
           "filename": "index.fa.json",
-          "sha256": "bd208632166479e32aff2cb2f5d59691919bb8850f64b4ad71a81b977bce2b56"
+          "sha256": "ffb79b290044616d24330d14cf35ffe7e0224aeae647d1a45aef4c720309aa7e"
         }
       ],
       "cdn": {
@@ -6409,7 +6409,7 @@
       "assets": [
         {
           "filename": "index.fr.json",
-          "sha256": "27dc5ab54daf34b3893a1b749e7fec9c4c8e4a0425eb4e7508fd48dd0bef6338"
+          "sha256": "737b592f1f51771b2f762e417fcc55980ca19a05cd6d63d8585081fa0a106890"
         }
       ],
       "cdn": {
@@ -6423,7 +6423,7 @@
       "assets": [
         {
           "filename": "index.ja.json",
-          "sha256": "eb61b84cc9fa73edb9dcc601c672e5b76f7f4abf742aa627985a6634a9da9c50"
+          "sha256": "88223cb77ee2ed87e5131f51c6702cc81d751935168068c38e0f787b57be6e60"
         }
       ],
       "cdn": {
@@ -6437,7 +6437,7 @@
       "assets": [
         {
           "filename": "index.ko.json",
-          "sha256": "20db00b3a9c8a12345fdc473fe120194fe241eb7ae0321cfcc80f0ecb3c1a852"
+          "sha256": "27076c322179125af60d112fbb5e751ea22ffb92ae87c6b3d3bc01a2eebbe481"
         }
       ],
       "cdn": {
@@ -6465,7 +6465,7 @@
       "assets": [
         {
           "filename": "index.pt-BR.json",
-          "sha256": "0a6c128a3fef74f85b002ceab77e09adb53d15bc45d6b5f8ef4b5f252c6af7a2"
+          "sha256": "3db1883e637bd7f93f45134bb4729bd910438458c505e64957a4cd91735e48b9"
         }
       ],
       "cdn": {
@@ -6479,7 +6479,7 @@
       "assets": [
         {
           "filename": "index.ru.json",
-          "sha256": "093c39596834c6393dff89c82c7236b04e7288ca3b4db45ad21701f1d35fbdc0"
+          "sha256": "95ff0939d7397918bf0c4c33675f9809ba647f742525eb8d0fcda20c41e82d3d"
         }
       ],
       "cdn": {
@@ -6493,7 +6493,7 @@
       "assets": [
         {
           "filename": "index.schema.json",
-          "sha256": "9a79552aead4135bd0a7d111d636c4940c98d12d2bf6bafa87554a341ac222a2"
+          "sha256": "5834ac1a31bd3d0281a3fda2f27015eb65dfefee0cdc48d56567b0095bc38a2d"
         }
       ],
       "cdn": {
@@ -6507,7 +6507,7 @@
       "assets": [
         {
           "filename": "index.tr.json",
-          "sha256": "905627e1ab6a83677be5e8964e58262a08a72099cb8c3b6aaaa29f03c79ccfc8"
+          "sha256": "c4b6491becbd4944a20e0c2a7c9f559763f98212699a52ecef384d4a4fd2a918"
         }
       ],
       "cdn": {
@@ -6521,7 +6521,7 @@
       "assets": [
         {
           "filename": "index.zh.json",
-          "sha256": "ab893f76ae702ef89fa5a4426b55ffb8f3bc581b21a0a55694aed191760a186b"
+          "sha256": "bbc22e3b32aaf50ab56c395ab2949020c92480e69f92155276371bb9b2f37249"
         }
       ],
       "cdn": {
@@ -6535,7 +6535,7 @@
       "assets": [
         {
           "filename": "index.zh-TW.json",
-          "sha256": "c4ac807cb8007f6e7f393d18a1d753732d8486387c295fc270ebb28e0bee542d"
+          "sha256": "8d8f82ab55db12f187e99c846a146d1c59e7d2e11f2a28804d1114c417a75cb5"
         }
       ],
       "cdn": {


### PR DESCRIPTION
Unbreaks `main`. `Build & Test` and `Validate Manifests` have been red since #1104 merged, with 39 stale-hash errors.

#1104 added `isApp` to `templates/index.json` and the eleven locale files. The committed manifest records a sha256 per index file, so those hashes went stale. Regenerated with `python scripts/sync/sync_bundles.py`.

Only sha256 values change. No template added, removed or reassigned. `validate_manifests.py` reports no errors afterwards (the 84 warnings are pre-existing unreferenced-template notices, unchanged by this).

Same failure and fix as #1094 after PR 1088.

**Why it was not caught on the PR:** `Validate Manifests` triggers on `templates/**`, but the manifest lives under `packages/`. A PR that edits an index file without running the bundle sync passes its own checks and only breaks once it lands on main. Worth a follow-up to make that gate catch it pre-merge.