### PR TITLE
feat(i18n): land the zh native review as overrides and sign-off records

### DIFF
--- a/site/src/i18n/overrides/zh.json
+++ b/site/src/i18n/overrides/zh.json
@@ -1,0 +1,716 @@
+{
+  "0136284ecc19": {
+    "extendedDescription": "cinematic_annotate_video 可将单张图片转为简短、流畅的电影感镜头：自动生成导演风格的摄像机路径，并转为Seedance 2.0运动提示。流程以LoadImage开始，将你的画面输入GeminiImage2Node，分析场景并用“Nano Banana 2”标注风格生成摄像机路径标注。该标注随后由GeminiNode优化/格式化为Seedance 2.0运动规范。\n\nSeedance 2.0提示和你的原始图片一同输入ByteDance2ReferenceNode，实现运动合成并保持源画面风格。PreviewImage和PreviewAny可帮助你在渲染前检查输入帧和自动生成的文本提示。最后，SaveVideo将结果写入磁盘。分组结构清晰：Annotate Image（图像分析与摄像机注释）、Prompt（LLM格式化为Seedance 2.0）、Seedance 2.0（参考驱动视频生成）。"
+  },
+  "16f123e593db": {
+    "extendedDescription": "本 ComfyUI 工作流“一键多角度角色生成”可将单张角色图片转化为多个不同角度的视图。这个工作流基于 Qwen-Image-Edit 模型，高效处理输入图片，生成多样化视角，特别适合需要在 3D 空间中可视化角色的艺术家和设计师，无需手动画出每个角度。流程包含 LoadImage 节点导入角色图片，SaveImage 节点导出生成视图。0f47377a-2933-4dba-9791-a9c54b078226 和 b7908082-f5ff-497d-8e80-e4b0ffde0419 等节点负责图片处理和转换，确保输出高质量。该流程不仅节省时间，还能激发创意，轻松获得多样视觉角度。",
+    "faqItems": [
+      {
+        "answer": "主体清晰、背景干扰少的角色图片效果最佳。",
+        "question": "这个工作流最适合什么类型的图片生成？"
+      },
+      {
+        "answer": "目前流程自动生成预设角度，后续版本可能支持自定义。",
+        "question": "可以自定义生成的角度吗？"
+      },
+      {
+        "answer": "虽然设计用于角色，但也可处理其他物体，复杂图片效果可能有差异。",
+        "question": "非角色图片可以用本流程吗？"
+      },
+      {
+        "answer": "可通过工作流作者备注中的链接反馈问题。",
+        "question": "如何反馈流程问题？"
+      }
+    ]
+  },
+  "181a9571c9a0": {
+    "howToUse": [
+      "打开 ComfyUI 并加载“Graphic Color Remixer”工作流。确认自定义重混节点（5772692b-9d2a-4a1f-b676-71b8fd315078）存在；若缺失，请安装提供该节点的扩展并重启 ComfyUI。",
+      "在 LoadImage 节点中选择源图（PNG/JPG）。形状清晰的扁平图形（logo、图标、海报、UI 元素）通常能获得更一致的换色结果。",
+      "选中重混节点（5772692b-9d2a-4a1f-b676-71b8fd315078）并设置：a）氛围/风格意图（如“retro neon”“earthy minimal”）；b）目标色板（根据节点 UI 输入色板名称或 hex 值）；c）变体数量：4、9 或 16。",
+      "如果节点需要 Nano Banana API 访问权限，请在节点设置或你的 ComfyUI 环境中提供/验证 API key 或凭证。一次 API 生成会用于产出所有请求的变体。",
+      "在 SaveImage 中设置文件命名前缀与输出目录，便于清晰地批量管理结果（例如“remix_neon_”）。",
+      "加入将工作流加入队列并运行。查看已保存的输出，然后继续迭代：调整氛围、微调色板值，或切换变体数量（2x2、3x3、4x4）以快速对比方案。"
+    ]
+  },
+  "18da3456241d": {
+    "howToUse": [
+      "在ComfyUI中打开工作流并加载模型（Step1-加载模型）：用UNETLoader选择Wan 2.1 UNet，用VAELoader加载Wan VAE，用CLIPLoader加载UMT5 XXL文本编码器（如umt5_xxl_fp8_e4m3fn_scaled.safetensors），用CLIPVisionLoader加载视觉主干。",
+      "用LoadImage上传起始图片（Step2-上传start_image）。为最佳效果，建议图片宽高比与目标视频一致。",
+      "设置视频参数（Step3-视频尺寸）：选择宽度、高度、帧数和帧率。如显存有限，建议先用较低分辨率，确认效果后再提升。",
+      "在CLIPTextEncode中输入提示词（Step4-提示）。可添加负面提示过滤不需要的特征（如“jpeg artifacts, low quality”）。用明确动作词鼓励画面运动（如turning、waving、rotating）。",
+      "确认采样与扩散设置：确保ModelSamplingSD3已连接，KSampler 的步数、引导强度（CFG）设置合理，并使用固定种子，这样结果可以复现。采样器配置保持默认以适配Wan 2.1。",
+      "队列并运行。用VAEDecode预览帧，按需调整提示、尺寸、步数或帧数。满意后，CreateVideo组装帧，SaveVideo输出最终文件。"
+    ]
+  },
+  "1c8383fd62e5": {
+    "howToUse": [
+      "在ComfyUI中加载工作流JSON。识别两个LoadImage节点：上方为人物，下方为服装（可参考MarkdownNote中的快速提示）。",
+      "选择清晰、正面、上半身无遮挡的人物照片。服装图片建议为光线充足、正面、纯色背景（无模特）。",
+      "将图片分别拖入对应LoadImage节点。确认两者已连接到FluxVTONode，且输出已连接到SaveImage、ImageCompare和（可选）ImageStitch。",
+      "点击运行按钮执行工作流。FluxVTONode会对齐并将服装转移到人物身上，保留面部和姿态。",
+      "检查输出：用ImageCompare快速前后对比，用ImageStitch生成三合一对比图（服装、人物、结果）。如对齐不理想，可尝试更正面的人物照片或更清晰的服装图片后重试。",
+      "满意后，可设置SaveImage输出路径/文件名并重新运行（或右键保存预览）导出最终试穿图。"
+    ]
+  },
+  "1d69cf9d1761": {
+    "suggestedUseCases": [
+      "为营销内容动画化产品图片。",
+      "将静态插画转为动态视觉艺术作品。",
+      "将图表或示意图制作成动画教学视频。",
+      "通过动画化角色草图或场景增强故事叙述。",
+      "制作吸引眼球的社交媒体动态视觉内容。"
+    ]
+  },
+  "1eab7aa23f6a": {
+    "suggestedUseCases": [
+      "制作带角色解说的动画讲解视频。",
+      "为社交媒体内容添加与观众对话的动画角色。",
+      "开发角色讲解知识点的趣味教育视频。",
+      "为品牌制作带动画代言人的宣传视频。",
+      "在数字营销领域为数字人或虚拟形象生成口型同步视频。"
+    ]
+  },
+  "1fb07c3b4b99": {
+    "howToUse": [
+      "在 ComfyUI 中加载工作流 JSON。确保已安装 VideoHelperSuite 扩展，以便使用 VHS_LoadVideo 和 VHS_VideoCombine。",
+      "打开 VHS_LoadVideo，选择输入视频。可选设置裁剪范围、调整分辨率和帧率。",
+      "找到 IC-LoRA 编辑节点（UUID 2e37ecc9-770a-4ac2-972c-e953901f49d3）。输入清晰的编辑提示（如“在左侧人行道添加一只棕色小狗”或“转换为水彩风格”）。如有负面提示，可用于保护不希望变动的元素（如“保留背景，避免多余人物”）。",
+      "在编辑节点调整编辑强度和一致性控制（如强度/去噪和引导）。低强度适合细微风格变化，高强度适合添加或移除对象。对比变体时建议固定种子。",
+      "在 VHS_VideoCombine 设置输出帧率、格式/编码（如 MP4/H.264）、质量和输出路径。预览时可降低帧率或分辨率。",
+      "点击运行按钮执行工作流。查看输出视频并迭代：优化提示、调整强度/引导，或缩短片段以提升时序稳定性。"
+    ]
+  },
+  "2da831d21d09": {
+    "description": "使用提示词列表中的提示词，依次加载并运行工作流。遍历每一条目，实现单次批量操作生成多张输出。"
+  },
+  "2f10814fd823": {
+    "howToUse": [
+      "在 ComfyUI 中加载工作流，定位三个分组：Prompt、首帧到末帧转换器、Seedance 2.0。",
+      "在 Prompt 组：用 LoadImage 加载首帧。如已有终帧，用另一个 LoadImage 加载；如无，直接在 GeminiNode 输入简要描述，传递给 GeminiImage2Node 生成终帧。确保终帧分辨率与首帧一致。",
+      "打开 Seedance 2.0 组，将 ByteDance2FirstLastFrameNode 设置为你的首帧和末帧。调整关键参数，如总帧数（或时长）、FPS 控制片段长度和节奏。根据需要微调运动/一致性参数，保持主体稳定。",
+      "用 PreviewAny 检查生成的终帧和转换测试。如效果不理想，可优化 Gemini 提示、调整种子（便于复现和变化），或重新生成终帧。",
+      "满意后，运行完整工作流。SaveImage 可导出生成的终帧（如有），SaveVideo 写出最终桥接片段。",
+      "检查输出。如有抖动或构图不匹配，可让首末帧在构图/光线上更接近，降低运动强度，或适当延长时长以获得更平滑过渡，然后重跑。"
+    ]
+  },
+  "3858678780f1": {
+    "extendedDescription": "本ComfyUI工作流旨在利用精修模型提升由Stable Diffusion XL（SDXL）模型生成的图片质量。工作流通过一系列节点，生成高质量、视觉效果出色的精修图片。流程从CheckpointLoaderSimple节点加载 SDXL 基础模型开始，该节点会自动应用适合所选SD模型版本的最佳设置。随后，EmptyLatentImage节点生成初始潜变量图片，作为后续精修的画布。\n\n核心部分是CLIPTextEncode节点，根据文本提示引导图片生成。KSamplerAdvanced节点引入可控噪声，使模型能迭代精修和增强视觉效果。精修后，VAEDecode节点将潜变量图片解码为可见格式，便于最终调整。SaveImage节点用于保存PNG格式的精修图片。该工作流适合需要高质量精修图片的艺术家和设计师，将SDXL模型与高级精修技术结合，提升项目品质。"
+  },
+  "3b9e9f29c1dc": {
+    "howToUse": [
+      "在ComfyUI中加载LTX-2：图转视频工作流。",
+      "用LoadImage节点导入静态图片。",
+      "用ResizeImageMaskNode调整图片尺寸，确保与视频设置兼容。",
+      "配置LTX-2模型参数，确保宽高为64的倍数，帧数为 8 的倍数加 1。",
+      "运行工作流生成视频，用SaveVideo节点导出最终结果。"
+    ]
+  },
+  "3cf3c6a082ed": {
+    "extendedDescription": "LTX-2 姿态转视频工作流旨在将姿态引导转化为高质量视频内容，并实现音视频同步。这个工作流基于 Lightricks 的 LTX-2 模型，支持精确的姿态控制和丰富的动作表现，非常适合创作动态视频内容。流程集成了 GetVideoComponents、PreviewImage 和 SaveVideo 等节点，分别用于分解视频组件、预览帧和保存最终输出。核心亮点是集成 comfyui_controlnet_aux 自定义节点，进一步提升姿态控制和动作表现的精度。\n\n技术流程包括：通过 LoadVideo 和 ResizeImageMaskNode 进行视频和图像预处理，随后用 DWPreprocessor 优化视频设置，确保帧数和分辨率最佳。支持最高 1920x1088 分辨率，默认 720p 以提升效率。帧数需满足被 8 整除再加 1，保证过渡和同步流畅。该流程特别适合需要精细动作和音视频同步的创作者，充分发挥 LTX-2 模型的专业级表现力。",
+    "faqItems": [
+      {
+        "answer": "分辨率需能被 64 整除。默认 720p，若设备支持可用到 1920x1088。",
+        "question": "这个工作流对分辨率有何要求？"
+      },
+      {
+        "answer": "这样可保证视频过渡和同步流畅，避免伪影或卡顿。",
+        "question": "为什么帧数要被 8 整除再加 1？"
+      },
+      {
+        "answer": "流程效率较高，但是否能实时生成取决于你的设备性能和视频复杂度。",
+        "question": "可以用于实时视频生成吗？"
+      },
+      {
+        "answer": "请确保姿态引导细致，视频分辨率和帧数符合流程要求。",
+        "question": "如何获得 LTX-2 模型的最佳效果？"
+      }
+    ]
+  },
+  "3eb92c1b2380": {
+    "description": "AI on the Lot 2026 发布的第六个也是最后一个工作流，供 ComfyUI 101 工作坊学员选择打开并跟随。这个文生视频工作流整合了前面所有工作流的内容，形成完整方案。"
+  },
+  "404250f61d0a": {
+    "extendedDescription": "本 ComfyUI 工作流带你进入艺术图像生成领域，基于 Stable Diffusion 1.5。通过 KSampler 和 CLIPTextEncode 等高级节点，可将简单文本提示转化为精美图像。这个工作流充分发挥 Stable Diffusion 的特性，模型训练于 512x512 数据集，确保合适尺寸下高质量输出。无论是用“beautiful scenery nature glass bottle”创作风景，还是用“purple galaxy bottle”探索抽象概念，节点组合都能实现丰富细节和创意表达。\n\n流程结构包括模型加载、图像尺寸设置和提示编写，适合新手和有经验用户。MarkdownNote 节点便于文档记录和创作迭代。正向与负向提示进一步提升创作控制力，帮助有效指定和优化视觉结果。整体流程展现了先进 AI 模型与直观 UI 设计带来的创意可能性。",
+    "faqItems": [
+      {
+        "answer": "用正向提示强调特定元素，用负向提示减少不需要的细节。",
+        "question": "如何细化生成图像的细节？"
+      },
+      {
+        "answer": "流程针对 512x512 优化，Stable Diffusion 1.5 模型训练于该尺寸数据集。",
+        "question": "这个工作流适合什么图像尺寸"
+      },
+      {
+        "answer": "可以。可用 CLIPTextEncode 节点自定义文本提示，引导图像生成。",
+        "question": "可以用自定义提示吗？"
+      },
+      {
+        "answer": "图像会自动保存到 ComfyUI/output 文件夹，也可右键 SaveImage 节点手动保存。",
+        "question": "如何保存生成的图像？"
+      }
+    ]
+  },
+  "40770c9eb41b": {
+    "extendedDescription": "ComfyUI 中的 LTX-2 文本转视频工作流，可将文本提示转为高质量视频，支持音视频同步。这个工作流基于 Lightricks 开发的 LTX-2 模型，具备出色的口型同步和动态动作生成能力。流程高效处理文本输入，生成与描述动作相符且视觉质量高的视频。技术上，流程用到 SaveVideo 节点和子工作流节点（ID b7c2d337-c38d-4c04-922b-2d638449d13e），分别负责输出保存和复杂视频生成。MarkdownNote 节点用于流程内文档和操作说明，帮助用户理解每一步和参数设置。"
+  },
+  "40dea2f852c3": {
+    "description": "用 Meshy 6 根据文本提示生成高质量 3D 模型。可创建细致角色、机械物体或游戏用低多边形资产。"
+  },
+  "44d156cf2723": {
+    "extendedDescription": "Beeble SwitchX：视频编辑是针对视频编辑的工作流，仅更改你描述的部分，其余内容保持不变。你可加载源视频和（可选）参考图片，输入描述新环境和光照的提示词。BeebleSwitchXVideoEdit节点应用Beeble SwitchX视频编辑模型，生成遮罩区域按提示词和参考调整、未遮罩区域保留原像素和运动的编辑片段。流程还输出alpha遮罩，便于在任意NLE中将编辑区域合成回原片段。\n\n技术上，流程用LoadVideo解码视频，GetVideoComponents提取尺寸和帧数，“Get frame counts (need < 240)”组帮助你控制在模型推荐帧数以内。片段过长可用Video Slice裁剪。LoadImage引入可选参考图，GetImageSize确保尺寸匹配。BeebleSwitchXVideoEdit节点按时序一致性处理帧，输出编辑后视频和每帧alpha遮罩。用PreviewAny检查中间结果，SaveVideo渲染最终编辑。适合无损重光、替换环境或定向风格化特定对象，且不破坏原始运动。"
+  },
+  "45c0ce6bcf2e": {
+    "extendedDescription": "Wan2.1 VACE首末帧视频生成引入了端点锚定的视频合成方式：你提供起始帧和结束帧，模型在两者之间规划时序连贯的过渡路径。不同于传统的光流插帧，工作流在潜空间中用Wan2.1的VACE先验合成中间内容，并可用提示词和可选LoRA引导。这样可实现身份稳定、风格连贯和可信的运动规划。\n\n在ComfyUI中，流程将WanVaceToVideo与ModelSamplingSD3配置文件、KSampler及严格的帧/布局规范配合：空间尺寸需为16的倍数，总帧数需满足4n+1规则（Length−1能被4整除）。这种结构，加上用来精确控制片段长度的 TrimVideoLatent，能产生又平滑又可控的过渡效果。14B模型支持清晰的480p和720p输出，1.3B轻量版适合480p。可选LoRA（如CausVid）可大幅减少采样步数，同时保持时序一致性。"
+  },
+  "4638e59ae7d2": {
+    "faqItems": [
+      {
+        "answer": "Qwen-VL是一款视觉-语言大模型。在本工作流中通过AILab_QwenVL_PromptEnhancer节点以纯文本模式，将简短创意扩展为具体的视觉描述（主体、风格、光效、构图），便于直接用于图像/视频生成。",
+        "question": "Qwen-VL是什么，为什么用于提示词增强？"
+      },
+      {
+        "answer": "取决于Qwen-VL后端配置。有些可本地运行（无需联网），有些需远程服务（需API密钥）。请打开AILab_QwenVL_PromptEnhancer节点，按节点说明配置环境。",
+        "question": "需要联网或API密钥吗？"
+      },
+      {
+        "answer": "在输入中明确约束（如“无文字，无水印，自然色，纪录片风格”）。如节点支持创造力/温度参数，低值更贴合原意，高值更具创意。也可通过更明确的表达反复迭代，指定必须和禁止项。",
+        "question": "如何控制风格或避免添加不需要的元素？"
+      },
+      {
+        "answer": "可以。输出为纯文本，可直接粘贴到Stable Diffusion或其他文生图/文生视频节点的正面提示词。如流程有负面提示字段，可将排除项单独填写或在增强输入中注明。",
+        "question": "增强后的提示词能用于任意ComfyUI图像流程吗？"
+      }
+    ]
+  },
+  "4a6697085e75": {
+    "howToUse": [
+      "在 ComfyUI 加载工作流，打开 LoadImage 节点，选择源设计图（PNG/JPG）。",
+      "打开重构节点（UUID 172f1008-9337-4d2f-9212-ee081cb4faf5），设置目标宽高比（如 1:1、4:5、16:9、9:16）或直接输入宽高。",
+      "选择重构模式：Fit（信箱填充，无裁剪）、Fill（智能裁剪，填满画面）、Extend（外延扩展画布）。",
+      "如用 Extend/外延，可调整边界大小、羽化和合成强度，控制新内容生成量及与原图的融合度。",
+      "确认重构节点输出已连接到 SaveImage。在 SaveImage 设置文件名前缀、输出文件夹和格式（如 PNG）。",
+      "点击“运行”按钮开始运行。检查输出，微调比例、模式或羽化后反复运行，直到满意为止。"
+    ]
+  },
+  "4e8809f5dfd3": {
+    "extendedDescription": "“Flux.1 Krea Dev”工作流利用微调的FLUX模型，实现极高水平的写实图像生成。该流程适合希望通过文本描述快速生成高度逼真图片的用户。这个工作流结合 SaveImage 和 MarkdownNote 等节点，便于生成和保存高质量图片。核心为Flux.1 Krea Dev模型，以极致写实著称，输出细节丰富、真实感强的图片。\n\n技术上，流程将文本输入送入Flux.1 Krea Dev模型，模型解析文本并生成写实图片。SaveImage节点高效保存输出，MarkdownNote节点可用于过程或结果注释。该流程特别适合艺术家、设计师和内容创作者快速高效地生成写实图片，是创意工具箱中的重要利器。"
+  },
+  "4f8b62bfd681": {
+    "faqItems": [
+      {
+        "answer": "支持MP3、WAV等常见音频格式。请确保文件格式兼容后再加载。",
+        "question": "这个工作流支持哪些音频文件格式？"
+      },
+      {
+        "answer": "可以。建议保留原始文件，编辑后另存新文件，便于随时还原。",
+        "question": "可以撤销对歌曲的更改吗？"
+      },
+      {
+        "answer": "在流程中的“Adjust the vocal volume”分组可精细调整人声音量。",
+        "question": "如何调整歌曲中的人声音量？"
+      },
+      {
+        "answer": "可以，在ComfyUI内可用播放功能试听编辑后的音频，满意后再保存。",
+        "question": "可以在保存前预览编辑效果吗？"
+      }
+    ]
+  },
+  "4fe8d97559cd": {
+    "extendedDescription": "该ComfyUI工作流可将单张图片转化为完整带纹理的3D模型，通过生成三视图实现。流程利用GeminiNanoBanana2模型，从输入图片生成准确的侧面和背面视图。随后用TripoImageToModelNode将这些视图合成为3D模型。这个工作流分为两大组：视图生成和 3D 模型生成。视图生成组用LoadImage和BatchImagesNode准备和处理输入图片，3D模型生成组用Meshy模型将多视图整合为完整3D结构。该流程适合艺术家和设计师用最少输入快速原型3D模型。",
+    "faqItems": [
+      {
+        "answer": "轮廓清晰、特征明显的图片最佳，有助于模型准确生成侧面和背面视图。",
+        "question": "这个工作流适合用于什么类型的图片？"
+      },
+      {
+        "answer": "流程可生成基础纹理，复杂细节建议在3D建模软件中进一步完善。",
+        "question": "该流程能处理复杂纹理吗？"
+      },
+      {
+        "answer": "可以，生成的3D模型可导出为GLB文件，在兼容3D建模软件中编辑。",
+        "question": "生成的3D模型可以编辑吗？"
+      },
+      {
+        "answer": "准确性取决于输入图片质量和主体复杂度。简单清晰的图片效果更好。",
+        "question": "生成的正交视图有多准确？"
+      }
+    ]
+  },
+  "50199f76fe74": {
+    "extendedDescription": "这个工作流可将插画角色打光匹配新背景，并融合为统一关键帧。核心功能封装在Subgraph节点（类型ID: 9e3c3756-d15f-4361-8e99-c35673036e68）中，用户只需操作少量输入和参数。通过LoadImage节点分别输入角色图和环境图，用提示词驱动风格（见流程内Note/MarkdownNote），用SaveImage导出结果。\n\n技术上，Subgraph叠加插画LoRA实现风格统一，再用打光LoRA根据环境调整明暗和色彩。子工作流自动处理条件、打光引导和前后景合成，暴露简单的强度滑块和融合选项，便于平衡“风格”与“光效”。流程内Note节点含中文提示词——请保持原文不变，后面可追加英文或其他编辑指令，细化光向、氛围、色温或边缘光。若本地运行，请确保相关文本编码器文件（如qwen_2.5_vl_7b_fp8_scaled.safetensors）已就位，便于子工作流正常编码提示词。"
+  },
+  "5652fbe7f479": {
+    "faqItems": [
+      {
+        "answer": "两个阶段都使用同一角色和服装平铺图作为 OpenAIGPTImageNodeV2 的参考。放大流程会复用这些参考，确保身份和服装细节被强化，而不是重新生成。",
+        "question": "如何保证拼贴和放大图的人脸与服装一致？"
+      },
+      {
+        "answer": "角色图需清晰、光线充足、脸部无遮挡、背景简洁。服装图需平铺在纯色背景上，正面完整可见，不要折叠或有遮挡，避免背景杂乱或图案干扰。",
+        "question": "什么样的输入图片最适合获得可靠的试穿效果？"
+      },
+      {
+        "answer": "用 ImageFromBatch 节点设置 batch_index，选择想要的拼贴（0=左上，1=右上，2=左下，3=右下）。作者备注：索引从0开始。",
+        "question": "如何选择要放大的四张图片中的哪一张？"
+      },
+      {
+        "answer": "可以。编辑 PrimitiveStringMultiline 提示词，指定姿势（如四分之三侧面、行走）、镜头（全身、中景）、灯光（柔光箱、轮廓光）、背景（无缝纸、彩色纸）。重新运行2×2拼贴分组即可预览新变体。",
+        "question": "不更换图片可以更改姿势、镜头或背景吗？"
+      }
+    ]
+  },
+  "5a3df986f9f8": {
+    "description": "用参考图片和文本提示生成4K电影级视频。在保持角色一致性和构图不变的同时，为图片添加富有表现力的动态并保持音频同步，也可以用详细提示词控制镜头运动和灯光。"
+  },
+  "5ae006b13a36": {
+    "extendedDescription": "本 ComfyUI 教程型工作流演示如何通过结构化JSON提示驱动 Ideogram v4，实现清晰文本渲染、品牌色彩一致和可靠布局控制。你无需只写一句自由提示，而是构建一个简洁JSON对象，描述场景、图片内文本、色彩方案和每个对象的边界框。该JSON输入 IdeogramV4 合作API节点，返回尽量贴合你布局要求的高质量图片，输出直接流向 SaveImage。\n\n为便于创作，JSON Prompt Builder 分组（选中后按 Ctrl+B 启用）内含 MarkdownNote，提供模板和schema，也可用 GeminiNode 将普通描述转为合格JSON。你可用 PreviewAny 预览结构化提示，反复调整边界框或色彩，再渲染最终图片。此方法适合需要可靠图片内文本、品牌色彩和对象精准定位的场景，在自然语言提示词难以实现时比较有效。"
+  },
+  "5f1e9e754358": {
+    "suggestedUseCases": [
+      "将静态图片转为动画，创作富有吸引力的社交媒体内容。",
+      "为数字艺术项目增添动态元素。",
+      "开发带动画视觉的互动演示文稿。",
+      "制作需要动画图解的教育视频。",
+      "为营销素材添加运动，提升观众参与度。"
+    ]
+  },
+  "67981edb9ad4": {
+    "faqItems": [
+      {
+        "answer": "用简明语言描述“核心动作”随时间展开（如“镜头缓慢推进，前景落叶飘过”），并列出需保留的“视觉细节”（构图、灯光、色彩、主体特征）。指令要简洁明确。",
+        "question": "如何为 LTX‑2.3 编写最佳运动提示？"
+      },
+      {
+        "answer": "干净、光线充足、主体分离清晰的图片更易生成连贯动画。分辨率与显存和默认设置匹配，输入输出宽高比一致可避免拉伸。",
+        "question": "什么样的图片输入效果最好？"
+      },
+      {
+        "answer": "视频长度由生成帧数和 SaveVideo 的 FPS 共同决定；增加帧数可增加视频长度，调整 FPS 可让视频更加流畅。增加帧数延长片段，调整 FPS 改变播放感觉。如 LTX‑2.3 节点支持帧数/时长，直接修改；再在 SaveVideo 设定目标 FPS。",
+        "question": "如何控制片段长度和流畅度？"
+      },
+      {
+        "answer": "在 LTX‑2.3 节点（如有）设置并复用固定种子，保持提示词和其他参数不变。更换种子可探索不同变化。",
+        "question": "每次运行结果不同，如何保证可复现？"
+      }
+    ]
+  },
+  "6a2b37d44146": {
+    "title": "步骤1：样片表工作流"
+  },
+  "6bc8dcf6317d": {
+    "faqItems": [
+      {
+        "answer": "如节点指向托管的Wan 2.7端点，通常需在节点设置中提供API密钥或凭证。请查阅节点文档或服务商说明。",
+        "question": "使用Wan2TextToVideoApi需要API密钥吗？"
+      },
+      {
+        "answer": "片段长度受Wan2TextToVideoApi节点和后端服务的限制。该工作流适合短片，时长越长生成时间和计算成本越高。",
+        "question": "生成视频最长能有多长？"
+      },
+      {
+        "answer": "请使用干净、以语音为主的音频（避免音乐/噪音），去除前置静音，保持人声居中且音量一致，并确保文本提示语言与音频一致。确保音频采样率和格式被节点支持。",
+        "question": "如何提升口型同步质量？"
+      },
+      {
+        "answer": "可以。在Wan2TextToVideoApi中设置固定种子（如节点支持）。固定种子和参数可提升多次运行间的一致性，否则输出可能有差异。",
+        "question": "如何保证结果可复现？"
+      }
+    ]
+  },
+  "6c3fa01b5d73": {
+    "title": "3x3 小样图"
+  },
+  "73a6511dc29e": {
+    "extendedDescription": "本ComfyUI工作流通过先进AI技术，将单张正面图片转化为高细节3D模型。这个工作流结合 Hunyuan3D 和 Qwen-Image-Edit 模型，重建主体背面，实现一致且真实的3D表现。流程以TencentImageToModelNode解析输入图片，为3D建模做准备。QwenMultiangleCameraNode生成多角度视图，为完整3D模型提供必要信息。Preview3D节点支持预览，便于在输出前调整。适用于虚拟现实、游戏、数字内容创作等对高质量3D模型有需求的场景。",
+    "faqItems": [
+      {
+        "answer": "高分辨率、细节清晰、光线良好的正面图片效果最佳。",
+        "question": "什么类型的图片最适合该流程？"
+      },
+      {
+        "answer": "主要针对正面图片设计，侧面或斜面图片也可尝试，但准确性可能有所下降。",
+        "question": "这个工作流能用侧面或斜面图片生成3D模型吗？"
+      },
+      {
+        "answer": "处理时间取决于图片分辨率和系统性能，通常几分钟即可完成。",
+        "question": "生成3D模型需要多长时间？"
+      },
+      {
+        "answer": "不需要。流程设计友好，初学者也可轻松上手。",
+        "question": "使用该流程需要相关经验吗？"
+      }
+    ]
+  },
+  "787cfd599758": {
+    "howToUse": [
+      "将MiniMax：文本转视频工作流JSON导入ComfyUI，确认MinimaxTextToVideoNode、SaveVideo和MarkdownNote节点已加载。",
+      "打开MarkdownNote，查看安全环境要求：本地（127.0.0.1）运行、Web服务用HTTPS、确保可访问MiniMax API。",
+      "选中MinimaxTextToVideoNode，输入文本提示。如节点支持，可设置时长、分辨率等参数，并填写API凭证/端点。",
+      "配置SaveVideo节点：选择清晰的文件名前缀和（如有）格式设置，确保片段写入目标输出文件夹。",
+      "在ComfyUI中点击运行按钮执行工作流。等待节点完成API任务并由SaveVideo写入视频。",
+      "从ComfyUI输出目录打开保存文件进行查看。根据需要调整提示和节点参数，优化运动、风格和构图。"
+    ]
+  },
+  "7905fe6d550c": {
+    "extendedDescription": "FLUX.2 [max]：物体替换工作流可在保持整体场景一致性和质量的前提下，无缝替换图像中的物体。核心为Flux2MaxImageNode，利用先进图像处理技术实现精确替换。这个工作流比较适合产品摄影、家具替换等对原图美观性有高要求的场景。\n\n流程以LoadImage节点导入待编辑图片，Flux2MaxImageNode识别并精确替换目标物体。GetImageSize节点确保全流程图像尺寸一致，BatchImagesNode支持批量处理多张图片，提升效率。最后，SaveImage节点输出编辑后图片，适用于多种应用场景。",
+    "faqItems": [
+      {
+        "answer": "只要替换物体与原场景在尺寸和视角上兼容，理论上可替换任意物体。",
+        "question": "这个工作流可以用于哪些类型的物体替换？"
+      },
+      {
+        "answer": "可以，使用BatchImagesNode可同时处理多张图片，适合批量编辑。",
+        "question": "可以批量处理多张图片吗？"
+      },
+      {
+        "answer": "不会，Flux2MaxImageNode设计时注重高质量输出，确保编辑后图片依然清晰锐利。",
+        "question": "编辑后原图质量会受影响吗？"
+      },
+      {
+        "answer": "有ComfyUI工作流基础更好，但流程步骤清晰，初学者也可快速上手。",
+        "question": "使用该流程需要什么技能？"
+      }
+    ]
+  },
+  "79227f845a2c": {
+    "faqItems": [
+      {
+        "answer": "带有清晰意象和具体细节的描述性提示效果最佳，Reve模型擅长将详细文本转化为视觉元素。",
+        "question": "什么样的提示词最适合这个工作流？"
+      },
+      {
+        "answer": "可以，ReveImageCreateNode支持风格参数调整，可微调输出图像的美学风格。",
+        "question": "可以调整生成图像的风格吗？"
+      },
+      {
+        "answer": "SaveImage节点支持多种格式，包括PNG和JPEG，便于灵活存储和分享。",
+        "question": "生成的图像可以保存为哪些格式？"
+      },
+      {
+        "answer": "没有严格限制，但简明详细的提示通常能生成更清晰、聚焦的图像。建议保持描述详细但简洁。",
+        "question": "文本提示长度有限制吗？"
+      }
+    ],
+    "howToUse": [
+      "打开ComfyUI界面，加载“Reve：文本转图像”工作流。",
+      "在ReveImageCreateNode输入框中输入你的文本提示。",
+      "在ReveImageCreateNode中配置其他参数，微调输出效果。",
+      "运行工作流，根据文本提示词生成图像。",
+      "用SaveImage节点将生成的图像保存为所需格式。",
+      "检查保存的图像，如有需要可调整参数后重新生成。"
+    ]
+  },
+  "795f78f5c9cb": {
+    "extendedDescription": "“Chatter Box：多说话人对话与声音克隆”工作流可用声音克隆技术生成真实的多说话人对话音频。基于Chatter Box模型，用户可为每位说话人上传简短语音样本并输入对话脚本，流程将为每位说话人克隆声音并生成完整对话音频。这个工作流使用 FL_ChatterboxDialogTTS 节点实现文本转语音与声音克隆，LoadAudio节点上传语音样本，AudioCrop节点可裁剪音频片段，SaveAudioMP3节点导出最终音频。MarkdownNote节点可用于流程注释。适合播客、有声书、虚拟助手等需要多角色音色的个性化音频内容创作。"
+  },
+  "7cecbe192fc2": {
+    "howToUse": [
+      "在 ComfyUI 中加载工作流，确保已安装所需组件：Video Helper Suite（VHS_LoadVideo 和 VHS_VideoCombine）及 LTX‑Video 2.3 流水线节点。确认 LTX‑Video 2.3 基础模型和 TheBurgstall “Googlyeyes” LoRA 已安装，并可在 LTX 节点/分组（id: 2e37ecc9-770a-4ac2-972c-e953901f49d3）中选择。",
+      "打开 VHS_LoadVideo 节点，选择源视频。设置 skip_first_frames 裁剪起始帧，frame_count 设置需处理的帧数（如 skip_first_frames: 60，frame_count: 480 表示处理第 60–540 帧）。",
+      "在 LTX 2.3 节点/分组中，选择 LTX‑Video 2.3 基础模型和 TheBurgstall 的 Googlyeyes LoRA。如有 LoRA 强度控制，建议初始为 1.0，效果不明显可适当提高，过强可降低。",
+      "首次运行建议保持其他 LTX 参数默认。长视频或高分辨率建议先处理短片段，降低 frame_count 验证质量和显存占用。",
+      "确认 LTX 节点输出已连至 VHS_VideoCombine，帧率由 VHS_LoadVideo 提供。如 VHS_VideoCombine 支持，可设置输出文件名/预设。",
+      "点击“运行”按钮开始运行完成后在 ComfyUI 输出目录查看视频。如需调整 LoRA 强度或裁剪参数，修改后重新队列。"
+    ]
+  },
+  "825e6fb23c2c": {
+    "howToUse": [
+      "在ComfyUI中加载Krea 2风格板测试工作流，确保已安装Krea2ImageNode自定义节点。按节点文档在设置或环境变量中添加Krea API密钥。",
+      "决定先测试哪些分支，跳过其他分支。通过MarkdownNote标签快速定位每组（01–06）。",
+      "对每个激活分支，设置PrimitiveNode值：粘贴风格板ID（可用作者备注中的示例UUID或自有ID）、填写提示词、选择风格板强度。如Krea2ImageNode版本支持，可选设置种子和尺寸。",
+      "打开每个激活分支的SaveImage节点，设置清晰的filename_prefix（如mb01_ethereal_），避免不同风格输出文件覆盖。",
+      "点击运行按钮执行工作流。Krea2ImageNode会为每个激活分支调用Krea 2 API，SaveImage将结果写入输出文件夹。",
+      "迭代：调整风格板强度平衡风格与提示词，优化提示词，替换风格板ID，或复制分支添加更多风格变体。"
+    ]
+  },
+  "88f014a33e2a": {
+    "extendedDescription": "“Grok：参考图转视频”工作流在 ComfyUI 中将静态参考图片转为动态视频内容。流程利用 Grok API 生成跨帧风格高度一致的视频，最多可用六张参考图片。流程以 LoadImage 节点上传参考图，GrokVideoReferenceNode 利用 Grok 模型解析并转化为连贯的视频序列，最后 SaveVideo 节点导出生成视频。\n\n这个工作流最大特点是可处理多张参考图，确保输出视频风格和角色表现高度一致。特别适合需要角色动画或艺术风格统一的视频项目。Grok 模型的高级能力可细致解析输入图片，是将静态美术转为动态视频的强大工具。"
+  },
+  "8c90417df6d3": {
+    "faqItems": [
+      {
+        "answer": "支持 PNG、JPEG 等常见图片格式，LoadImage 节点可兼容大多数 Logo 文件。",
+        "question": "这个工作流支持哪些 Logo 格式？"
+      },
+      {
+        "answer": "可在 GeminiImage2Node 中调整纹理参数，使其与品牌色彩方案匹配，确保品牌一致性。",
+        "question": "如何确保纹理与品牌色彩一致？"
+      },
+      {
+        "answer": "可以，SaveVideo 节点用于导出视频，SaveImage 节点用于导出图片，满足多场景需求。",
+        "question": "最终资产可以导出为视频和图片吗？"
+      },
+      {
+        "answer": "可使用 ResizeAndPadImage 节点调整 Logo 尺寸，确保其在工作流中完美适配。",
+        "question": "如果 Logo 尺寸不适配工作流怎么办？"
+      }
+    ]
+  },
+  "8e090ccf5a29": {
+    "extendedDescription": "本模板为基于 Z-Image Turbo 生成器的紧凑型文本生成图像工作流，只需最少的设置，即可从提示词直接生成输出。核心为单一自定义 Z-Image Turbo T2I 节点（节点 id f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1），集成文本编码与图像生成，配合 SaveImage 节点将结果写入磁盘，并通过 MarkdownNote 提供流程内指导。模板默认使用 Qwen 3 4B 文本编码器权重（qwen_3_4b.safetensors）进行提示条件化。\n\n在技术实现上，Z-Image Turbo 节点负责端到端生成：接收你的提示（及可选负面提示），用指定文本编码器编码，并运行模型内部采样器生成图像张量。张量直接传递给 SaveImage，导出 PNG 至 ComfyUI 输出文件夹，文件名前缀可自定义。由于所有流程封装在单一节点内，整个 T2I 流程简洁可靠，便于反复迭代：在同一处调整提示、分辨率、种子和采样参数，轻松保存一致、可复现的输出。"
+  },
+  "9173ef378024": {
+    "extendedDescription": "“Vidu Q2：图片转视频”工作流可将静态图片转为动态1080p视频，支持电影级镜头控制并保持多主体一致性。这个工作流基于Vidu Q2模型，专为将静态图生成高质量视频而优化。通过LoadImage、Vidu2ImageToVideoNode和SaveVideo等节点，用户可轻松将图片转为带专业特效的视频。LoadImage节点导入图片，Vidu2ImageToVideoNode用算法动画化图片，确保帧间平滑过渡和主体一致性。最后，SaveVideo节点将生成帧合成为完整视频文件。",
+    "faqItems": [
+      {
+        "answer": "高分辨率、主体和背景清晰的图片效果最佳，便于Vidu2ImageToVideoNode处理。",
+        "question": "哪些图片最适合这个工作流？"
+      },
+      {
+        "answer": "可以，在Vidu2ImageToVideoNode设置中可指定视频时长。",
+        "question": "可以调整生成视频的时长吗？"
+      },
+      {
+        "answer": "Vidu2ImageToVideoNode已针对主体一致性优化，也可通过调整节点参数进一步提升主体跟踪效果。",
+        "question": "如何保证视频多主体一致性？"
+      },
+      {
+        "answer": "这个工作流专注于视频生成。可在导出后用外部视频编辑软件添加音频。",
+        "question": "能为生成视频添加音频吗？"
+      }
+    ]
+  },
+  "94ed41b87579": {
+    "howToUse": [
+      "将工作流 JSON 加载到 ComfyUI（拖拽文件到画布或用 ComfyUI Manager 导入）。",
+      "打开 Z-Image Turbo 节点（UUID f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1），输入提示和（如有）负面提示。设置种子、步数、引导等参数。如节点支持模型/vae输入，指向你喜欢的模型。",
+      "在同一节点（或其连接的超分控件）设置输出尺寸或超分倍数。建议从2x开始，获得清晰细节且不过度锐化。",
+      "点击运行按钮执行工作流，依次执行 T2I 生成和超分阶段。ImageCompare 节点会生成基础图与超分图的对比图。",
+      "查看对比图，检查细节保留和伪影。如需调整，优化提示、种子、步数、引导或超分倍数后重试。",
+      "满意后，让 SaveImage 节点将基础图和超分图保存到磁盘。可在 SaveImage 节点编辑文件名前缀，便于版本管理。"
+    ]
+  },
+  "99aec65eea89": {
+    "howToUse": [
+      "安装自定义节点：将ComfyUI-MelBandRoFormer添加到ComfyUI/custom_nodes并重启ComfyUI。",
+      "放置模型文件：将MelBandRoformer_fp16.safetensors复制到ComfyUI/models/diffusion_models/。",
+      "加载工作流：在ComfyUI中打开MelBandRoFormer音频分离工作流JSON。",
+      "选择输入：在LoadAudio节点中选择你的歌曲、播客或音频片段。",
+      "加载模型：在MelBandRoFormerModelLoader中确认MelBandRoformer_fp16.safetensors路径。",
+      "运行分离：运行工作流，MelBandRoFormerSampler输出人声和伴奏到两个SaveAudioMP3节点，分别写入输出文件夹。"
+    ]
+  },
+  "9c0e04762e99": {
+    "metaDescription": "通过ComfyUI的SDXL Turbo工作流，快速生成高质量图片。一键文生图工作流。"
+  },
+  "9c3c4722a8e1": {
+    "howToUse": [
+      "在ComfyUI中加载工作流JSON，打开图表查看Prompt输入、Stable Audio 3节点和SaveAudioMP3输出。",
+      "从Hugging Face（Comfy-Org/stable-audio-3）下载Stable Audio 3模型，按仓库说明放置文件。下载qwen3.5_2b_bf16.safetensors，放入ComfyUI/models/text_encoders。重启ComfyUI以便节点识别模型。",
+      "在Prompt字段输入简短创意（2–10 个单词最佳）。可在Stable Audio 3节点设置时长（秒）和种子，控制片段长度和可复现性。首次运行建议其他参数保持默认。",
+      "点击运行按钮执行工作流/运行。子工作流用Qwen扩展提示并传递给Stable Audio 3生成节点，等待音频渲染完成。",
+      "在SaveAudioMP3节点设置输出路径（如有比特率选项可调整），运行或重新运行以保存MP3。可在控制台或节点预览查看保存位置。",
+      "多次迭代：更换种子获得不同变体，调整时长适配需求。如结果过于复杂，可简化提示（Qwen扩展仍会丰富短输入）。"
+    ]
+  },
+  "9e033fb4e06a": {
+    "extendedDescription": "在 ComfyUI 中的“人像重光”工作流可通过参考图片调整目标图片的光照。这个工作流利用 Qwen-Image-Edit 模型智能调整目标图片的光照，使其看起来像在参考图片的光照条件下拍摄。主要节点包括 LoadImage（导入图片）和 SaveImage（导出结果）。本流程特别适合摄影师和数字艺术家实现多图统一光照风格，或无需实体灯光设备进行创意光效实验。"
+  },
+  "9f1bb8c2f14f": {
+    "faqItems": [
+      {
+        "answer": "分级不需要检查点——GLSLShader 直接应用 CurveEditor 设置。生成视频需 ByteDance2ReferenceNode（Seedance 2.0）及其依赖。只做分级静帧无需视频节点。",
+        "question": "这个工作流需要扩散模型或 checkpoint 模型吗？"
+      },
+      {
+        "answer": "不是必需。GeminiNode 仅用于提示生成或润色。可手动输入提示并传给 ByteDance2ReferenceNode。如用 Gemini，需按节点说明配置 API。",
+        "question": "GeminiNode 必须用吗？"
+      },
+      {
+        "answer": "曲线尽量平滑，锚点越少越好，避免极端 S 曲线。用 PrimitiveFloat 控制 GLSLShader 混合度。用 ImageHistogram 保证黑白不过界，SaveVideo 导出时用高码率减少压缩瑕疵。",
+        "question": "用曲线时如何避免断层或色彩溢出？"
+      },
+      {
+        "answer": "确保 ByteDance2ReferenceNode 的参考输入为分级图片。适当降低运动强度或风格化参数，固定种子保证可复现，SaveVideo 前不要再做额外色彩变换。",
+        "question": "为什么视频颜色和分级静帧有偏差？如何保持一致？"
+      }
+    ]
+  },
+  "a335e0968d76": {
+    "howToUse": [
+      "在 ComfyUI 中加载 Music Generator 工作流 JSON，确认所有节点均为绿色（已加载）。",
+      "打开流程图中的 MarkdownNote，快速了解流程和作者提示。",
+      "在 Stable Audio 3 节点（UUID: 8b66c757-fe2f-4184-91f3-479a19deb565）输入简明提示词，包含风格、乐器、情绪/能量及关键描述（如“振奋的合成器流行，模拟贝斯，强劲鼓点，100 BPM 感觉”）。",
+      "用 PrimitiveFloat 节点设置所需时长（如 0.8 代表单击采样，3–5 代表音效，15–60 代表音乐底床）。如有需要，调整 Stable Audio 3 节点的其他参数。",
+      "配置 SaveAudioAdvanced，选择输出文件夹和文件名规则。如需自动保存，可启用自动保存功能。",
+      "点击运行按钮执行工作流。运行完成后试听保存文件。可通过优化提示词或时长反复迭代，调整风格、紧凑度或冲击力。"
+    ]
+  },
+  "b27220a578ee": {
+    "metaDescription": "用 Chatter Box 将音频转换为不同声音，保留时序和表现。适合配音和个性化旁白。"
+  },
+  "b4577f326660": {
+    "extendedDescription": "本 ComfyUI 工作流可将视频素材转换为时序稳定的深度图，采用先进 AI 模型。核心为 Depth Anything v2 模型，擅长从视频输入生成准确的深度图。流程以 VHS_LoadVideo 节点导入视频，DepthAnything_V2 节点处理每帧，生成在帧间保持时序一致性的深度图。这对于增强现实或 3D 重建等需平滑过渡和稳定性的应用尤为重要。\n\n流程还包含 VHS_VideoCombine 和 VHS_VideoInfo 节点，便于在 ComfyUI 环境中管理和整合视频数据。comfyui-videohelpersuite 和 comfyui_controlnet_aux 自定义节点增强了视频处理和参数控制能力。通过这些节点，用户可获得高质量、可直接用于后续处理或集成的深度图。这个工作流特别适合虚拟现实、游戏、影视制作等领域的专业人士，深度信息可极大提升数字内容的真实感和交互性。"
+  },
+  "b4d8756a63c1": {
+    "metaDescription": "用 ACE-Step v1 将文本转为音乐。这个工作流通过文本提示生成歌曲，助力创意与音乐表达。"
+  },
+  "b8c030205d86": {
+    "extendedDescription": "Fast GAN 视频超分工作流基于生成对抗网络（GAN）模型（如 Real-ESRGAN），高效提升视频分辨率。适用于需要提升视频质量但无需生成新细节的场景（与扩散模型不同）。这个工作流的核心节点包括 UpscaleModelLoader 和 ImageUpscaleWithModel，对每一帧应用超分模型。流程以 LoadVideo 节点加载视频，通过 GetVideoComponents 拆分帧，随后进行超分处理。\n\n技术上，流程利用 Real-ESRGAN 模型按所选倍率（如 2x、4x）对每帧超分。ImageUpscaleWithModel 节点逐帧处理，最后用 CreateVideo 节点重组为视频，SaveVideo 节点输出超分后的视频。该方法比基于扩散的超分更快，适合快速增强。建议先超分到最高分辨率，再根据需要调整到目标分辨率，以获得最佳效果。"
+  },
+  "b993c1885a29": {
+    "extendedDescription": "本ComfyUI工作流“Flux.1 Dev：文生图”专为通过文本提示生成高质量图像而设计，采用Flux Dev完整版。这个工作流需加载多个模型文件，并需要较大显存以保证高效运行。其突出特点是优异的提示词理解能力和卓越的图像质量。关键节点包括VAEDecode和SaveImage，分别负责将潜空间解码为图像并保存最终输出。KSampler节点在采样潜空间以生成多样化图像时起核心作用。流程还用到UNETLoader和VAELoader加载UNET和VAE模型，是扩散过程的基础。此外，CLIPTextEncodeFlux节点将文本提示编码为模型可理解格式，确保生成图像与输入文本高度一致。",
+    "faqItems": [
+      {
+        "answer": "由于需加载多个模型文件并生成高质量图像，建议使用至少8GB显存的GPU。",
+        "question": "这个工作流对硬件有何要求？"
+      },
+      {
+        "answer": "可以，流程设计为高度遵循提示词，但生成效果与提示词的清晰度和具体性密切相关。",
+        "question": "可以用任意文本提示吗？"
+      },
+      {
+        "answer": "请确保使用正确的模型文件，并尽量详细、具体地编写提示词。根据显存调整图像尺寸也有助于提升质量。",
+        "question": "如何提升生成图像的质量？"
+      },
+      {
+        "answer": "请优化文本提示的清晰度和具体性，并确保所有模型文件已正确加载且与流程兼容。",
+        "question": "生成图像与提示不符怎么办？"
+      }
+    ]
+  },
+  "baa06a413558": {
+    "description": "这个工作流适合用Seedance 2.0从单张图片快速生成4-15秒视频"
+  },
+  "be07722555ff": {
+    "extendedDescription": "ComfyUI 中的 Flux.1 图像外扩绘图工作流用于将图片扩展到原有边界之外，即外扩（outpainting）。该技术适合为图片添加内容或将小图扩展为大场景。流程用到多个关键节点和模型，包括用于外扩的Flux.1模型（由FluxGuidance节点引导）。流程先加载所需模型和待外扩图片，再用ImagePadForOutpaint节点为图片扩边。随后，KSampler节点迭代生成新区域，VAEDecode和UNETLoader协作，确保新内容与原图无缝融合。\n\n本流程优势在于利用先进AI模型，在扩展图片时保持原有美学和主题一致性。CLIPTextEncode节点可输入文本提示，引导外扩内容风格和主题。适用范围广，从艺术创作到设计、媒体生产均可用。",
+    "howToUse": [
+      "在 ComfyUI 中加载 Flux.1 图像外扩绘图工作流。",
+      "用LoadImage节点导入需扩展的图片。",
+      "确保已加载Flux.1及相关文本编码器等必要模型。",
+      "用ImagePadForOutpaint节点为图片扩边，准备外扩。",
+      "运行流程，用KSampler和VAEDecode节点生成扩展内容。",
+      "用SaveImage节点保存最终外扩图片。"
+    ]
+  },
+  "c1959fdc5642": {
+    "extendedDescription": "此 ComfyUI 工作流利用开源 SeedVR2 放大模型，实现高质量的单图像超分辨率。流程极简且适合生产：LoadImage 节点导入原始图像，SeedVR2 Upscale 节点（c35dd4ba-0fe3-47d6-afce-1c56d9fe5beb）提升分辨率并重建细节，SaveImage 节点将结果写入磁盘。由于流程专注于放大，无需提示词、采样器或扩散步骤——速度快、可重复、易于调整。\n\n底层原理是 SeedVR2 通过学习映射，在更高分辨率下预测高频细节，同时保留原始构图和色彩，并提升锐度和纹理。实际操作中，加载图像，选择 SeedVR2 节点提供的放大倍数（常见为2倍或4倍，具体取决于节点配置），提交任务并获取输出。非常适合用于印刷资产准备、渲染放大或给 AI 生成的图像润色放大，同时保持内容不变。"
+  },
+  "c2aae816fe63": {
+    "description": "照片级的 AI 人脸替换"
+  },
+  "c3e308dab99b": {
+    "extendedDescription": "本 ComfyUI 工作流通过开源方案自动实现真实的产品植入。你只需提供最多三张产品图和一张参考合成图，工作流会将产品放入场景，并保留文本感知的细节，同时使光照跟随参考图。Qwen3-VL 阶段分析输入并生成富上下文的编辑提示，Flux.2 Klein 9B 进行多图合成，LTX-2.3 将最终静帧转为精致的产品短视频。核心实用节点如 LoadImage、PreviewImage、PreviewAny、BatchImagesNode、StringConcatenate 和 SaveVideo，方便你反复调整和导出。\n\n技术细节上，产品和参考图片会被加载、批量处理并自动缩放，无论原始分辨率如何，Flux.2 Klein 都能获得清晰一致的输入。Qwen3-VL 通过 StringConcatenate 组装提示词，并传递给 Flux.2 的采样器，控制产品位置、标签还原和场景光照。合成效果可在 PreviewImage/PreviewAny 节点确认，满意后由 LTX-2.3 生成短动画片段，SaveVideo 节点将结果保存到本地。自定义推理节点（461b058e-342d-497e-aac1-a5fb6551e33a、fdd45ff8-8dff-43e8-b2c0-2d26053388b8、6dbca6ef-ca4b-4af8-a99b-b834745f3a9b、5c2c98c8-2e8f-47ca-9403-686e35a5ef94、04e3b3b1-a711-485c-be05-f59f9507bd4e、ffacbfba-7659-45df-a3b8-7560f4800088）封装了模型推理和缩放/条件逻辑，支持完全本地或 Comfy Cloud 云端运行，无需闭源API。"
+  },
+  "c5cbee07611f": {
+    "extendedDescription": "此 ComfyUI 工作流帮助品牌和创意团队快速将现有海报放入真实的户外广告（OOH）场景。流程分为两个清晰阶段。第一步——海报重新构图：读取源海报，并以非破坏性方式将其重新适配为多种长宽比（竖版、横版、方形或自定义），同时保留原始设计。该阶段由 LoadImage、PrimitiveNode（宽/高数值）等节点驱动。，通过 PrimitiveBoolean 控制格式启用/禁用，ComfySwitchNode 路由所需格式，BatchImagesNode 批量输出，SaveImage 保存干净的重排版本，便于后续投放。\n\n第二步——户外广告可视化，将选定的重排海报合成到真实或描述的环境中。你可以通过 IMAGE ENVIRONMENT 分组的 LoadImage 上传实景照片，或在 PROMPT ENVIRONMENT 分组用自然语言描述场景（如“旧金山市中心两层楼顶的户外广告牌，行人视角”）。GeminiImage2Node 作为提示助手，将描述转为结构化场景说明和文件名上下文。两个自定义处理节点（ae42e662-5e2b-4f52-b31d-267bd68f1c6f 和 88b611c3-ce43-4e7a-a59f-dd16f57a8853）负责将海报透视映射并融合到目标表面，可微调比例、倾斜和叠加强度，实现真实投放效果。SaveImage 输出最终提案，可批量导出，便于对比不同格式和场景。"
+  },
+  "ccf567b604be": {
+    "faqItems": [
+      {
+        "answer": "需在允许 `127.0.0.1` 或 `localhost` 访问的安全网络环境下，并且必须使用以 `https` 开头的 Web 服务。",
+        "question": "使用该工作流需要什么网络环境？"
+      },
+      {
+        "answer": "可以，工作流支持自定义运动幅度和时长，满足不同视频需求。",
+        "question": "可以调整视频长度和运动幅度吗？"
+      },
+      {
+        "answer": "视频以主流标准格式保存，兼容大多数播放器，便于播放和分享。",
+        "question": "视频保存为哪种格式？"
+      },
+      {
+        "answer": "有相关经验会更好上手，不过这个工作流设计得很友好，节点配置和运行都很简单。",
+        "question": "需要有 ComfyUI 使用经验吗？"
+      }
+    ]
+  },
+  "d70243b6fc64": {
+    "title": "证件照生成器"
+  },
+  "d7677ac50371": {
+    "extendedDescription": "本 ComfyUI 工作流“虚拟试衣与角色 - 4 合 1”专为 AI 图像生成虚拟试衣设计。用户可上传角色图片和服装平铺图，随后用 Nano Banana Pro 模型在单次提示下生成角色穿着该服装的 4 种变体。这个工作流用到 LoadImage 导入图片，ResizeAndPadImage 调整尺寸，BatchImagesNode 支持多图并行处理。comfyui-kjnodes 和 comfyui_essentials 的自定义节点增强了功能，实现无缝集成和处理。适合时装设计师、数字艺术家、电商平台无需实物样品即可可视化服装上身效果。"
+  },
+  "dc4b3f6dab6e": {
+    "extendedDescription": "此ComfyUI工作流可快速、可复用地生成时尚产品九宫格。你只需提供两项输入——时尚大片参考和干净的产品图，流程即可生成8个角度变化且产品一致的图像。流程核心依赖Nano Banana Pro进行图像生成，并用一组简明一致的提示词驱动多样性，确保产品外观不漂移。输出以9:16竖版4K（2160x3840）九宫格拼图，便于快速评审或社交/电商交付。\n\n技术上，流程用LoadImage节点导入大片参考和产品图。PrimitiveStringMultiline节点存储8个角度指令（可编辑以更换视角），PrimitiveNode节点存储数值参数（如角度数或种子）。GeminiImage2Node（配置为gemini-3-pro-image-preview）可辅助分析大片参考或生成提示文本。两个essentials节点（UUID为68c58c16-e698-45a4-97f9-54ae8eb9dee9和487baed2-dc27-49c3-a6b2-0bf45a53e64d，来自comfyui_essentials）负责图像拼接和布局，BatchImagesNode收集8张结果，RegexReplace清理文件名，SaveImage输出单张8 格拼版及可选单帧。最终仅用两次Nano Banana生成即可扩展为8个一致角度。",
+    "faqItems": [
+      {
+        "answer": "编辑 PrimitiveStringMultiline 节点。替换或调整角度指令顺序以匹配所需视角。流程会按每行生成一张图片，最后将八张拼成拼版。",
+        "question": "如何更改生成的八个角度？"
+      },
+      {
+        "answer": "不必。GeminiImage2Node（gemini-3-pro-image-preview）是可选辅助节点，用于从参考图自动生成角度提示。若需完全手动控制，可只用 PrimitiveStringMultiline 节点。",
+        "question": "必须用 GeminiImage2Node 吗？"
+      },
+      {
+        "answer": "一致性来自使用同一产品图片输入和严格限定的 Nano Banana Pro 提示。保持产品图片干净、光线充足，避免过度创意修饰，若需更高复现性可复用固定种子。",
+        "question": "如何保证产品一致性？"
+      },
+      {
+        "answer": "可以。BatchImagesNode 会将每帧传递给 SaveImage。你可以同时保留 8 格拼图和单帧图片，或关闭拼图输出路径，仅保留单独图片。",
+        "question": "能否导出单张图片而不是拼图？"
+      }
+    ]
+  },
+  "def270551fbe": {
+    "faqItems": [
+      {
+        "answer": "FlashVSR在提升视频细节和减少伪影的同时，保持运动一致性，能在多种分辨率下输出自然效果。",
+        "question": "使用FlashVSR进行视频超分的主要优势是什么？"
+      },
+      {
+        "answer": "分辨率越高（如2K、4K），处理时间通常越长，因为需要处理的数据和细节更多。",
+        "question": "分辨率选择如何影响处理时间？"
+      },
+      {
+        "answer": "工作流支持常见视频格式，具体兼容性需参考LoadVideo节点的支持范围。",
+        "question": "这个工作流可用于任何视频格式吗？"
+      },
+      {
+        "answer": "请根据质量需求、目标显示尺寸和处理能力综合考虑。高分辨率细节更好，但资源消耗也更大。",
+        "question": "如何选择合适的超分辨率？"
+      }
+    ]
+  },
+  "e2df0992de37": {
+    "extendedDescription": "Nano Banana Pro：产品细节增强工作流旨在将你的产品图片提升到更高水准，增强细节和锐度。该工作流利用专为产品图片优化的Nano Banana Pro模型。流程从LoadImage节点上传产品图片开始，随后通过GeminiImage2Node应用高级算法，提升图片细节、优化排版，并保证真实感。最后，使用SaveImage节点保存增强后的图片，获得高分辨率、高质量的输出。\n\n这个工作流特别适合需要以最佳效果展示产品的电商企业和产品摄影师。通过提升产品图片的细节和锐度，有助于吸引客户，提升视觉吸引力。Nano Banana Pro模型确保增强效果既真实又美观，既提升展示效果又保持产品本身的真实性。"
+  },
+  "e5c914d15241": {
+    "extendedDescription": "Qwen-Image-Layered 图层控制拆分，帮助用户利用 Qwen-Image-Layered 模型将图片分解为各个组成部分。该流程特别适合需要隔离图像特定部分以便进一步处理或分析的艺术家和设计师。流程从 LoadImage 节点加载图片开始，通过 ImageScaleToMaxDimension 节点调整尺寸。核心节点 f754a936-daaf-4b6e-9658-41fdc54d301d 利用 Qwen-Image-Layered 模型进行分解。\n\n该工作流技术上非常健壮，允许对图像图层进行精确控制，并可通过 SaveImage 节点保存。MarkdownNote 节点用于记录流程和提供操作指引。分层分解适用于需要细致编辑的场景，如平面设计、数字艺术，甚至科学成像中对特定特征的隔离和分析。"
+  },
+  "ed1c4eade3a3": {
+    "howToUse": [
+      "在 ComfyUI 中加载工作流，将源图片拖入 LoadImage 节点（批量处理可用 BatchImagesNode）。",
+      "在 PrimitiveStringMultiline 节点描述所需运动（如“头发轻轻飘动，眼睛眨动”）。RegexReplace 和 GeminiNode/GeminiNanoBanana2 会自动简化为模型友好提示。",
+      "定义运动区域：用 MaskPreview 检查动画区域并调整，MaskToImage 转换遮罩用于运动阶段，保证背景静止。",
+      "打开 ByteDance2ReferenceNode，检查运动强度、循环长度等关键参数（如有）。在 GetVideoComponents/CreateVideo 设置 fps/时长以适配平台。",
+      "点击运行按钮执行工作流/生成。用 PreviewAny 监控中间帧，如有边缘伪影或抖动可调整遮罩柔和度或运动强度。",
+      "用 SaveVideo（MP4）导出结果，如需保留遮罩或关键帧可用 SaveImage。"
+    ]
+  },
+  "ef36ec96537f": {
+    "extendedDescription": "本 ComfyUI 工作流聚焦对比 ACE-Step 1.5 音乐生成模型与其小模型版本。主要目标是评估 4B 版本模型在音频理解和作曲能力上的提升。通过文本提示生成音乐，用户可探索不同模型在音质、复杂度和还原度上的差异。这个工作流用到 KSampler、VAEDecodeAudio 和 TextEncodeAceStepAudio1.5 等节点，便于对比。4B 模型可处理更复杂的作曲，生成更丰富的音频纹理，尤其在生成较长或复杂音乐片段时优势明显。",
+    "faqItems": [
+      {
+        "answer": "ACE-Step 1.5 模型具备更强音频理解和作曲能力，生成的音乐比小模型更丰富、更复杂。",
+        "question": "ACE-Step 1.5 与小模型主要区别是什么？"
+      },
+      {
+        "answer": "流程用 TextEncodeAceStepAudio1.5 和 VAEDecodeAudio 等节点，将文本提示转为音频，充分利用 ACE-Step 模型能力。",
+        "question": "这个工作流如何实现音乐生成？"
+      },
+      {
+        "answer": "可以，在文本提示中加入风格关键词即可引导模型生成目标风格音乐。",
+        "question": "可以用该流程生成特定风格音乐吗？"
+      },
+      {
+        "answer": "需根据所需音频复杂度和质量，以及计算资源情况选择。大模型生成更复杂音频但需更多算力。",
+        "question": "选择 4B 模型还是小模型应考虑哪些因素？"
+      }
+    ]
+  },
+  "f889bba5102a": {
+    "howToUse": [
+      "在 ComfyUI 中加载工作流 JSON。如本地运行，先下载所需 Qwen-Image 资源：将 qwen_image_vae.safetensors 放入 models/vae 目录，并按文档安装 Qwen-Image 扩展。确保 Gummy Animals LoRA 已放入 LoRA/models 文件夹。",
+      "打开 Qwen-Image 生成节点（id: e5cfe5ba-2ae0-4bc4-869f-ab2228cb44d3）。在提示词中输入动物主体（如“红熊猫，半透明酸味软糖，糖晶体，柔光背打，白底棚拍”）。可选输入负向提示词（如“毛发，真实皮肤，水印，logo”）。",
+      "设置 LoRA 强度控制风格。建议 0.7–1.0 呈现强烈软糖感；低值保留更多基础模型写实感，高值则极度风格化。",
+      "调整生成参数：分辨率（如 768×768 适合单主体），步数（如 20–30），引导（中等值保持色彩鲜明），种子（固定便于复现，-1/随机便于探索）。",
+      "点击运行按钮执行工作流。可在 ComfyUI 预览器和 ComfyUI/output 目录查看输出（由 SaveImage 节点写入）。迭代优化：调整提示词（如加入“半透明”“糖衣”“颗粒表面”），调节 LoRA 强度和引导，直至质感和通透感理想。",
+      "可选：将 Qwen-Image + LoRA 封装为子工作流（见 Markdown 注释的子工作流指南），便于在其他流程或批量管道中复用软糖风格模块。"
+    ]
+  },
+  "f9cffe716495": {
+    "extendedDescription": "这个工作流可将简短文本提示转为连贯视频，基于 Wan 2.1 VACE。流程用 CLIPLoader + CLIPTextEncode 编码提示词，驱动 Wan VACE UNet（UNETLoader）通过扩散循环（KSampler），采样行为由 ModelSamplingSD3 配置。WanVaceToVideo 节点负责时序潜变量生成，TrimVideoLatent 可精确裁剪帧数。采样后，VAELoader + VAEDecode 将潜变量转为 RGB 帧。最后 CreateVideo 组装帧，SaveVideo 输出 MP4，SaveAnimatedWEBP 可生成轻量预览。\n\n支持两种模型体积：VACE-14B（高质量，慢，支持 480p/720p）和 VACE-1.3B（快，仅 480p）。流程分组清晰：加载模型、提示词、采样与解码、保存视频（Mp4）、保存视频（WebP），14B 和 1.3B 独立分区便于切换。内置 CausVid LoRA（通过 LoraLoader）可提速，建议强度 0.3–0.7、步数 2–4、cfg ~1.0 用于草稿。最终高质量建议关闭或降低 LoRA，用 14B 默认参数（约 20 步，cfg ~6.0）。"
+  }
+}

