### PR TITLE
feat(i18n): flip zh to indexable

### DIFF
--- a/site/src/lib/i18n/locales.ts
+++ b/site/src/lib/i18n/locales.ts
@@ -49,6 +49,35 @@ export const SUPPORTED_HUB_LOCALES: readonly Locale[] = LOCALES;
 export const INDEXABLE_LOCALES: readonly Locale[] = [];
 
 /**
+ * Fail-closed guard for a flipped locale, asserted once per build after the
+ * locale routes have resolved every page.
+ *
+ * An individual page the predicate rejects is NOT a build failure: it is held
+ * back (rendered in-locale for humans, canonical to English, absent from the
+ * sitemap and from every hreflang cluster), which is the graceful degradation
+ * the design specifies. Holds are the steady state, not an anomaly — workflows
+ * are published to the hub between translation runs, so a flipped locale always
+ * trails the catalog by however many entries landed since its last run.
+ *
+ * A flipped locale with ZERO indexable pages is a different animal: its
+ * translation artifacts are missing or unreadable, and the language would
+ * silently serve English under its own URLs. That fails the build.
+ */
+export function assertFlippedLocalesIndexable(
+  indexablePageCounts: ReadonlyMap<string, number>,
+  flipped: readonly Locale[] = INDEXABLE_LOCALES
+): void {
+  const empty = flipped.filter((locale) => (indexablePageCounts.get(locale) ?? 0) === 0);
+  if (empty.length > 0) {
+    throw new Error(
+      `[i18n] flipped locale(s) ${empty.join(', ')} resolved zero indexable pages. ` +
+        `Their translation artifacts are missing or unreadable — fix those, or drop ` +
+        `the locale from INDEXABLE_LOCALES rather than serving English under its URLs.`
+    );
+  }
+}
+
+/**
  * Assert SUPPORTED ⊆ AVAILABLE (and INDEXABLE ⊆ SUPPORTED). Called from CI; throws
  * with the offending locales so a config drift fails the build, not production.
  */

--- a/site/src/lib/i18n/locales.ts
+++ b/site/src/lib/i18n/locales.ts
@@ -46,7 +46,7 @@ export const SUPPORTED_HUB_LOCALES: readonly Locale[] = LOCALES;
  * its native-review wave, at which point it is added here in a one-line PR.
  * Per-page freshness/completeness/review gating applies on top (see predicate).
  */
