### PR TITLE
fix(site): use the ai-prefixed keyword on the sprite sheet page, and budget the related rail

### DIFF
--- a/site/src/lib/workflow-pages/use-case-resolver.ts
+++ b/site/src/lib/workflow-pages/use-case-resolver.ts
@@ -133,10 +133,23 @@ export function qualifyingGroups(catalog: SerializedTemplate[]): ModelGroup[] {
  * that drives many of the page's templates is more related than an incidental
  * one). Replaces hand-typed `relatedModels`, so it can never drift from the grid.
  */
+/**
+ * Caps on the "Keep exploring" rail, named because the two interact and the
+ * interaction is invisible at the call site: the page concatenates model cards
+ * ahead of use-case cards and truncates to RELATED_RAIL_LIMIT, so a page can
+ * only ever surface RELATED_RAIL_LIMIT - RELATED_MODEL_LIMIT of its own
+ * `relatedSlugs`. Declaring more is not an error at runtime, the extras simply
+ * never render, so `use-case-resolver.test.ts` asserts the budget instead.
+ */
+export const RELATED_RAIL_LIMIT = 5;
+export const RELATED_MODEL_LIMIT = 3;
+/** How many `relatedSlugs` a page can actually show. */
+export const RELATED_SLUG_BUDGET = RELATED_RAIL_LIMIT - RELATED_MODEL_LIMIT;
+
 export function relatedModelsForUseCase(
   def: SeoPageDef,
   catalog: SerializedTemplate[],
-  limit = 3
+  limit = RELATED_MODEL_LIMIT
 ): RelatedModel[] {
   const grid = resolveUseCasePageTemplates(def, catalog);
   const gridNames = new Set(grid.map((template) => template.name));
@@ -168,7 +181,7 @@ export function relatedUseCasesForPage(
   def: SeoPageDef,
   allPages: SeoPageDef[],
   routedSlugs: string[],
-  limit = 5
+  limit = RELATED_RAIL_LIMIT
 ): SeoPageDef[] {
   const routed = new Set(routedSlugs);
   const bySlug = new Map(allPages.map((page) => [page.slug, page]));

--- a/site/src/lib/workflow-pages/use-cases.ts
+++ b/site/src/lib/workflow-pages/use-cases.ts
@@ -529,10 +529,16 @@ export const SEO_PAGES: SeoPageDef[] = [
     slug: 'sprite-sheet-generator',
     title: 'AI Sprite Sheet Generator | Comfy Workflows',
     h1: 'AI Sprite Sheet Generator Workflows',
+    // Primary carries the "ai " prefix, matching the other pages and the SEO
+    // review's framing. It is not only metadata: the body heading is built from
+    // it as "What is the {keyword}?", and the bare term renders as "What is the
+    // Sprite Sheet Generator?", which is the exact title of the workflow pinned
+    // first on this page. The bare term stays targeted from `secondary`, the
+    // meta description and the h1.
     keywords: {
-      primary: 'sprite sheet generator',
+      primary: 'ai sprite sheet generator',
       secondary: [
-        'ai sprite sheet generator',
+        'sprite sheet generator',
         'sprite sheet maker',
         'animated sprite sheet generator',
         'character sprite generator',

--- a/site/src/pages/workflows/use-cases/[slug].astro
+++ b/site/src/pages/workflows/use-cases/[slug].astro
@@ -30,6 +30,7 @@ import {
   resolveUseCasePageTemplates,
   relatedModelsForUseCase,
   relatedUseCasesForPage,
+  RELATED_RAIL_LIMIT,
   assertCuratedSharesResolve,
   type RelatedModel,
 } from '../../../lib/workflow-pages/use-case-resolver';
@@ -189,7 +190,7 @@ const relatedUseCaseCards = relatedUseCasesForPage(def, SEO_PAGES, routedSlugs).
 }));
 
 const relatedCards = resolveRailImages(
-  [...relatedModelCards, ...relatedUseCaseCards].slice(0, 5),
+  [...relatedModelCards, ...relatedUseCaseCards].slice(0, RELATED_RAIL_LIMIT),
   [...templates, ...fallbackPool],
   { excludeName: heroTemplateName, excludeStills: heroImage ? [heroImage] : [] }
 );

--- a/site/tests/unit/use-case-resolver.test.ts
+++ b/site/tests/unit/use-case-resolver.test.ts
@@ -4,9 +4,10 @@ import {
   assertCuratedSharesResolve,
   useCasePageHasGrid,
   relatedUseCasesForPage,
+  RELATED_SLUG_BUDGET,
   type FilterableTemplate,
 } from '../../src/lib/workflow-pages/use-case-resolver';
-import type { SeoPageDef } from '../../src/lib/workflow-pages/use-cases';
+import { SEO_PAGES, type SeoPageDef } from '../../src/lib/workflow-pages/use-cases';
 
 function tpl(shareId: string, tags: string[], usage = 100): FilterableTemplate {
   return { shareId, tags, models: [], usage };
@@ -280,5 +281,24 @@ describe('relatedUseCasesForPage', () => {
     const out = relatedUseCasesForPage(def, allPages, [...routedSlugs, 'ghost']);
     expect(out.map((p) => p.slug)).toEqual(['a', 'b', 'd', 'e', 'f']);
     expect(out.every(Boolean)).toBe(true);
+  });
+});
+
+/**
+ * `relatedSlugs` beyond the budget do not error, they silently never render: the
+ * page puts model cards first and truncates the rail, so the extras fall off the
+ * end. Assert the budget here so adding one fails loudly in CI rather than
+ * disappearing from a page nobody re-counts.
+ */
+describe('relatedSlugs budget', () => {
+  it('no page declares more relatedSlugs than the rail can show', () => {
+    const overBudget = SEO_PAGES.filter(
+      (page) => (page.relatedSlugs?.length ?? 0) > RELATED_SLUG_BUDGET
+    ).map((page) => `${page.slug} declares ${page.relatedSlugs?.length}`);
+    expect(overBudget).toEqual([]);
+  });
+
+  it('keeps a budget worth asserting', () => {
+    expect(RELATED_SLUG_BUDGET).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Follow-up to #1142. Two small things found reviewing it after approval, neither worth holding that PR for.

## 1. The primary keyword names a workflow that is on the page

`keywords.primary` is not only metadata. The body heading is built from it:

```
"useCase.whatIs": "What is the {keyword}?"
```

With `primary: 'sprite sheet generator'` that renders:

> ### What is the Sprite Sheet Generator?

**"Sprite Sheet Generator" is the exact title of the workflow pinned first on that page** (`fe5600667e2c`). So the heading reads as an introduction to that one workflow, sitting a few hundred pixels above it, rather than to the use case.

Swapping `primary` with the `ai sprite sheet generator` already in `secondary`:

| | heading | collides with the pinned workflow title |
| --- | --- | --- |
| before | What is the Sprite Sheet Generator? | **yes** |
| after | What is the Ai Sprite Sheet Generator? | no |

It also lines up with the rest of the site: **13 of the 16 other pages** use an `ai `-prefixed primary, and the SEO review on #1142 explicitly asked for "AI Sprite Sheet Generator" rather than the bare term, to stay away from the atlas-packing half of the intent.

Nothing is lost in targeting: the bare term stays in `secondary`, in the meta description, and inside the h1.

Not fixed here, because it is site-wide rather than this page: `titleCaseKeyword` renders `Ai` rather than `AI`, so every ai-prefixed page has that already. Worth a separate one-line fix in that helper.

## 2. The related rail silently drops extra relatedSlugs

`relatedSlugs` shipped in #1142. The page builds the rail as:

```ts
[...relatedModelCards, ...relatedUseCaseCards].slice(0, 5)
```

Model cards are capped at 3, so **a page can only ever show 2 of its own `relatedSlugs`**. This page declares exactly 2, so it works today with nothing spare. A third would not error, it would just never render, and nobody would notice without counting cards on the live page.

Named both caps and derived the budget from them, so the relationship is visible where it is set rather than implied across two files:

```ts
export const RELATED_RAIL_LIMIT = 5;
export const RELATED_MODEL_LIMIT = 3;
export const RELATED_SLUG_BUDGET = RELATED_RAIL_LIMIT - RELATED_MODEL_LIMIT;
```

A test asserts no page exceeds the budget. **Mutation-checked**: adding a third slug to this page fails with

```
expected [ 'sprite-sheet-generator declares 3' ] to deeply equal []
```

so it fails loudly in CI instead of disappearing from the page.

## Verification

- 563 unit tests, eslint clean, prettier clean, `astro check` 0 errors
- Heading change confirmed against the real `en.json` template, not assumed
- No behaviour change for any other page: the caps keep their existing values, and pages without `relatedSlugs` are untouched