--- a/site/src/i18n/reviews/zh.json
+++ b/site/src/i18n/reviews/zh.json
@@ -1,0 +1,4286 @@
+{
+  "00d3d57a5195": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "18d757c3e105",
+    "reviewedArtifactChecksum": "4cd86ffe2c8d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "011974792e13": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "806a5b976903",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0136284ecc19": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "8018e1a61643",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "017694778c62": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "9e409db6b6aa",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "021a11a45320": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "6515b3807443",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0250a153895c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "a152df2588c6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "02b3722db38c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "44edc2331fb8",
+    "reviewedArtifactChecksum": "e17ecfb054c3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "02bd87067503": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "9691f9721d1f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "02c118b50bc2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "219e0e92fc3f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0309de53eb52": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "32d192b2ebff",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0314e3bcf260": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "46fe50e34613",
+    "reviewedArtifactChecksum": "6a5496c2845e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "ec118c46c941",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "03ec1a367585": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "c57149348dec",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "e2793052e113",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "04479f67187d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "85877fbf56f8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "04bae0edf048": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "8960a3ccf0ac",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0553e57852fe": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c73130ac13b8",
+    "reviewedArtifactChecksum": "718fd2e5c11c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0615e56af586": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "934a33a0754c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "064da31db8f3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "5bb3cfaf2814",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "06caca08d30b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "d8b6f775a71e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "d019251ea49d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0801185d2115": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ac5c7d51b77a",
+    "reviewedArtifactChecksum": "7ade6c29f676",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0812b435d117": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "94987c995a43",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "085a4bba12f8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "52a19a3b1b16",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "085ff06f65f2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "60667c7de7b4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "08d91c5f3020": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "0484f893712a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "094c40ffb14f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "92018807a4c8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0a6672ca248d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "3febf03caf9c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "ca3fb4ee8655",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0b405e2734df": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "0f66d5bf3627",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "b6f434c21026",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "205ddab88b6d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0ba871b9578d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "a5d61e6a3c87",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "fcb7d5419ef5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "c877f9b0bdf5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "cba1e03e9d98",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1043317e75c9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "7e8b73799a3c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "105559626c80": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e095741cc033",
+    "reviewedArtifactChecksum": "b325381a1c24",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "113c9ab2c6d7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "387ec1f14afa",
+    "reviewedArtifactChecksum": "a1d889c46244",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "11657ed32877": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "63b92d2012c3",
+    "reviewedArtifactChecksum": "7654ecc17f42",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "126feda70bcc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "d08bd1b066e6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "12c2481d04b4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9c6ff6175b64",
+    "reviewedArtifactChecksum": "bc35dd7d0208",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "130a350ff0b3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "f62c7a68c32d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "13ba3af78782": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f35ddb881ae7",
+    "reviewedArtifactChecksum": "1bf3aa1c4cc5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1446c7f47aee": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "4bce966f888c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "14597b195403": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c17e54fbe09a",
+    "reviewedArtifactChecksum": "60c807d6394e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "15538e51d812": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "935eb3882193",
+    "reviewedArtifactChecksum": "1067639c1173",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "94a1167321cb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1606e79dd224": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "197dfb23e33a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "1e1ec302e7e7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "16f123e593db": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "6317396d7a51",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "171dea657096": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "91799cf35e77",
+    "reviewedArtifactChecksum": "7a230140e27b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1785e38f230a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "d54e3690681a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "17883fb20765": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "bdf1edefd36b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "181a9571c9a0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "4f1e1c084b43",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "182021fcf3dc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f0eff80aeaad",
+    "reviewedArtifactChecksum": "a49e7e8ba500",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1880d7035ea2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "074cabcfbdca",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "18da3456241d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6f5a6f71f9d9",
+    "reviewedArtifactChecksum": "a29e07942732",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "18f288d70060": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "48c650d69db9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1a126268f912": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "2317f9a999ee",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1af3df552a07": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "68504f3cd460",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "c9ab67095f2b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1c77e82713b7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "37fd0dce8daa",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "85133dd6da9f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "7b74d19966ef",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1cbba0417673": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "533da403c88b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1d16e17134e1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "fbd092108274",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "8b1dbc8630a4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "d43b4febfef9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "3c6bfb876c28",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1f594885b9cb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "3e14b5c76d6f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "1fb07c3b4b99": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0d2ce08d29a8",
+    "reviewedArtifactChecksum": "f68be6ef49da",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "9d1ce3334a39",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "204bbd9ee146": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "d96080c2151f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "20ff6cad791c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "7fd0118d4360",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "228fef3dbe05": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "c5ed4b5cd449",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2318d5c3d250": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "3fb264fd03a0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "231992fee1a6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "32ff03411593",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "23226868cf80": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "267006baa10b",
+    "reviewedArtifactChecksum": "c954e23f3114",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "234798f9a5cd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "ea61b35d5034",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "260ed6c2147f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "73a812d2aaf7",
+    "reviewedArtifactChecksum": "581ac366ba8b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2620e5135442": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "898d2af58acc",
+    "reviewedArtifactChecksum": "a5bbfd6a0c86",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2639a76cf00e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "f5f3bafc7956",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2652985596d8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "eddea5c0dbca",
+    "reviewedArtifactChecksum": "3cdebcd422ec",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "268307c5793e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e73f6dbefda5",
+    "reviewedArtifactChecksum": "af35be5884d7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "26e1f4eddd7e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "44093fc53faa",
+    "reviewedArtifactChecksum": "2bc06cb9c1fa",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "27bacca060cb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "81664c530a0a",
+    "reviewedArtifactChecksum": "816087ec4a53",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "282b1e22f040": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "654c197aff95",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "28bef9a984ce": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b5c9754c6f0e",
+    "reviewedArtifactChecksum": "f9ed10c8acd0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "29633c85694f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "699270df1f2f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "cf95023f8f46",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "299685fcb8dd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "4288c85ea965",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "29be9776c3b0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "245077b26bf4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2a95da601676": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f3cd6bdb534d",
+    "reviewedArtifactChecksum": "658123e934ca",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "d0a21bdaba4b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "a72d69155525",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2c4b652466d9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0ccc760fcbc2",
+    "reviewedArtifactChecksum": "b0683c1331ef",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "5a5897334ad1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2da831d21d09": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "0eb9da77acc5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2da9ee24ad74": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4186cea3bf4d",
+    "reviewedArtifactChecksum": "c8139d76b55d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "2ac761d36ba2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2f10814fd823": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "e3cc60d8e76e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "e4d4018ab097",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "300efdae24f6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "b76376ff8393",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "f1c713cc2689",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3249521762e4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "5858db0b173f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "325247297bf2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "72b890749d2d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "32890fa5798a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "b7db420382bb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "330550d83e6c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "780f36467b34",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3340bf62687d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "ad1c488c0a25",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "33747bd52ad5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "fa33ee195c74",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "33c621f7803f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "e6026cbc8ac1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "6383b268a7cd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3515c5083027": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "554e4ef6a5f3",
+    "reviewedArtifactChecksum": "579bc4859ead",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "351e79d06ae1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "358d6127c306",
+    "reviewedArtifactChecksum": "86659841738d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "361cd788164e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "2a05e9be339a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "364e72458b36": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5605da08c0e6",
+    "reviewedArtifactChecksum": "cdc47b68ef71",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "36794f399aa0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "10bb52f9335e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3755b3465820": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "788a5febdf8a",
+    "reviewedArtifactChecksum": "1a150acce8fb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3858678780f1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2b9a6690fdf4",
+    "reviewedArtifactChecksum": "8e5bec02fc2d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "387eb41c0702": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "4f5071aa91f4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "9ddaa22deac0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "39d6048bf91e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d3a2c2fbc8ec",
+    "reviewedArtifactChecksum": "65ff6afd3102",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "39f7098079f8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1e2c27847ee1",
+    "reviewedArtifactChecksum": "67915dc7ae03",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3b9e9f29c1dc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "69a67afce7c6",
+    "reviewedArtifactChecksum": "ffd718bdae04",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "c4af665a1d7d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3cb47a67b81a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "19d587d12601",
+    "reviewedArtifactChecksum": "f78379e65d2d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3cf3c6a082ed": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "23fa60e1ebba",
+    "reviewedArtifactChecksum": "bfb6d9d6c380",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "59a8f76fcd6b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "6aee7db97aa0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3eb92c1b2380": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bf7aa20f745d",
+    "reviewedArtifactChecksum": "ef08970b948a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3ef4de40106b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "5e3b8441969e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "3efed399a12d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3ef55610485f",
+    "reviewedArtifactChecksum": "0c92b060e9d8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "404250f61d0a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c6f1fe977608",
+    "reviewedArtifactChecksum": "79aa5c62c671",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "40770c9eb41b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "f08f05efcc36",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "40a427168ef7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "a7c6e6e01c44",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "40dea2f852c3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "281d325c9adf",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "ca6c9f26ac24",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4176b98e2b7e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "810032a8dcaa",
+    "reviewedArtifactChecksum": "b80b3e3d36c9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "417d8dfe78c2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "583467999376",
+    "reviewedArtifactChecksum": "50d952ea9715",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "41f029c74cd4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "8006fa5d8ec7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "430b718c2c90": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "bd76fe891f1a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "439a815b15a0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "4c9527696427",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "44d156cf2723": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1e049f067e24",
+    "reviewedArtifactChecksum": "30c28d32123b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "452e68e4a484": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "44f9407339a6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4540c3f34805": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "5c769864a423",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "45638e198c1d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "19dbbbb7ff98",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "459fcec528e6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "65905a45506f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "45a8be9c1124": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "189dbae0eb4a",
+    "reviewedArtifactChecksum": "1846bbee8096",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "45c0ce6bcf2e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "152763825cc8",
+    "reviewedArtifactChecksum": "b4c7f1ee32aa",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4600a60d661b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "bdd00971db0b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "460daa6b205d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bb1e02435d8e",
+    "reviewedArtifactChecksum": "463d6c28a4eb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4638e59ae7d2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8a0e59ae686f",
+    "reviewedArtifactChecksum": "78bf4a1583ec",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "46a303cbccf9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "38811bc5d525",
+    "reviewedArtifactChecksum": "22eda756766d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "46a80518c9c6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "55cd4863a54d",
+    "reviewedArtifactChecksum": "2f5f772e5d75",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "46fc617ad144": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c8f8ad09fe7e",
+    "reviewedArtifactChecksum": "43b0d20c9252",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "471717404074": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "3339523f8dc1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4724032fa666": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "3d212bfa86a3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "47a892d81764": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "376ecaaeccc6",
+    "reviewedArtifactChecksum": "4462981b9933",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "47d245c34a7d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "fd5fa08711c8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "49a2f3a0811f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "51dc5f124b8f",
+    "reviewedArtifactChecksum": "09cec1638578",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4a4da321a45d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "04f477efeaa6",
+    "reviewedArtifactChecksum": "5729b8512785",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4a6697085e75": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ad1c8a8ecac9",
+    "reviewedArtifactChecksum": "78f56afd34e1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4ab928487496": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "9b421a3350d4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4b042b6638a6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "27c46c50ab30",
+    "reviewedArtifactChecksum": "7d0e2f38f4ba",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4b23697cd68c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "1ff530ed22ca",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4b64f0419f57": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "b0a0bb5f8727",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "bcd064e8511a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4ca799182440": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a16c03fe7032",
+    "reviewedArtifactChecksum": "cf1c36f8c94a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "f2490d7b66fb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "6200762c85eb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4d989a34d147": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "a6c07df2c385",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4df9e62285aa": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "69a95a27d19d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4dfdaf8f07d3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a50bbbf99764",
+    "reviewedArtifactChecksum": "4576c41f655e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4e430639b9b0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "b320b58abd0f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4e57a7fe516e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "83e635a7828c",
+    "reviewedArtifactChecksum": "7c0421b3bc10",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "9fdf5e102727",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "a039c9087a26",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "bba212726eb6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4f8b62bfd681": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6d64266bfd70",
+    "reviewedArtifactChecksum": "329214adb9f0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "5f26331afd84",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "50199f76fe74": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3c1fb24a9e72",
+    "reviewedArtifactChecksum": "7c755bbff9f1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "524727db7cac": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "c1e821b91af5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "7c1d027bbac2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "2552088ab14c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "52dd3f09bb59": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ce2975c65c9c",
+    "reviewedArtifactChecksum": "014a70926d3e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "536dc32faee1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1a12ade6eb6f",
+    "reviewedArtifactChecksum": "4863440de23d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "537cf7f1f745": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bb039818c192",
+    "reviewedArtifactChecksum": "ef6a6101aa04",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5427ef92c853": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "d71d77cdc0a9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5489b3cf2ac1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "62d873360da1",
+    "reviewedArtifactChecksum": "44046e987447",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "558cc012978d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6c9a40936909",
+    "reviewedArtifactChecksum": "95b96a47077e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "558dc01ae546": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c5045c9c5f05",
+    "reviewedArtifactChecksum": "eb224f8c50f8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "560738f98e65": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "4e5da271aa88",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5615df5d2e0d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "baf17938711f",
+    "reviewedArtifactChecksum": "aaf2d70e0e4f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "563f9b5f6ce3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "092def4efba1",
+    "reviewedArtifactChecksum": "3f4ae5bece43",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5652fbe7f479": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ec4de54fd666",
+    "reviewedArtifactChecksum": "e238c4f84d8e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5697ddf9182f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "5ca93167383c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "56e17946ef8c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9233fda5148f",
+    "reviewedArtifactChecksum": "210a973ef75f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "57eb4f2ddb92": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2271b8120f36",
+    "reviewedArtifactChecksum": "e626fd70dad0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "585c7006af9f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "7ecbcc8f4e67",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5931e9bdf9db": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "916bf36e3b22",
+    "reviewedArtifactChecksum": "f255dc2de913",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "598da2637dc8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "ad085dc1b6b5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "f88539cc502f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5ad4348c8417": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8e5f70f83529",
+    "reviewedArtifactChecksum": "29141f3edc7f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5ae006b13a36": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fa7092ff2f81",
+    "reviewedArtifactChecksum": "d5b61b931310",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5b8156052b93": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "0fa9c9539f9d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "54d3f85426a5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5cd417e793b8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "2f114cae089b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5cef286d4c51": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fab982dd28db",
+    "reviewedArtifactChecksum": "da37b7d09321",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5d0cbc370579": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "698aba7e4fe0",
+    "reviewedArtifactChecksum": "7e2e408f1fb0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5d72bed48e89": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "df522329de4a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5f1e9e754358": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "05e549cccdbc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5f8b74d92e62": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "23954b90525f",
+    "reviewedArtifactChecksum": "9e19aa4000a3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "ac5f31903733",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5fa9b44388cb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c75268e0ea37",
+    "reviewedArtifactChecksum": "e538b4f6324a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "5fd7dc1f9db5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "70417a1c18f0",
+    "reviewedArtifactChecksum": "e62b780ca723",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "603b2d01feb0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bab688e65c3f",
+    "reviewedArtifactChecksum": "c41882c42e80",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "60e1839cbb34": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "23ded424e7e5",
+    "reviewedArtifactChecksum": "b614c325c5df",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "615266189e02": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1a7cb54de4c8",
+    "reviewedArtifactChecksum": "9a777a2a29f3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "62cb2b168265": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9dc4ceaa4e05",
+    "reviewedArtifactChecksum": "04d3f72beb8b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6332ca621968": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1c422eaca74c",
+    "reviewedArtifactChecksum": "6ca47afe9f35",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "0cedc7e89a6d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6453aedf71ef": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "0a1aeb2622e8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "64f4db9e3e33": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "223cf2121461",
+    "reviewedArtifactChecksum": "363e9be9516c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "655893ad7990": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "904aabfd86ab",
+    "reviewedArtifactChecksum": "5b3a69df6448",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "65758201b8ae": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c1dcc0da6d2e",
+    "reviewedArtifactChecksum": "f1d354362506",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6645006a0cb7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "c549da9024fc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "67981edb9ad4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fa37a7c8d562",
+    "reviewedArtifactChecksum": "ce05677966f7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "67a816af8a73": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ee604150adb4",
+    "reviewedArtifactChecksum": "aea53ba95381",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "67b461209d58": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e95ee7304036",
+    "reviewedArtifactChecksum": "8cc616f34346",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "68c39b4c6a6f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5106ec4eb948",
+    "reviewedArtifactChecksum": "b75c59bf6fa2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "68dcfc02a679": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5dbfcd37a1ff",
+    "reviewedArtifactChecksum": "d2a38daeabb1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "68f726502f5a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "869370bc45ea",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "69850664cf89": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "a45ec80a17b4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6991493996fd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "ffeb3f23c2b7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "69a3789c4840": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "79a4cab80516",
+    "reviewedArtifactChecksum": "31cc40fb5b32",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "24578e85e2cf",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6a2b37d44146": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ebbffb505567",
+    "reviewedArtifactChecksum": "e351f674f5f1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6a74b644797c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "0f1e4c911cc7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6afbca6e9d22": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bb05dda45844",
+    "reviewedArtifactChecksum": "7be4f1716259",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "eae88258e963",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6b3078795300": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "2423acd87839",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "2c69233d713d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6be2f4df213a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "9e32d5cc6b8f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6c3fa01b5d73": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ce44981723ba",
+    "reviewedArtifactChecksum": "0b631630720b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "672d2fae6d2a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6d0042d2f554": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "07611af3f621",
+    "reviewedArtifactChecksum": "bdd1dfdd1afa",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6e099b1a7822": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "85c8585ef6ce",
+    "reviewedArtifactChecksum": "e4042c3dc724",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6e92ce657980": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "8f4b238c5477",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6f168e04611e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "cdc37ca6fd18",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "607abe74796e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "fdb4b01c6a4f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6fcaf95e52b2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b98247d4d4a3",
+    "reviewedArtifactChecksum": "c472c04bfd67",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "6fec31e40f4a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "dc934cbc82b8",
+    "reviewedArtifactChecksum": "ab066c218109",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7016f027bcf1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "89bfae371435",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "70dea50257fa": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "46d745fc4a4f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "70e6b211c5ff": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bfd219d920b4",
+    "reviewedArtifactChecksum": "966e44e44d88",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "70f751a09a5f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "fdb1db01e77d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "71355ee91724": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9f168dc59d8b",
+    "reviewedArtifactChecksum": "ff5e3c2cf498",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "71a0edbac544": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "9c11a70d0b0d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "723870e886d7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "2fc7e92580c6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "d5556d7b5a3b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "730d964da0cc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "02c64ba307fd",
+    "reviewedArtifactChecksum": "fc7a7653036b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7330608df8b7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "c6fb428b13a0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7332830d0455": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "01cf4079c482",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "736ab92b893a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ca13f304ebba",
+    "reviewedArtifactChecksum": "be70eeaed6f8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "73a6511dc29e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "728cfd09e417",
+    "reviewedArtifactChecksum": "0cd36a9a2ca7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "74335786d7e5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "f610ccaf4c6f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7553d92529e0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "7504fd0d0f81",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "75fb83052003": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2997faf42514",
+    "reviewedArtifactChecksum": "57260e891ecc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "768526487e8d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5f1c03a7a813",
+    "reviewedArtifactChecksum": "8cc9b236bb18",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "76d64ca52b45": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "a13884228d3a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "770640dfddef": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "8b17f207ae96",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "782abbc43435": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "b9c252e23f45",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "787cfd599758": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "e525fa951d2b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7905fe6d550c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "dda9abdd432e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "79227f845a2c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "24d37188be5e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "1d08daf0bc99",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "79bdba6f2250": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "bd53422a6cd5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7a6ab8b6e694": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bac15fa24b1e",
+    "reviewedArtifactChecksum": "7251e1fa4b4e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7b25a77c44de": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "2a804f036be7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7b973ace62af": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "e8439ddc4f31",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7c0c712700e0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bb9bf2dbbc9f",
+    "reviewedArtifactChecksum": "3f359bcd12d7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "6184764b50ff",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7cecbe192fc2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "195d7bfcd500",
+    "reviewedArtifactChecksum": "39534569eda0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7cfb99272578": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "f868110248ee",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7dca0438edf4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0a20647f365c",
+    "reviewedArtifactChecksum": "47cd36217e0e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "5ac365f73f68",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "80434583707e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "597c5c85c0b5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "814fd547d86e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "22b0892dda93",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "81643690b5e9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "971aaed4573b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "81ba03930d2b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "2aabe2303240",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "821350279daf": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "00a7c0404dfe",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "825e6fb23c2c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2f9084ed9312",
+    "reviewedArtifactChecksum": "7b7cb2caf8a3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8357db8ead93": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "846d1964fbdf",
+    "reviewedArtifactChecksum": "a7ce103dcce3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "83ff3768d42b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2c3e7617c972",
+    "reviewedArtifactChecksum": "4d1ed071e7b8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "840b6e4c3983": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "575ac8693ee3",
+    "reviewedArtifactChecksum": "5ea083444774",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "847f17f3f95c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ba380c49e96f",
+    "reviewedArtifactChecksum": "0476d74bd73e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "857e50707831": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "806767ed8960",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "85e7df4b564e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "f7baa79e3bee",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "86efedaffa3e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "0509a76ab00c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "874c251ff2f2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "8ff24be3c43c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "875410c650b8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "5f337602d791",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "87f3b4c32e4f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "405b0711392d",
+    "reviewedArtifactChecksum": "5f7134a071cd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "c51b998c6a2a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "88f014a33e2a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "7cc3723c5df2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "894c44a995a2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f8eec53904a2",
+    "reviewedArtifactChecksum": "3be7e8d5ccc7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "895960b69952": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "5a4dc010c8f2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8a1f5f5998cb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2d71fda9dbb3",
+    "reviewedArtifactChecksum": "7e98063e6abc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "e437bff4920a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8a90e1694881": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "65a70bb6e04a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8c553cc7c664": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "499792e4d375",
+    "reviewedArtifactChecksum": "f59ec7c369c9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8c7390cc52c2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6713a12925e8",
+    "reviewedArtifactChecksum": "770b81454ced",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8c7511104c80": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "367563a42b07",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8c90417df6d3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a607c0fb4184",
+    "reviewedArtifactChecksum": "45dc868c42f3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "b6319af757fb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "4dc9bf7656fd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "40d12d2ada27",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8e090ccf5a29": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "47f76e5028f9",
+    "reviewedArtifactChecksum": "579302daa2c9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "b6ca179a41cd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8f381a482443": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "b8a7f6da0009",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8f90aec3d12c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5b3ffacce720",
+    "reviewedArtifactChecksum": "139362d53aef",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "8fe7ed30c4ec": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7a9cc5890cb7",
+    "reviewedArtifactChecksum": "08995cb9f815",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "901ea40700aa": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "1ef32277c602",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "8e41499d94d5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "90d086fef9e3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7ef0f5883edf",
+    "reviewedArtifactChecksum": "ed1e80010a84",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "911c19a4391b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8d806844167e",
+    "reviewedArtifactChecksum": "7a0b4dfb95d6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "915d8a703908": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "a5dddf264936",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9173ef378024": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "745a96cf4e29",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "91a17d5206d2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9f80b0c183e1",
+    "reviewedArtifactChecksum": "03c958a48bd9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "91ec966e3abb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "7461b7d32020",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "920c6926e747": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "d0649cb3f11f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "924b279f0df1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "fb6daafc3fc8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "c58deaa5ebc8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "259c1b41ba11",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9394f9968da3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d3dcee651464",
+    "reviewedArtifactChecksum": "06582741dfd7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "93c182d3aefb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "824a32cd04a0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "93f286fbc2c8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "37ff0c409aa4",
+    "reviewedArtifactChecksum": "7ddb75875abe",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "947be2b6d997": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "6b34c2779c51",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "94ed41b87579": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "adb1da920293",
+    "reviewedArtifactChecksum": "3877e2c3dc37",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9654558acd06": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "55a12731a191",
+    "reviewedArtifactChecksum": "727e6dc23916",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "b28a03a84ab7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "96f9694b12c4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "6bfeefe2c9ce",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9717b437111c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "6c7f29fabf50",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "977bc7f55865": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "16b8504f3ddc",
+    "reviewedArtifactChecksum": "99c07302bf59",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "977fefa2b934": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "78dc929ff375",
+    "reviewedArtifactChecksum": "ed7c7559ff0e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "97efe22684e2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "34770692b486",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9829786b38f5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "040c3bddf80d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "983da4819066": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "af3445725f04",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9851c174a194": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "dd55d897b05c",
+    "reviewedArtifactChecksum": "a27209c18d63",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9974666c3acb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "71d3d1fa5eeb",
+    "reviewedArtifactChecksum": "ae2305a985a2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "99820d00487b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "42d250839599",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9990019f0e74": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "4b4ac899f877",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "99ac5a75449c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "0dd864d3f732",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "99aec65eea89": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "08ee59c22c25",
+    "reviewedArtifactChecksum": "49652f237a31",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9a2d779f8ddb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "22a817436ead",
+    "reviewedArtifactChecksum": "513b1bf0d732",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "19875ed0e97c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "f03f77d57ce2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9be3d7110c75": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "d07316034a8b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9c0e04762e99": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "409e8afd3ba2",
+    "reviewedArtifactChecksum": "ad483199951d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "31a19aea5e21",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9cc2917611e9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "8e246e2fe390",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9cca5e2b3dde": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "478c9fb1fb03",
+    "reviewedArtifactChecksum": "52073a855baf",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9d588c37e728": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "622a9dd0cd5e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9dac2dae8bfc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "aef58f46958a",
+    "reviewedArtifactChecksum": "0a30c7bcd95f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "f0b328574249",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9e910f3b95c2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "222b5e4fda0b",
+    "reviewedArtifactChecksum": "6d143938154e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9ed4f6b88b6a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c3118fbc5ef5",
+    "reviewedArtifactChecksum": "c9a40efeba72",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "992bd41162d4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9f1bb8c2f14f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "dd521aa22072",
+    "reviewedArtifactChecksum": "bbfd0652872e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9f9f595534d8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "47ebf99edfc0",
+    "reviewedArtifactChecksum": "1803dcff9731",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "9ff401a65647": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "b7259d54046e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a013e57e6d51": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3676bc6af0c3",
+    "reviewedArtifactChecksum": "7ad0f0f65d51",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a084de008c94": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "d2e369e37c38",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a09d65985659": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "05dfceafb99c",
+    "reviewedArtifactChecksum": "8862fd4e662e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "5b568ab55873",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "19e0acdfc784",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "374cf0bda783",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a20d3822a38f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "68dd19dd32a9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a2460ab23a60": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "4ab035ed780b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "1c05362f9da5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a335e0968d76": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5a271486f288",
+    "reviewedArtifactChecksum": "3c19a1b537c2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a39b591d8c3b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a234de78d008",
+    "reviewedArtifactChecksum": "1066481b3083",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a3e50e79cb89": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9fbf819fbfc3",
+    "reviewedArtifactChecksum": "68ce42ef82bd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a47d77950ec1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "824608d2bf26",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "8e61ee81b78a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a50ab9e1df59": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e09f98cd488d",
+    "reviewedArtifactChecksum": "219e5e365f7e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "9427ddb3abd1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a58c512532df": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "14dca94ffa69",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "428fe8677305",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "4bf78906fe59",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a781503cf508": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "61b07056f4fb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a84541c0018a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "993e005eecf2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a8749454536e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "31205a999625",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a8d139dba458": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e6189bdf610c",
+    "reviewedArtifactChecksum": "b5d446dc3445",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a8d874e28508": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "f2145799c97f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "a42107b474c6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a8f813117159": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "a5bfe978ab4d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a9241caf70ac": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "25699da31ab8",
+    "reviewedArtifactChecksum": "324c1381a157",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a9294d9380a6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "6401354ea288",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "ec298babdb99",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "97b216890ea7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "aac8b0d80e73": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c55f22e29a79",
+    "reviewedArtifactChecksum": "a94837706d1e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ab2f354cd396": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "db1a213cadcf",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "7636bee1270a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ad8614720882": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6d4fc106119f",
+    "reviewedArtifactChecksum": "1674b3cb3ccc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "adca306765ce": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "0e8e8d0bc50f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ae12a241076c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "9eaba126c564",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "aeb71e383642": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "82a0af168030",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "a0d1d50a348b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "23c268e23aa4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "afd30ccf8238": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8baf7e5024e1",
+    "reviewedArtifactChecksum": "c573e25a8197",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "bdc0b1b3a4d7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b27220a578ee": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "3314321a4047",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b3045580a973": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "294170b49808",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b3437893d89d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "d9091c3a9295",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b34841f6789c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "e7580670d041",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b35c9fa7658c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "52f2757246e6",
+    "reviewedArtifactChecksum": "3b2fb9deb14a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b37902cee452": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e60d5dfd84a3",
+    "reviewedArtifactChecksum": "bd6ea8d2fe8b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b3a950cbe689": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "e1251f08757d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "229b600c752f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b4577f326660": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "3340eeab8ccd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "bf94a7603cf6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "88f862d58ae8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b594a01df1d6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "94660f232c6a",
+    "reviewedArtifactChecksum": "4ddac6f29353",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b5e0c3c14836": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0e5859746672",
+    "reviewedArtifactChecksum": "966b01603468",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "5fe19822811e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "beaaf9c7145b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b6e55869de51": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "e85a9ccf67da",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b74ad340c930": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "665fcba1d6b4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b893149a8671": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c53aa635287a",
+    "reviewedArtifactChecksum": "183d0d879da3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b89d812e25e0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "02df7ba3c2b5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b8c030205d86": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "50357242ad4a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "98729de06ee1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b95499a55c9f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "16809786d5b3",
+    "reviewedArtifactChecksum": "565258b2b9d3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "b993c1885a29": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "fbdde2ef993a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ba62b8d37772": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3c238c0c4184",
+    "reviewedArtifactChecksum": "0e99642fa503",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "baa06a413558": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "eb0421c78c54",
+    "reviewedArtifactChecksum": "c751524d8f61",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "badeb885763a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "223201d268fe",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "bb33cc433026": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "85815e140e2d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "bd874c5e02d6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b205dfd4c7b0",
+    "reviewedArtifactChecksum": "b6dd7aab1215",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "be07722555ff": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "2e99361ebdf5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "be0889296f65": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "34d64d2dad9b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "914ec6348e7c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "bea767ed39db": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "4a64e7c42c3f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "bed989744195": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7a326351226e",
+    "reviewedArtifactChecksum": "ce9e91ca45cf",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "8a6ef49f5eec",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "bfba92751be8": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "346d47321248",
+    "reviewedArtifactChecksum": "ebd7d39c6d21",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c0198b907108": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "dad4a86934c0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c01a333cfbd3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9026217dfd87",
+    "reviewedArtifactChecksum": "55fccc0b4fba",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "248dfebd94b9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "5b1f37a3cbc4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c0a547f8fee6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9d006aaa7074",
+    "reviewedArtifactChecksum": "fe8cd8501e43",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "1d640bf20994",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c1956ef24421": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a70fceb5d9f7",
+    "reviewedArtifactChecksum": "f2374e5941ee",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c1959fdc5642": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "314621ba0722",
+    "reviewedArtifactChecksum": "c09dc94a7ed4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "2eed1d1aa338",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c2193a84a956": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "75b2b76341e6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c2586087f709": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "b7fe0e3f3475",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "c8eafa692a33",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c2aae816fe63": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2c5a8fc3c87b",
+    "reviewedArtifactChecksum": "fb4a48347c8d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "f616a40494fc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c365c23d9a69": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "e5a88de08040",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c384585f8b2c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "6810607a8ffb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c3e308dab99b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "b95d9093bbad",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c51538d3e644": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "008cffd28830",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c5cbee07611f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "f92825badd8f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c666b9b4014e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "95771cd3bad9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "c19d916dc6b4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c6a221e04f71": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "3cd0ac815de1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c70904777c65": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "14bbd452b9af",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "ea6915cddf32",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c826cbc01388": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "2b75253d99ff",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "d20a132ca33d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "c98e5c457e1e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f8bc16ce3029",
+    "reviewedArtifactChecksum": "3c1f18947299",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "45889b7d7f3b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cba1264de4b6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "c9c64cbf9df1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cc053bb55df6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b9c62043d7a5",
+    "reviewedArtifactChecksum": "891b24acc901",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cc078724f871": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "d86381b9daa1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cc23c187984a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d3b18a4f3d32",
+    "reviewedArtifactChecksum": "b20466cb4a55",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "19fcdf56af84",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ccc43113008f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "13f887432375",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ccf567b604be": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "0c412c5ae209",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "757f45417815",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "0a24afd072f6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "a7bfcb07aafe",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cd929d504424": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "d9e74a07cd52",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cf405c0f714c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "545dfc586ce9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "f8b112cb1b00",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cfa230785872": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "b958f173fa88",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "cff9f70a9137": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f0888293ad9f",
+    "reviewedArtifactChecksum": "b346d25edb93",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d124e24eca67": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5c2a79ee0629",
+    "reviewedArtifactChecksum": "af07f49f58de",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d16e25ecd710": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "a897f47ea501",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "e5211d67d5bc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d23f62e48d10": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "2b5949b00ab5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d25788ed5d19": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "83348769fd9f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d2cee11e428d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "d97d0a81fbf9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d32f7ff48696": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "01ba8edbd1f3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "f0b9cc992ab2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d4b951896b54": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "74603b189b71",
+    "reviewedArtifactChecksum": "0fc7cef08d0c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d54ddc21563b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "491dce120c54",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "77445bee3ee1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d6109704c9d6": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "aae0ba6a79f3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d636956bdddc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "9cbb3aea42c3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d686f64879fb": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "c448d133f9c0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d6bda294b8ec": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "347186231e5f",
+    "reviewedArtifactChecksum": "27abeafd7413",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d6e252fb4880": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "62f633c8f930",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d70243b6fc64": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "0bc457597544",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d7677ac50371": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "ff02289e8abc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d768fd20d606": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "2f22d9084774",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d78377cf53f4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "62ce15566253",
+    "reviewedArtifactChecksum": "c0a6de359f85",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d82f4527c76a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6517985e895c",
+    "reviewedArtifactChecksum": "b4a77b8c4f63",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d833dc5abe59": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6ff8e0fc1088",
+    "reviewedArtifactChecksum": "7457afe05847",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d8915378c317": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "a1e89bc5fcc9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d8bd574de179": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0ed010eb61ee",
+    "reviewedArtifactChecksum": "43d6eb96a8d9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d99717df8788": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "746e2830ce5d",
+    "reviewedArtifactChecksum": "d9d3938933c1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "75946b0cf395",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "932d52765423",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "2dc778f24adb",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "db4717458b6a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "469f442a6434",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dba8340fd0f3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d2f5928f73e0",
+    "reviewedArtifactChecksum": "33cf64f0b3aa",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "6c02cc490cde",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dc41de374da5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "c4d945b9d097",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dc4b3f6dab6e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bbbc8180df94",
+    "reviewedArtifactChecksum": "aca22cac4eb7",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dc62b97bc1fc": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "607d1c185682",
+    "reviewedArtifactChecksum": "fc6845ab164d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "d1b6bc8c2d99",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dc73712c1842": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b483aac476e6",
+    "reviewedArtifactChecksum": "477f9b20cf8b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dc7727f63c0c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "eb408a2280dd",
+    "reviewedArtifactChecksum": "8e7101070efa",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dce6a906dc66": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "1d1ba4be42fd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dcf21d867c91": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7b380339f8c1",
+    "reviewedArtifactChecksum": "803576c60944",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "def270551fbe": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "a8af3375863c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "dff780783fbe": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "d7d9a07ba741",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e06088bda436": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "3ee8fd09c060",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e0df9e9c7683": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "07c0da77ff02",
+    "reviewedArtifactChecksum": "7e0a47e57b53",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e0f1fb8115ed": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2208cdd14461",
+    "reviewedArtifactChecksum": "87c8813d6158",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e173ace9bf90": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "6bef36861f33",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e1e03cafda18": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "11cc7048ff73",
+    "reviewedArtifactChecksum": "3d8644687f0a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e2716c39cb46": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "88d2297a2338",
+    "reviewedArtifactChecksum": "c80fcf3ec7c4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e2df0992de37": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f18a7f8283b5",
+    "reviewedArtifactChecksum": "233f82470dad",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "48ca1db6c7a0",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e41b80eb587d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "e205cc9c4333",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e4a4339afda4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "24b973a76f4a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e4ab88456b9b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8a28a6937d8b",
+    "reviewedArtifactChecksum": "eb29a31b75c1",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e4d64e14c5e1": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a8b9fb83ba3b",
+    "reviewedArtifactChecksum": "acd4ddda1fbc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e5c914d15241": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "ec8b488bc942",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "da52920c76f6",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e5f83394283d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "d6f262f7c1d2",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "4d620cf78d95",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e6aa60b3fa90": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "157edbd2a5dd",
+    "reviewedArtifactChecksum": "2361eb984f68",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e6af724bfa83": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "e3a31f5b7e0c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e6f74ca84e32": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e68fb1567b85",
+    "reviewedArtifactChecksum": "91b58da7ce9b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e6fd8da0c247": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "aefaba1e21a5",
+    "reviewedArtifactChecksum": "d406328a5c90",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e78f02853c98": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a7a2357bf6d3",
+    "reviewedArtifactChecksum": "154d601c43f5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e8099b642c9f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c535e0408092",
+    "reviewedArtifactChecksum": "a9d23c666ecf",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "3e70b7c100c5",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e81f8eb0ee5f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fee8d86b0c31",
+    "reviewedArtifactChecksum": "e2672f3c0016",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e8694205d953": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "20342cfacf03",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e9543e32164b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "3146c890cfa8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "c70258d96f30",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "e9f70b059f43": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f2449f49b504",
+    "reviewedArtifactChecksum": "1b629dd7b1ac",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ea4911d91143": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a921f371596f",
+    "reviewedArtifactChecksum": "e2ff003e9fd3",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ea6154c3447d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "9f875055d02b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "eb53769b541b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "882c4917c540",
+    "reviewedArtifactChecksum": "0f3bb2e27d56",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "eb986f4b9142": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "23c36c604fcc",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ebd212d934a7": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "61899ae3451f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ec337321a25d": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "4d0a707b3a1f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "8b687cc0980b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "75285436ac4e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "3c8e34fdc750",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ef10fc1fe4d3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2f61d2cc731a",
+    "reviewedArtifactChecksum": "2e515adc6d60",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ef36ec96537f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "c441d842731b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "d37eaaaf83a4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ef543bd4a773": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a7debec13329",
+    "reviewedArtifactChecksum": "cc782415e539",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "9e16f005ab7e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ef8586090398": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "d26554d9e9d9",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "db5aac3dd484",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f052abfce10e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "20728203171d",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f1dc525f26dd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0240a925b535",
+    "reviewedArtifactChecksum": "23b5b704a87a",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "cc0d38577ffd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f49b24114ea9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "0e89780c7120",
+    "reviewedArtifactChecksum": "50361c8f2c0c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "046ff66db752",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f4e29143100c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d18726770189",
+    "reviewedArtifactChecksum": "e79fbbe5f281",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "42363aaa6897",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f5199b5121f3": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "85e05b7c5360",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f56329f28659": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "cece2ed7b43f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "408b2815806b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f6be37ba0bde": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "55a4060336a6",
+    "reviewedArtifactChecksum": "eb052ff79a8c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "1066881d2625",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "3b5a5149c274",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "6c9fdf08b83c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f83ee3caa04e": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "a47e936b4941",
+    "reviewedArtifactChecksum": "3b84cfd8f59b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "b68625b0954e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f889bba5102a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "5417ce1d2b38",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "fc239d6e3996",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f920eaa9a538": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "6dd8a023f51e",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f93775fd8ce0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "41bb23f3a44e",
+    "reviewedArtifactChecksum": "aa2b94a32c66",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "62bf278bb47f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "f9cffe716495": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "beaa27cce795",
+    "reviewedArtifactChecksum": "028970edb8dd",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fa1f01a51d17": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "33418f4fe697",
+    "reviewedArtifactChecksum": "96ffa2b73b30",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "f3186c604276",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fa9731c2000f": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "da9922d1bc7d",
+    "reviewedArtifactChecksum": "1b4aeebe5b8f",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fb60d80de54b": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "dd6ae3f63e4c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fb63409aebf0": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "f40a7e7b42da",
+    "reviewedArtifactChecksum": "44c01a0156ba",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "262f49d62ae8",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fd76422c14ea": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "921409d196e4",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fdab9848b160": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "bc70dfe515b2",
+    "reviewedArtifactChecksum": "b15a1b0a64ca",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fe5600667e2c": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "7b1889e03b6c",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fe773d7d7377": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "ee227b866f03",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "0c7263e61174",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ff88e6723334": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "2f665f0fba35",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "ffbc62a77b85": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "6cbb7a2feaeb",
+    "reviewedArtifactChecksum": "b48511173691",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  },
+  "fffa07892f17": {
+    "reviewer": "zhixiong-lin",
+    "reviewedAt": "2026-08-18",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "74840f80846b",
+    "approvedScope": "ai-flagged items (native review sheet 2026-08-14); unflagged text machine-translated and AI-review clean"
+  }
+}


### PR DESCRIPTION
Lands the Chinese native review (Zhixiong Lin, with Tiger's spot-check endorsement in Slack) as two data files:

**overrides/zh.json**: 88 corrected fields across 73 workflows. 85 are Lin's own wording, including the one critical (Qwen-Image-Layered half-translation, his fix is better than the AI's). 3 are AI-suggested fixes that still applied. The other 209 suggested-fix rows were already superseded before review landed: the nightly loop had pruned and retranslated those fields with the current model, and the AI reviewer re-reviewed the fresh text. 7 items are deferred (content churned between snapshots, will confirm wording with Lin) and are safe meanwhile: those fields serve English or fresh reviewed text.

**reviews/zh.json**: checksum-bound sign-off records per workflow, scope stated on each record. Later changes to English or the resolved translation de-index that page until re-review, per the predicate design.

Verified with the site's own resolver: with zh flipped, **519 of 612 detail pages become indexable**; 93 hold themselves back per-page (English fallback in a required field) and rejoin as resolved. i18n:validate clean, 553 unit tests green.

Nothing in this PR flips zh: the INDEXABLE_LOCALES flip is a separate one-line PR after this merges, so the flip diff is reviewable on its own.