### PR TITLE
fix(i18n): hold a locale page instead of aborting the build

### DIFF
--- a/site/src/lib/i18n/locales.ts
+++ b/site/src/lib/i18n/locales.ts
@@ -49,6 +49,35 @@ export const SUPPORTED_HUB_LOCALES: readonly Locale[] = LOCALES;
 export const INDEXABLE_LOCALES: readonly Locale[] = [];
 
 /**
+ * Fail-closed guard for a flipped locale, asserted once per build after the
+ * locale routes have resolved every page.
+ *
+ * An individual page the predicate rejects is NOT a build failure: it is held
+ * back (rendered in-locale for humans, canonical to English, absent from the
+ * sitemap and from every hreflang cluster), which is the graceful degradation
+ * the design specifies. Holds are the steady state, not an anomaly — workflows
+ * are published to the hub between translation runs, so a flipped locale always
+ * trails the catalog by however many entries landed since its last run.
+ *
+ * A flipped locale with ZERO indexable pages is a different animal: its
+ * translation artifacts are missing or unreadable, and the language would
+ * silently serve English under its own URLs. That fails the build.
+ */
+export function assertFlippedLocalesIndexable(
+  indexablePageCounts: ReadonlyMap<string, number>,
+  flipped: readonly Locale[] = INDEXABLE_LOCALES
+): void {
+  const empty = flipped.filter((locale) => (indexablePageCounts.get(locale) ?? 0) === 0);
+  if (empty.length > 0) {
+    throw new Error(
+      `[i18n] flipped locale(s) ${empty.join(', ')} resolved zero indexable pages. ` +
+        `Their translation artifacts are missing or unreadable — fix those, or drop ` +
+        `the locale from INDEXABLE_LOCALES rather than serving English under its URLs.`
+    );
+  }
+}
+
+/**
  * Assert SUPPORTED ⊆ AVAILABLE (and INDEXABLE ⊆ SUPPORTED). Called from CI; throws
  * with the offending locales so a config drift fails the build, not production.
  */

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -10,8 +10,11 @@
  *    (translated + current + reviewed + locale flipped); otherwise it canonicals
  *    to the English URL, so humans see the translation while Google keeps
  *    indexing English. This is the "safety by canonical" the whole design rests on.
- *  - for a locale in INDEXABLE_LOCALES, a non-indexable page fails the build
- *    (fail-closed) rather than shipping a half-English indexable URL.
+ *  - in a flipped locale, a page the predicate rejects is held rather than
+ *    shipped: same English canonical, no sitemap entry, no hreflang. The
+ *    fail-closed assert is per LOCALE (zero indexable pages = broken artifacts),
+ *    not per page, because holds are normal — workflows are published to the hub
+ *    between translation runs.
  *
  * With INDEXABLE_LOCALES empty, every page is non-indexable, so canonicals all
  * point at English and the Google-facing output is unchanged.
@@ -45,7 +48,11 @@ import { localizeUrl } from '../../../i18n/utils';
 import { t } from '../../../i18n/ui';
 import { resolveLocalizedWorkflow, indexableAlternateLocales } from '../../../lib/i18n/resolver';
 import { localizeCards } from '../../../lib/i18n/localize-cards';
