### PR TITLE
Unify author attribution styling across hub components

### DIFF
--- a/site/src/components/hub/FeaturedCarousel.vue
+++ b/site/src/components/hub/FeaturedCarousel.vue
@@ -203,17 +203,19 @@ onUnmounted(() => {
               <a
                 v-if="slide.creatorUrl"
                 :href="slide.creatorUrl"
-                class="pointer-events-auto relative z-20 flex min-w-0 items-center gap-2 text-white/95 transition-colors hover:text-white"
+                class="author-link pointer-events-auto relative z-20 flex min-w-0 items-center gap-2 text-white/95 hover:text-white focus-visible:text-white"
+                style="--author-link-highlight: rgb(255 255 255 / 0.18)"
                 @click.stop
               >
                 <Avatar
                   :src="slide.creatorAvatarUrl"
                   :name="slide.creatorName"
-                  class="size-5 sm:size-6"
+                  class="author-link-avatar size-5 sm:size-6"
                 />
-                <span class="ppformula-text-center-sm truncate text-sm sm:text-base">{{
-                  slide.creatorName
-                }}</span>
+                <span
+                  class="author-link-name ppformula-text-center-sm truncate text-sm sm:text-base"
+                  >{{ slide.creatorName }}</span
+                >
               </a>
               <div v-else class="flex min-w-0 items-center gap-2 text-white/95">
                 <Avatar

--- a/site/src/components/hub/HubWorkflowCard.vue
+++ b/site/src/components/hub/HubWorkflowCard.vue
@@ -382,11 +382,13 @@ function handleCardClick() {
         <a
           v-if="creatorUrl"
           :href="creatorUrl"
-          class="creator-link flex items-center gap-2 min-w-0 w-fit text-content-secondary hover:text-content transition-colors"
+          class="creator-link author-link flex items-center gap-2 min-w-0 w-fit text-content-secondary hover:text-content focus-visible:text-content"
           @click.stop
         >
-          <Avatar :src="creatorAvatarUrl" :name="authorName" class="size-5" />
-          <span class="ppformula-text-center-sm text-base truncate">{{ authorName }}</span>
+          <Avatar :src="creatorAvatarUrl" :name="authorName" class="author-link-avatar size-5" />
+          <span class="author-link-name ppformula-text-center-sm text-base truncate">{{
+            authorName
+          }}</span>
         </a>
         <div v-else class="flex items-center gap-2 min-w-0 text-content-secondary">
           <Avatar :src="creatorAvatarUrl" :name="authorName" class="size-5" />

--- a/site/src/components/template-detail/TemplateDetailPage.astro
+++ b/site/src/components/template-detail/TemplateDetailPage.astro
@@ -52,6 +52,9 @@ const profile = data.username ? profiles.get(data.username) : null;
 const authorName = profile?.display_name || data.username || 'ComfyUI';
 const authorAvatarUrl = profile?.avatar_url || null;
 const authorProfileUrl = data.username ? creatorPath(data.username, locale) : null;
+// Render the author block as a link when the creator has a profile page, so the
+// avatar and name share one hover target (see `.author-link` in global.css).
+const AuthorTag = authorProfileUrl ? 'a' : 'div';
 const thumbnails = data.detailImages?.length ? data.detailImages : data.thumbnails || [];
 // Only video heroes can turn out to be portrait; the client script below measures
 // the loaded file and opts those pages out of the cover crop.
@@ -204,49 +207,48 @@ function formatRelativeDate(dateStr: string): string {
           }
 
           <SidebarSection title={t('labels.createdBy', locale)}>
-            <div class="flex items-center gap-3">
-              <div class="size-8 shrink-0 rounded-full overflow-hidden">
-                {
-                  authorAvatarUrl && (
-                    <img
-                      src={authorAvatarUrl}
-                      alt={authorName}
-                      class="w-full h-full object-cover"
-                      loading="lazy"
-                      onerror="this.hidden=true;this.nextElementSibling.hidden=false;"
-                    />
-                  )
-                }
-                <div
-                  hidden={Boolean(authorAvatarUrl)}
-                  class="w-full h-full rounded-full bg-brand flex items-center justify-center text-xs font-bold text-page"
-                  aria-hidden="true"
-                >
-                  {authorName.charAt(0).toUpperCase()}
+            <div class="flex flex-col gap-1">
+              <AuthorTag
+                href={authorProfileUrl ?? undefined}
+                class:list={[
+                  'flex items-center gap-3 w-fit text-content',
+                  authorProfileUrl && 'author-link',
+                ]}
+                data-astro-prefetch={authorProfileUrl ? '' : undefined}
+              >
+                <div class="author-link-avatar size-8 shrink-0 rounded-full overflow-hidden">
+                  {
+                    authorAvatarUrl && (
+                      <img
+                        src={authorAvatarUrl}
+                        alt={authorName}
+                        class="w-full h-full object-cover"
+                        loading="lazy"
+                        onerror="this.hidden=true;this.nextElementSibling.hidden=false;"
+                      />
+                    )
+                  }
+                  <div
+                    hidden={Boolean(authorAvatarUrl)}
+                    class="w-full h-full rounded-full bg-brand flex items-center justify-center text-xs font-bold text-page"
+                    aria-hidden="true"
+                  >
+                    {authorName.charAt(0).toUpperCase()}
+                  </div>
                 </div>
-              </div>
-              <div class="flex flex-col">
-                {
-                  authorProfileUrl ? (
-                    <a
-                      href={authorProfileUrl}
-                      class="font-semibold text-base text-content hover:opacity-80 transition-opacity"
-                      data-astro-prefetch
-                    >
-                      {authorName}
-                    </a>
-                  ) : (
-                    <span class="font-semibold text-base text-content">{authorName}</span>
-                  )
-                }
-                {
-                  data.date && (
-                    <span class="text-xs text-content-secondary">
-                      {formatRelativeDate(data.date)}
-                    </span>
-                  )
-                }
-              </div>
+                <span
+                  class:list={['font-semibold text-base', authorProfileUrl && 'author-link-name']}
+                >
+                  {authorName}
+                </span>
+              </AuthorTag>
+              {
+                data.date && (
+                  <span class="ml-11 text-xs text-content-secondary">
+                    {formatRelativeDate(data.date)}
+                  </span>
+                )
+              }
             </div>
           </SidebarSection>
         </div>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -207,6 +207,63 @@
     position: relative;
     top: 0.12em;
   }
+
+  /* Author attribution links (workflow cards, carousel, detail sidebar,
+     creator index). Hovering or keyboard-focusing one lifts a pill highlight
+     behind it, underlines the name and rings the avatar, so it reads as a
+     clickable person rather than a caption. Padding is cancelled by an equal
+     negative margin, so the highlight never shifts surrounding layout. */
+  .author-link {
+    --author-link-highlight: var(--color-transparency-white-t8);
+    --author-link-ring: currentColor;
+    padding: 0.125rem 0.375rem;
+    margin: -0.125rem -0.375rem;
+    border-radius: 9999px;
+    cursor: pointer;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease;
+  }
+
+  .author-link:hover,
+  .author-link:focus-visible {
+    background-color: var(--author-link-highlight);
+  }
+
+  .author-link:focus-visible {
+    outline: 2px solid var(--author-link-ring);
+    outline-offset: 2px;
+  }
+
+  .author-link-name {
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+    transition: text-decoration-color 150ms ease;
+  }
+
+  .author-link:hover .author-link-name,
+  .author-link:focus-visible .author-link-name {
+    text-decoration-color: currentColor;
+  }
+
+  .author-link-avatar {
+    transition: box-shadow 150ms ease;
+  }
+
+  .author-link:hover .author-link-avatar,
+  .author-link:focus-visible .author-link-avatar {
+    box-shadow: 0 0 0 2px var(--author-link-ring);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .author-link,
+    .author-link-name,
+    .author-link-avatar {
+      transition: none;
+    }
+  }
 }
 @property --border-angle {
   syntax: '<angle>';


### PR DESCRIPTION
## Summary

Refactors author attribution UI across the hub to use a consistent, reusable `.author-link` component pattern with unified hover/focus styling. This improves visual consistency and accessibility by making author names and avatars read as a single clickable entity.

## Changes

- **TemplateDetailPage.astro**: Refactored author block to dynamically render as `<a>` or `<div>` based on profile availability, wrapping avatar and name in a single semantic link element with `.author-link` styling
- **global.css**: Added comprehensive `.author-link` style suite with:
  - Pill-shaped highlight background on hover/focus
  - Underline animation on author name
  - Ring effect on avatar
  - Proper padding/margin cancellation to prevent layout shift
  - Reduced motion support
- **FeaturedCarousel.vue**: Applied `.author-link` classes to carousel creator attribution, with custom highlight color for white text context
- **HubWorkflowCard.vue**: Applied `.author-link` classes to workflow card creator link

## Implementation Details

- The `.author-link` pattern uses CSS custom properties (`--author-link-highlight`, `--author-link-ring`) for theming across different contexts (dark sidebar, white carousel)
- Avatar and name elements use `.author-link-avatar` and `.author-link-name` sub-classes for targeted hover effects
- Negative margins offset padding to prevent layout shift when highlight appears
- All transitions respect `prefers-reduced-motion` preference

https://github.com/user-attachments/assets/2e7d2143-f32a-40f0-aa73-812cc45927b2
