### PR TITLE
ci(site): stop the preview deploy uploading the whole repository

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,5 +1,6 @@
-# The preview deploy runs `vercel deploy --cwd <repo root> --prebuilt --archive=tgz`
-# (.github/workflows/preview-site.yml). `--archive=tgz` tars the whole working
+# Both preview deploys run `vercel deploy --cwd <repo root> --prebuilt --archive=tgz`:
+# .github/workflows/preview-site.yml (per pull request) and preview-cron.yml
+# (nightly). They share this ignore list. `--archive=tgz` tars the whole working
 # directory, while a prebuilt deploy needs only `.vercel/output`, so without this
 # file every preview uploads gigabytes of repository content. That upload dies
 # intermittently with "Error: fetch failed" partway through, which reads on a PR
@@ -40,6 +41,8 @@
 /README.md
 
 # Sources and dependencies. The build already ran, and its output was copied to
-# the repo-root .vercel/output before this deploy step.
+# the repo-root .vercel/output before this deploy step. `/site` already covers
+# site/node_modules, so this rule is anchored too rather than left to match at
+# any depth, where it could strike a bundled dependency inside .vercel/output.
 /site
-node_modules
+/node_modules

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,45 @@
+# The preview deploy runs `vercel deploy --cwd <repo root> --prebuilt --archive=tgz`
+# (.github/workflows/preview-site.yml). `--archive=tgz` tars the whole working
+# directory, while a prebuilt deploy needs only `.vercel/output`, so without this
+# file every preview uploads gigabytes of repository content. That upload dies
+# intermittently with "Error: fetch failed" partway through, which reads on a PR
+# as broken code rather than as a transfer too large to be reliable.
+#
+# Every pattern is anchored with a leading slash on purpose. An unanchored rule
+# matches at any depth, so a bare `output` would also exclude `.vercel/output`
+# and deploy nothing at all.
+#
+# Listed explicitly rather than ignoring everything and re-including the output,
+# so a rule here can never exclude the artifact being deployed.
+
+# Fixtures and generated artifacts. The two largest directories in the repo.
+/input
+/output
+/archived
+
+# Template payload: the site loads thumbnails from the CDN, not from these.
+/templates
+/thumbnail
+/blueprints
+
+# Python packaging and tooling, unrelated to the built site.
+/packages
+/scripts
+/tools
+/setup.py
+/pyproject.toml
+/MANIFEST.in
+/run_full_validation.sh
+
+# Documentation and repo meta.
+/docs
+/.github
+/.claude
+/AGENTS.md
+/CLAUDE.md
+/README.md
+
+# Sources and dependencies. The build already ran, and its output was copied to
+# the repo-root .vercel/output before this deploy step.
+/site
+node_modules


### PR DESCRIPTION
## The failure

The `preview` job dies partway through its upload:

```
Uploading [===============-----] (1.3GB/1.8GB)
Error: fetch failed
##[error]Process completed with exit code 1.
```

It reads on a PR as broken code. It is a transfer large enough to be unreliable, and it succeeds or fails by luck rather than by anything in the diff.

## Why 1.8GB

Both `preview-site.yml` (per PR) and `preview-cron.yml` (nightly) deploy the same way:

```
npx vercel@latest deploy --cwd "$GITHUB_WORKSPACE" --prebuilt --archive=tgz
```

`--archive=tgz` tars the whole working directory, and there was no `.vercelignore`. A prebuilt deploy reads only `.vercel/output`, which the step copies to the repo root a few lines above, so the rest of the tar is dead weight:

| Directory | Tracked size |
| --- | --- |
| `input` | 1.9 GB |
| `output` | 933 MB |
| `templates` | 497 MB |
| `thumbnail` | 362 MB |
| `docs` | 128 MB |
| `site` | 48 MB |

Roughly 3.9GB of tracked content, plus `node_modules`, compressed into the 1.8GB that fails to upload.

## The change

One new file, `.vercelignore`, excluding what a prebuilt deploy never reads.

**Every pattern is anchored with a leading slash, deliberately.** `.vercelignore` uses gitignore matching, where an unanchored pattern matches at any depth. A bare `output` would also exclude `.vercel/output` and deploy an empty site, and a bare `node_modules` would strike a bundled dependency inside the output. `/site` already covers `site/node_modules`, so anchoring costs nothing.

Exclusions are listed explicitly rather than ignoring everything and re-including the output, so no rule here can exclude the artifact being deployed.

## Verification

- All 21 patterns confirmed anchored, and all 20 paths confirmed to exist at the repo root
- Checked that no pattern can match `.vercel/output`

**This PR cannot verify itself, which is worth stating plainly.** `preview-site.yml` triggers on `paths: ['site/**']` and this changes only a root file, so the `preview` check does not run here. I verified it instead by dispatching **Preview Site** manually against this branch via `workflow_dispatch`, which exercises the real deploy under the new ignore list. The upload size in that run's log is the measurement.

Nothing outside CI is touched, and no site code changes.