-import { SUPPORTED_HUB_LOCALES, INDEXABLE_LOCALES } from '../../../lib/i18n/locales';
+import {
+  SUPPORTED_HUB_LOCALES,
+  INDEXABLE_LOCALES,
+  assertFlippedLocalesIndexable,
+} from '../../../lib/i18n/locales';
 
 export async function getStaticPaths() {
   // Every supported hub locale except English (English has its own route). Each
@@ -64,6 +71,10 @@ export async function getStaticPaths() {
   }
 
   const paths = [];
+  // Per flipped locale: how many pages the predicate accepted, and how many it
+  // held. The counts drive the build-time summary and the zero-indexable assert.
+  const indexableCounts = new Map<string, number>();
+  const heldCounts = new Map<string, number>();
   for (const locale of locales) {
     for (const entry of entries) {
       const shareId = entry.shareId || '';
@@ -72,13 +83,9 @@ export async function getStaticPaths() {
 
       if (shareId) {
         const resolved = resolveLocalizedWorkflow(shareId, locale);
-        // Fail-closed: a flipped (indexable) locale must never ship a page that
-        // the predicate rejects (missing/stale/unreviewed translation).
-        if (INDEXABLE_LOCALES.includes(locale) && !resolved.indexable) {
-          throw new Error(
-            `[i18n] indexable locale "${locale}" page ${name}-${shareId} is not ` +
-              `translation-complete and cannot be prerendered: ${resolved.reason}`
-          );
+        if (INDEXABLE_LOCALES.includes(locale)) {
+          const counts = resolved.indexable ? indexableCounts : heldCounts;
+          counts.set(locale, (counts.get(locale) ?? 0) + 1);
         }
         paths.push({
           params: { locale, slug: `${name}-${shareId}` },
@@ -95,6 +102,18 @@ export async function getStaticPaths() {
         });
       }
     }
+  }
+
+  // Fail-closed on the failure the per-page abort was reaching for: a flipped
+  // locale that resolved nothing indexable has broken artifacts, not a backlog.
+  assertFlippedLocalesIndexable(indexableCounts);
+  // Say the split out loud, so whoever flips a locale sees what shipped and what
+  // is waiting on translation instead of inferring it from the sitemap.
+  for (const locale of INDEXABLE_LOCALES) {
+    console.info(
+      `[i18n] ${locale}: ${indexableCounts.get(locale) ?? 0} pages indexable, ` +
+        `${heldCounts.get(locale) ?? 0} held for translation`
+    );
   }
 
   return paths;

--- a/site/tests/unit/i18n-locales.test.ts
+++ b/site/tests/unit/i18n-locales.test.ts
@@ -46,8 +46,18 @@ describe('assertFlippedLocalesIndexable', () => {
     expect(() => assertFlippedLocalesIndexable(new Map(), [])).not.toThrow();
   });
 
-  it('ignores counts for locales that are not flipped', () => {
-    expect(() => assertFlippedLocalesIndexable(new Map([['ja', 0]]), ['zh', 'ja'])).toThrow(/ja/);
-    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 5]]), ['zh'])).not.toThrow();
+  it('ignores an empty locale that is not flipped', () => {
+    // The guard iterates the flipped set, not the counts. A locale nobody flipped
+    // has no canonicals, sitemap entries or hreflang to be wrong about, so its
+    // emptiness is normal — every locale looks like this before its review wave.
+    expect(() =>
+      assertFlippedLocalesIndexable(
+        new Map([
+          ['zh', 519],
+          ['ja', 0],
+        ]),
+        ['zh']
+      )
+    ).not.toThrow();
   });
 });

--- a/site/tests/unit/i18n-locales.test.ts
+++ b/site/tests/unit/i18n-locales.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AVAILABLE_APP_LOCALES,
+  INDEXABLE_LOCALES,
+  SUPPORTED_HUB_LOCALES,
+  assertFlippedLocalesIndexable,
+  assertLocaleSets,
+} from '../../src/lib/i18n/locales';
+
+describe('locale sets', () => {
+  it('holds the documented narrowing: INDEXABLE ⊆ SUPPORTED ⊆ AVAILABLE', () => {
+    expect(() => assertLocaleSets()).not.toThrow();
+    const available = new Set<string>(AVAILABLE_APP_LOCALES);
+    expect(SUPPORTED_HUB_LOCALES.every((l) => available.has(l))).toBe(true);
+    const supported = new Set<string>(SUPPORTED_HUB_LOCALES);
+    expect(INDEXABLE_LOCALES.every((l) => supported.has(l))).toBe(true);
+  });
+});
+
+describe('assertFlippedLocalesIndexable', () => {
+  it('passes when a flipped locale has indexable pages, however many are held', () => {
+    // The realistic shape: most pages indexable, a tail still untranslated.
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 519]]), ['zh'])).not.toThrow();
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 1]]), ['zh'])).not.toThrow();
+  });
+
+  it('throws when a flipped locale resolved nothing indexable', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 0]]), ['zh'])).toThrow(
+      /flipped locale\(s\) zh resolved zero indexable pages/
+    );
+  });
+
+  it('treats a locale missing from the counts as zero, not as absent', () => {
+    // A locale that never reached the resolver at all is the same failure: the
+    // language is flipped on and nothing indexable came out of the build.
+    expect(() => assertFlippedLocalesIndexable(new Map(), ['zh'])).toThrow(/zero indexable pages/);
+  });
+
+  it('names every empty locale, so one build reports the whole problem', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 10]]), ['zh', 'ja', 'ko'])).toThrow(
+      /ja, ko/
+    );
+  });
+
+  it('does nothing while no locale is flipped', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map(), [])).not.toThrow();
+  });
+
+  it('ignores counts for locales that are not flipped', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map([['ja', 0]]), ['zh', 'ja'])).toThrow(/ja/);
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 5]]), ['zh'])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