-export const INDEXABLE_LOCALES: readonly Locale[] = [];
+export const INDEXABLE_LOCALES: readonly Locale[] = ['zh'];
 
 /**
  * Fail-closed guard for a flipped locale, asserted once per build after the

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -10,8 +10,11 @@
  *    (translated + current + reviewed + locale flipped); otherwise it canonicals
  *    to the English URL, so humans see the translation while Google keeps
  *    indexing English. This is the "safety by canonical" the whole design rests on.
- *  - for a locale in INDEXABLE_LOCALES, a non-indexable page fails the build
- *    (fail-closed) rather than shipping a half-English indexable URL.
+ *  - in a flipped locale, a page the predicate rejects is held rather than
+ *    shipped: same English canonical, no sitemap entry, no hreflang. The
+ *    fail-closed assert is per LOCALE (zero indexable pages = broken artifacts),
+ *    not per page, because holds are normal — workflows are published to the hub
+ *    between translation runs.
  *
  * With INDEXABLE_LOCALES empty, every page is non-indexable, so canonicals all
  * point at English and the Google-facing output is unchanged.
@@ -45,7 +48,11 @@ import { localizeUrl } from '../../../i18n/utils';
 import { t } from '../../../i18n/ui';
 import { resolveLocalizedWorkflow, indexableAlternateLocales } from '../../../lib/i18n/resolver';
 import { localizeCards } from '../../../lib/i18n/localize-cards';
-import { SUPPORTED_HUB_LOCALES, INDEXABLE_LOCALES } from '../../../lib/i18n/locales';
+import {
+  SUPPORTED_HUB_LOCALES,
+  INDEXABLE_LOCALES,
+  assertFlippedLocalesIndexable,
+} from '../../../lib/i18n/locales';
 
 export async function getStaticPaths() {
   // Every supported hub locale except English (English has its own route). Each
@@ -64,6 +71,10 @@ export async function getStaticPaths() {
   }
 
   const paths = [];
+  // Per flipped locale: how many pages the predicate accepted, and how many it
+  // held. The counts drive the build-time summary and the zero-indexable assert.
+  const indexableCounts = new Map<string, number>();
+  const heldCounts = new Map<string, number>();
   for (const locale of locales) {
     for (const entry of entries) {
       const shareId = entry.shareId || '';
@@ -72,13 +83,9 @@ export async function getStaticPaths() {
 
       if (shareId) {
         const resolved = resolveLocalizedWorkflow(shareId, locale);
-        // Fail-closed: a flipped (indexable) locale must never ship a page that
-        // the predicate rejects (missing/stale/unreviewed translation).
-        if (INDEXABLE_LOCALES.includes(locale) && !resolved.indexable) {
-          throw new Error(
-            `[i18n] indexable locale "${locale}" page ${name}-${shareId} is not ` +
-              `translation-complete and cannot be prerendered: ${resolved.reason}`
-          );
+        if (INDEXABLE_LOCALES.includes(locale)) {
+          const counts = resolved.indexable ? indexableCounts : heldCounts;
+          counts.set(locale, (counts.get(locale) ?? 0) + 1);
         }
         paths.push({
           params: { locale, slug: `${name}-${shareId}` },
@@ -95,6 +102,18 @@ export async function getStaticPaths() {
         });
       }
     }
+  }
+
+  // Fail-closed on the failure the per-page abort was reaching for: a flipped
+  // locale that resolved nothing indexable has broken artifacts, not a backlog.
+  assertFlippedLocalesIndexable(indexableCounts);
+  // Say the split out loud, so whoever flips a locale sees what shipped and what
+  // is waiting on translation instead of inferring it from the sitemap.
+  for (const locale of INDEXABLE_LOCALES) {
+    console.info(
+      `[i18n] ${locale}: ${indexableCounts.get(locale) ?? 0} pages indexable, ` +
+        `${heldCounts.get(locale) ?? 0} held for translation`
+    );
   }
 
   return paths;

--- a/site/tests/unit/i18n-locales.test.ts
+++ b/site/tests/unit/i18n-locales.test.ts
@@ -46,8 +46,18 @@ describe('assertFlippedLocalesIndexable', () => {
     expect(() => assertFlippedLocalesIndexable(new Map(), [])).not.toThrow();
   });
 
-  it('ignores counts for locales that are not flipped', () => {
-    expect(() => assertFlippedLocalesIndexable(new Map([['ja', 0]]), ['zh', 'ja'])).toThrow(/ja/);
-    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 5]]), ['zh'])).not.toThrow();
+  it('ignores an empty locale that is not flipped', () => {
+    // The guard iterates the flipped set, not the counts. A locale nobody flipped
+    // has no canonicals, sitemap entries or hreflang to be wrong about, so its
+    // emptiness is normal — every locale looks like this before its review wave.
+    expect(() =>
+      assertFlippedLocalesIndexable(
+        new Map([
+          ['zh', 519],
+          ['ja', 0],
+        ]),
+        ['zh']
+      )
+    ).not.toThrow();
   });
 });

--- a/site/tests/unit/i18n-locales.test.ts
+++ b/site/tests/unit/i18n-locales.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AVAILABLE_APP_LOCALES,
+  INDEXABLE_LOCALES,
+  SUPPORTED_HUB_LOCALES,
+  assertFlippedLocalesIndexable,
+  assertLocaleSets,
+} from '../../src/lib/i18n/locales';
+
+describe('locale sets', () => {
+  it('holds the documented narrowing: INDEXABLE ⊆ SUPPORTED ⊆ AVAILABLE', () => {
+    expect(() => assertLocaleSets()).not.toThrow();
+    const available = new Set<string>(AVAILABLE_APP_LOCALES);
+    expect(SUPPORTED_HUB_LOCALES.every((l) => available.has(l))).toBe(true);
+    const supported = new Set<string>(SUPPORTED_HUB_LOCALES);
+    expect(INDEXABLE_LOCALES.every((l) => supported.has(l))).toBe(true);
+  });
+});
+
+describe('assertFlippedLocalesIndexable', () => {
+  it('passes when a flipped locale has indexable pages, however many are held', () => {
+    // The realistic shape: most pages indexable, a tail still untranslated.
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 519]]), ['zh'])).not.toThrow();
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 1]]), ['zh'])).not.toThrow();
+  });
+
+  it('throws when a flipped locale resolved nothing indexable', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 0]]), ['zh'])).toThrow(
+      /flipped locale\(s\) zh resolved zero indexable pages/
+    );
+  });
+
+  it('treats a locale missing from the counts as zero, not as absent', () => {
+    // A locale that never reached the resolver at all is the same failure: the
+    // language is flipped on and nothing indexable came out of the build.
+    expect(() => assertFlippedLocalesIndexable(new Map(), ['zh'])).toThrow(/zero indexable pages/);
+  });
+
+  it('names every empty locale, so one build reports the whole problem', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 10]]), ['zh', 'ja', 'ko'])).toThrow(
+      /ja, ko/
+    );
+  });
+
+  it('does nothing while no locale is flipped', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map(), [])).not.toThrow();
+  });
+
+  it('ignores counts for locales that are not flipped', () => {
+    expect(() => assertFlippedLocalesIndexable(new Map([['ja', 0]]), ['zh', 'ja'])).toThrow(/ja/);
+    expect(() => assertFlippedLocalesIndexable(new Map([['zh', 5]]), ['zh'])).not.toThrow();
+  });
+});


### PR DESCRIPTION
Turns Chinese on. One line: `INDEXABLE_LOCALES` gains `'zh'`.

> **Stacked on #1151.** Without it this change fails the build: the locale route currently aborts on any page the predicate rejects, and 96 of 615 are legitimately held. Base retargets to `main` once #1151 merges.

## Why now

Chinese passed native review. Zhixiong Lin worked the flagged sheet, and his 85 corrections landed as overrides plus a checksum-bound sign-off record in #1145, after Tiger Fu's spot check endorsed the AI recommendations. The sign-off is what the predicate checks, so this is the gate the design intends.

## What it turns on

Resolved against the live hub index: **519 of 615 pages become indexable.**

- self-canonicals and sitemap entries for those 519
- reciprocal hreflang between them and their English twins
- the footer language switcher, which derives itself from this constant and has rendered nothing until now

The remaining **96 are held** by the per-page predicate (93 with an English-fallback field, 3 published since the last translation run). They keep today's behavior exactly: Chinese for humans, canonical to English, out of the sitemap, out of every hreflang cluster. They join automatically as their fields land, no further PR.

## Verified locally before opening this

Dev server with this change, driven by Playwright, 11/11:

| Check | Result |
|---|---|
| switcher renders on English `/workflows/` | `English  简体中文`, linking `/zh/workflows/` |
| switcher on `/zh/workflows/` | 简体中文 marked `aria-current`, English offered back |
| indexable zh page canonical | self, `/zh/workflows/…` |
| indexable zh page hreflang | emits `zh` alternate |
| held page | 200, still Chinese (`LTX-2.3: 文生视频`), canonical to English, no `zh` alternate |
| English twin of an indexable page | advertises `zh` |
| English twin of a held page | does **not** advertise `zh` |

Full unit suite (560) green with the flip applied, lint and format clean.

Note the switcher label is **简体中文**, not `中文` — that is `LANGUAGES.zh.nativeName` in `src/i18n/config.ts`, and it pairs correctly with `繁體中文` for zh-TW.

## Two things reviewers should know

**Deploying is a separate manual step.** Merging does not deploy this repo — `deploy-site.yml` runs on `workflow_dispatch` or after a successful PyPI publish. Nothing reaches comfy.org until that is dispatched.

**Pre-existing, not from this PR:** English listing pages (e.g. `/workflows/category/image/`) emit every hreflang twice, because `BaseLayout` emits a set and the page passes a second `HreflangTags`. That is live on production today and is unchanged by this change; it belongs with the GTM-349 indexability work.
