### PR TITLE
fix(site): compare publish dates by day, not by raw string

### DIFF
--- a/site/src/lib/partner-nodes.ts
+++ b/site/src/lib/partner-nodes.ts
@@ -56,7 +56,21 @@ export function wasScannedForPartnerNodes(
   const scannedDate = SCANNED_AT.get(shareId);
   if (scannedDate === undefined) return false;
   // No date to compare means the claim cannot be checked, so it is not made.
-  return !!publishedDate && scannedDate === publishedDate;
+  if (!publishedDate) return false;
+  return publishDay(scannedDate) === publishDay(publishedDate);
+}
+
+/**
+ * The calendar day of a publish date, whichever endpoint it came from.
+ *
+ * The two sides of this comparison are populated from different endpoints and
+ * arrive in different shapes: the snapshot records the index's `date`
+ * (`2025-07-29`), while a detail page passes `publish_time` (`2025-07-29T00:00:00Z`).
+ * Comparing the raw strings matches nothing, which silently bills every scanned
+ * workflow instead of only re-published ones.
+ */
+function publishDay(value: string): string {
+  return value.slice(0, 10);
 }
 
 /**

--- a/site/tests/unit/partner-nodes.test.ts
+++ b/site/tests/unit/partner-nodes.test.ts
@@ -141,9 +141,29 @@ describe('publish dates from different endpoints', () => {
     expect(isBillableWorkflow(['Image'], id, `${scannedDate}T00:00:00Z`)).toBe(false);
   });
 
+  // The day after the scan, not a far-future date. A distant year passes even if
+  // the comparison is truncated to the year, so it would not notice normalising
+  // away more than the time component.
+  const nextDay = (iso: string) => {
+    const d = new Date(`${iso.slice(0, 10)}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() + 1);
+    return d.toISOString().slice(0, 10);
+  };
+
   it('still rejects a different day in either shape', () => {
-    const [id] = cleanEntry;
-    expect(wasScannedForPartnerNodes(id, '2099-01-01')).toBe(false);
-    expect(wasScannedForPartnerNodes(id, '2099-01-01T00:00:00Z')).toBe(false);
+    const [id, scannedDate] = cleanEntry;
+    const stale = nextDay(scannedDate);
+    expect(stale.slice(0, 4)).toBe(scannedDate.slice(0, 4));
+    expect(wasScannedForPartnerNodes(id, stale)).toBe(false);
+    expect(wasScannedForPartnerNodes(id, `${stale}T00:00:00Z`)).toBe(false);
+  });
+
+  // Through the public entry point too, in both shapes: that is the one the page
+  // calls, and normalising the day must not soften the stale-date verdict.
+  it('bills a re-published workflow whichever shape the date arrives in', () => {
+    const [id, scannedDate] = cleanEntry;
+    const stale = nextDay(scannedDate);
+    expect(isBillableWorkflow(['Image'], id, stale)).toBe(true);
+    expect(isBillableWorkflow(['Image'], id, `${stale}T00:00:00Z`)).toBe(true);
   });
 });

--- a/site/tests/unit/partner-nodes.test.ts
+++ b/site/tests/unit/partner-nodes.test.ts
@@ -125,3 +125,25 @@ describe('the committed snapshot', () => {
     expect(PARTNER_NODE_SNAPSHOT_META.apiNodeCount).toBeGreaterThan(0);
   });
 });
+
+/**
+ * The two sides of the freshness check come from different endpoints and arrive
+ * in different shapes. The index gives `2025-07-29`; a detail page passes
+ * `publish_time`, which is `2025-07-29T00:00:00Z`. Comparing raw strings matched
+ * nothing and billed every scanned workflow, which reached production.
+ */
+describe('publish dates from different endpoints', () => {
+  const cleanEntry = scannedEntries.find(([id]) => !snapshot.shareIds.includes(id))!;
+
+  it('accepts the detail endpoint timestamp for the same day', () => {
+    const [id, scannedDate] = cleanEntry;
+    expect(wasScannedForPartnerNodes(id, `${scannedDate}T00:00:00Z`)).toBe(true);
+    expect(isBillableWorkflow(['Image'], id, `${scannedDate}T00:00:00Z`)).toBe(false);
+  });
+
+  it('still rejects a different day in either shape', () => {
+    const [id] = cleanEntry;
+    expect(wasScannedForPartnerNodes(id, '2099-01-01')).toBe(false);
+    expect(wasScannedForPartnerNodes(id, '2099-01-01T00:00:00Z')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Live regression, introduced by me in #1100

Every genuinely free workflow currently shows **"Try on Comfy Cloud"** instead of **"Try free on Comfy Cloud"** on production. Verified on the live site just now.

## Cause

#1100 added a freshness check so a workflow re-published under the same share id stops being vouched for. It compares the date the snapshot recorded against the date the page carries. Those two values come from **different endpoints in different shapes**:

```
snapshot, from /workflows/index      '2025-07-29'
page, from /workflows/<id>           '2025-07-29T00:00:00Z'   (publish_time)
```

The raw strings never match, so every scanned workflow looked re-published and fell through to billable. The check was written and tested entirely against index-shaped dates, so nothing caught it.

## Fix

Compare the calendar day on both sides. Re-publish detection is unchanged, because it was always day-granular.

## Verification

- New test asserts the detail-endpoint timestamp is accepted for the same day, and that a different day is still rejected **in both shapes**
- **Mutation-tested:** restoring the raw string comparison fails exactly that test, so it genuinely covers the live bug rather than passing vacuously
- 528 unit tests, prettier, eslint, `astro check` 0 errors

Confirmed the logic locally against the committed snapshot: with the correct date, the two workflows I sampled return `billable: false`.

## Note

This needs a deploy to take effect. Merging alone will not change the site: `Deploy Template Site` runs only on manual dispatch or after a successful PyPI publish, which is why #1100 sat undeployed for hours before I dispatched it.