The localized detail route aborts the entire build if a flipped locale contains any page the predicate rejects ([`[slug].astro:77`](https://github.com/Comfy-Org/workflow_templates/blob/main/site/src/pages/%5Blocale%5D/workflows/%5Bslug%5D.astro#L77)). There is no filter before it, so the first rejection ends the build.

Measured with the real predicate against the live hub index, with `zh` flipped:

| | |
|---|---|
| approved workflows live | 615 |
| resolve indexable in zh | 519 |
| **rejected → build aborts** | **96** |

The 96 are 93 entries with an English-fallback field (29 missing `extendedDescription`, 24 `faqItems`, 10 `metaDescription`, the rest combinations) **plus 3 workflows published to the hub since the last translation run, which have no English row at all.**

Those 3 are the point. This cannot be cleared by finishing a backlog: any template merged between a translation run and a deploy puts it back. Under the current assert, a flipped locale means the build breaks the next time someone ships a workflow.

## The design already specifies the other behavior

`design-doc-hub-localization.md` §8.4:

> Silent per-field English substitution remains correct for non-indexable locales (graceful degradation for humans); for indexable pages any English-fallback field fails the predicate and **the page drops out** instead of rendering half-English.

Its fail-closed table lists infrastructure failures: hub API down, a missing language file, a malformed artifact, a page-count collapse. An individually incomplete page is not on it. `locales.ts` says the same in one line: *"Per-page gating still applies on top (see predicate)."*

## What changes

The per-page abort becomes a per-page **hold** — the behavior every non-flipped locale already has today:

- renders in-locale for humans
- canonicals to the English URL
- absent from the sitemap and from every hreflang cluster

The predicate is untouched. Nothing half-English becomes indexable.

The fail-closed intent moves to the level it belongs at. `assertFlippedLocalesIndexable` throws when a flipped locale resolves **zero** indexable pages, which means its artifacts are missing or unreadable and the language would silently serve English under its own URLs. Asserted once per build, unit-tested, with the flipped set injectable so the tests do not depend on the live constant.

The build log now states the split per flipped locale, so whoever flips a language sees it rather than inferring it from the sitemap:

```
[i18n] zh: 519 pages indexable, 96 held for translation
```

## Risk

**None in production today.** `INDEXABLE_LOCALES` is empty on `main`, so the removed throw is unreachable and the new assert has nothing to assert. Verified by running the full suite in both states.

## Verification

- 560 unit tests pass, including 7 new ones for the guard
- ESLint and Prettier clean
- Behavior verified end to end on a local dev server with `zh` flipped, driven by Playwright, 11/11 checks: an indexable zh page is self-canonical and emits its cluster; a held page returns 200, still shows Chinese to humans, canonicals to English, and emits no zh alternate; the English twin of an indexable page advertises zh; the English twin of a held page does not

The zh flip itself is a separate one-line PR on top of this one.
