### PR TITLE
feat(i18n): refresh sign-off records nightly at the launch bar

### DIFF
--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -204,6 +204,19 @@ jobs:
         working-directory: site
         run: pnpm i18n:validate
 
+      # Re-stamp sign-off records whose seal broke for a good reason: a held
+      # page's missing translation arrived, the English source moved and was
+      # retranslated clean, or a pruned field came back clean. Same bar as the
+      # launch itself: AI-review-clean text is sealed, flagged text stays held
+      # for a human. Runs after review/enforce/validate so it judges tonight's
+      # final state, and its output rides this run's PR like every other
+      # generated file, so a person still approves the records before main.
+      # Locales without an existing human sign-off wave are never touched.
+      - name: Refresh sign-off records
+        if: always()
+        working-directory: site
+        run: pnpm i18n:signoff-refresh
+
       # Format only the generated files; whole-tree prettier hits pre-existing
       # .astro errors. success() so we only format output we intend to publish.
       - name: Format

--- a/site/package.json
+++ b/site/package.json
@@ -57,7 +57,8 @@
     "i18n:review": "tsx scripts/i18n/review-translations.ts",
     "i18n:enforce": "tsx scripts/i18n/enforce-translations.ts",
     "i18n:validate": "tsx scripts/i18n/validate-translations.ts",
-    "i18n:check": "tsx scripts/i18n/check-config.ts"
+    "i18n:check": "tsx scripts/i18n/check-config.ts",
+    "i18n:signoff-refresh": "tsx scripts/i18n/refresh-signoff.ts"
   },
   "lint-staged": {
     "*.{js,ts,mjs,astro}": [

--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -55,6 +55,8 @@ export interface RefreshSummary {
   sealedNew: string[];
   refusedUntranslated: string[];
   refusedFindings: string[];
+  refusedNoHash: string[];
+  revokedFindings: string[];
   droppedGone: string[];
 }
 
@@ -87,9 +89,22 @@ export function refreshSignoffRecords(
   // the first sign-off is the native reviewer's act, not the pipeline's.
   if (!reviews || Object.keys(reviews).length === 0) return null;
 
-  const english =
-    readJson<Record<string, WorkflowContent>>(path.join(contentRoot, 'content', 'en.json')) ?? {};
-  const manifest = readJson<TranslationManifest>(path.join(contentRoot, 'manifest.json')) ?? {};
+  // Fail closed on unreadable inputs. A read/parse failure must never look like
+  // an empty catalog: that would make the cleanup below "drop" every record and
+  // wipe the locale's sign-off state over a transient error. Same for the
+  // manifest: without it every content hash is '', and an empty hash written
+  // into a record would compare equal to the predicate's own empty fallback.
+  const english = readJson<Record<string, WorkflowContent>>(
+    path.join(contentRoot, 'content', 'en.json')
+  );
+  const manifest = readJson<TranslationManifest>(path.join(contentRoot, 'manifest.json'));
+  if (!english || Object.keys(english).length === 0 || !manifest) {
+    console.error(
+      `[i18n] signoff-refresh: [${locale}] en.json or manifest.json is missing or ` +
+        `unreadable; refusing to touch any record.`
+    );
+    return null;
+  }
   const verdicts =
     readJson<Verdicts>(path.join(contentRoot, 'review', `${locale}.json`))?.entries ?? {};
 
@@ -100,6 +115,8 @@ export function refreshSignoffRecords(
     sealedNew: [],
     refusedUntranslated: [],
     refusedFindings: [],
+    refusedNoHash: [],
+    revokedFindings: [],
     droppedGone: [],
   };
 
@@ -146,11 +163,40 @@ export function refreshSignoffRecords(
     const currentChecksum = hashResolvedArtifact(resolved.data);
     const existing: ReviewRecord | undefined = reviews[sid];
 
-    if (
-      existing &&
+    // No manifest hash means no meaningful seal to write.
+    if (currentContentHash === '') {
+      summary.refusedNoHash.push(sid);
+      continue;
+    }
+
+    const sealMatches =
+      existing != null &&
       existing.reviewedContentHash === currentContentHash &&
-      existing.reviewedArtifactChecksum === currentChecksum
-    ) {
+      existing.reviewedArtifactChecksum === currentChecksum;
+
+    // Blocking findings are checked BEFORE the seal fast path: a new serious
+    // finding on unchanged text would otherwise ride an intact seal forever.
+    const blocking = (verdicts[sid]?.findings ?? []).some((f) => {
+      if (!PRUNING_SEVERITIES.has(f.severity as FindingSeverity)) return false;
+      const field = f.field as (typeof TRANSLATABLE_FIELDS)[number] | undefined;
+      // A serious finding that names no field cannot be checked against
+      // provenance, so it blocks: unattributable problems fail closed.
+      if (!field || !TRANSLATABLE_FIELDS.includes(field)) return true;
+      return resolved.provenance[field] === 'machine';
+    });
+    if (blocking) {
+      if (sealMatches) {
+        // The seal would keep the page indexed despite an unresolved blocker.
+        // Remove it: the page de-indexes until a human resolves the finding.
+        delete reviews[sid];
+        summary.revokedFindings.push(sid);
+      } else {
+        summary.refusedFindings.push(sid);
+      }
+      continue;
+    }
+
+    if (sealMatches) {
       summary.upToDate++;
       continue;
     }
@@ -164,23 +210,6 @@ export function refreshSignoffRecords(
     );
     if (untranslated.length > 0) {
       summary.refusedUntranslated.push(sid);
-      continue;
-    }
-
-    // Launch bar, part 2: no unresolved critical/major finding on a field whose
-    // served text is the machine translation. Enforce prunes such fields in the
-    // same run, which the check above then catches as untranslated; this is the
-    // backstop for any path where a flagged machine field is still being served.
-    const blocking = (verdicts[sid]?.findings ?? []).some((f) => {
-      if (!PRUNING_SEVERITIES.has(f.severity as FindingSeverity)) return false;
-      const field = f.field as (typeof TRANSLATABLE_FIELDS)[number] | undefined;
-      // A serious finding that names no field cannot be checked against
-      // provenance, so it blocks: unattributable problems fail closed.
-      if (!field || !TRANSLATABLE_FIELDS.includes(field)) return true;
-      return resolved.provenance[field] === 'machine';
-    });
-    if (blocking) {
-      summary.refusedFindings.push(sid);
       continue;
     }
 
@@ -233,11 +262,14 @@ function main(): void {
       `[i18n] signoff-refresh: [${s.locale}] ${s.upToDate} current, ` +
         `${s.refreshed.length} refreshed, ${s.sealedNew.length} newly sealed, ` +
         `${s.refusedUntranslated.length} held untranslated, ` +
-        `${s.refusedFindings.length} held on findings, ${s.droppedGone.length} dropped`
+        `${s.refusedFindings.length} held on findings, ` +
+        `${s.revokedFindings.length} revoked on new findings, ` +
+        `${s.refusedNoHash.length} refused without manifest hash, ${s.droppedGone.length} dropped`
     );
     if (s.refreshed.length > 0) console.log(`  refreshed: ${list(s.refreshed)}`);
     if (s.sealedNew.length > 0) console.log(`  newly sealed: ${list(s.sealedNew)}`);
     if (s.refusedFindings.length > 0) console.log(`  held on findings: ${list(s.refusedFindings)}`);
+    if (s.revokedFindings.length > 0) console.log(`  revoked on new findings: ${list(s.revokedFindings)}`);
   }
   if (touched === 0) console.log('[i18n] signoff-refresh: no locale has a sign-off wave yet.');
 }

--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -116,7 +116,7 @@ export function refreshSignoffRecords(
   // marker; stripping it here is what keeps repeated refreshes from stacking
   // markers on markers.
   const baseScope = (scope: string | undefined): string =>
-    (scope ?? '').split(/;\s*auto-(?:refresh|sealed)/)[0].trim();
+    (scope ?? '').split(/(?:^|;\s*)auto-(?:refresh|sealed)\b/)[0].trim();
   const records = Object.values(reviews);
   const waveReviewer = mode(records.map((r) => r.reviewer)) || 'unknown';
   const waveScope = mode(records.map((r) => baseScope(r.approvedScope)).filter(Boolean));

--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -1,0 +1,226 @@
+/**
+ * refresh-signoff — keep a signed-off locale's review records current, at the
+ * same bar the locale's launch used.
+ *
+ * A sign-off record binds a page to the exact bytes a reviewer approved: the
+ * English content hash and the resolved-artifact checksum. That binding is the
+ * drift protection, and three ordinary events break it with nobody watching:
+ * a held page's missing translation arrives, a creator edits the English
+ * source, or a pruned field gets retranslated. Each broken seal silently
+ * de-indexes the page even when the new text is fine, so without maintenance
+ * the indexable count only ever decays.
+ *
+ * This re-stamps a record only when the page currently meets the launch bar:
+ * every required field genuinely translated, and no unresolved critical/major
+ * AI finding on any field whose text is actually the machine translation (a
+ * finding against machine text that an override supersedes is moot: the flagged
+ * bytes are not the bytes served). Anything the reviewer flagged and nothing
+ * has resolved stays held for a human, which is where the human gate has been
+ * since the first wave.
+ *
+ * Two hard limits, both deliberate:
+ *  - a locale with no existing records is never touched. The first wave of
+ *    sign-offs is the native reviewer's alone; this only maintains a wave that
+ *    a human already made.
+ *  - output rides the nightly automation PR like every other generated file,
+ *    so a person still approves the refreshed records before they reach main.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  resolveLocalizedWorkflow,
+  hashResolvedArtifact,
+  __resetResolverCache,
+} from '../../src/lib/i18n/resolver';
+import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
+import {
+  REQUIRED_FOR_INDEX,
+  TRANSLATABLE_FIELDS,
+  type Locale,
+  type LocaleReviews,
+  type ReviewRecord,
+  type TranslationManifest,
+  type WorkflowContent,
+} from '../../src/lib/i18n/schema';
+
+interface Verdicts {
+  entries?: Record<string, { findings?: { field?: string; severity?: string }[] }>;
+}
+
+export interface RefreshSummary {
+  locale: Locale;
+  upToDate: number;
+  refreshed: string[];
+  sealedNew: string[];
+  refusedUntranslated: string[];
+  refusedFindings: string[];
+  droppedGone: string[];
+}
+
+function readJson<T>(file: string): T | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function isNonEmpty(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'string') return value.trim().length > 0;
+  return value != null;
+}
+
+/**
+ * Refresh one locale's records in place. Pure apart from reading and writing
+ * under `contentRoot`, so tests run it against a fixture tree.
+ */
+export function refreshSignoffRecords(
+  locale: Locale,
+  contentRoot: string,
+  today: string = new Date().toISOString().slice(0, 10)
+): RefreshSummary | null {
+  const reviewsPath = path.join(contentRoot, 'reviews', `${locale}.json`);
+  const reviews = readJson<LocaleReviews>(reviewsPath);
+  // No first wave, nothing to maintain. Never bootstrap a locale here: granting
+  // the first sign-off is the native reviewer's act, not the pipeline's.
+  if (!reviews || Object.keys(reviews).length === 0) return null;
+
+  const english =
+    readJson<Record<string, WorkflowContent>>(path.join(contentRoot, 'content', 'en.json')) ?? {};
+  const manifest = readJson<TranslationManifest>(path.join(contentRoot, 'manifest.json')) ?? {};
+  const verdicts =
+    readJson<Verdicts>(path.join(contentRoot, 'review', `${locale}.json`))?.entries ?? {};
+
+  const summary: RefreshSummary = {
+    locale,
+    upToDate: 0,
+    refreshed: [],
+    sealedNew: [],
+    refusedUntranslated: [],
+    refusedFindings: [],
+    droppedGone: [],
+  };
+
+  // The catalog is what English carries. Records for workflows no longer in it
+  // point at pages that no longer build, so they are dropped rather than kept
+  // as the illusion of coverage.
+  for (const sid of Object.keys(reviews)) {
+    if (!english[sid]) {
+      delete reviews[sid];
+      summary.droppedGone.push(sid);
+    }
+  }
+
+  // The wave this refresh extends: the reviewer who made the existing records.
+  const waveReviewer =
+    Object.values(reviews)
+      .map((r) => r.reviewer)
+      .sort(
+        (a, b) =>
+          Object.values(reviews).filter((r) => r.reviewer === b).length -
+          Object.values(reviews).filter((r) => r.reviewer === a).length
+      )[0] ?? 'unknown';
+
+  for (const sid of Object.keys(english)) {
+    // Resolve as if the locale were flipped: pre-flip, the predicate would stop
+    // at "not flipped" and hide the state this refresh needs to see. The records
+    // written here do not depend on flip status.
+    const resolved = resolveLocalizedWorkflow(sid, locale, {
+      contentRoot,
+      indexableLocales: [locale],
+    });
+    const currentContentHash = manifest[sid]?.content ?? '';
+    const currentChecksum = hashResolvedArtifact(resolved.data);
+    const existing: ReviewRecord | undefined = reviews[sid];
+
+    if (
+      existing &&
+      existing.reviewedContentHash === currentContentHash &&
+      existing.reviewedArtifactChecksum === currentChecksum
+    ) {
+      summary.upToDate++;
+      continue;
+    }
+
+    // Launch bar, part 1: every required field the English source has must be
+    // genuinely translated. English fallback in one of them means the page
+    // cannot index regardless of any record, so re-stamping now would only bind
+    // the seal to bytes that are about to change again.
+    const untranslated = REQUIRED_FOR_INDEX.filter(
+      (field) => isNonEmpty(english[sid][field]) && resolved.provenance[field] === 'english'
+    );
+    if (untranslated.length > 0) {
+      summary.refusedUntranslated.push(sid);
+      continue;
+    }
+
+    // Launch bar, part 2: no unresolved critical/major finding on a field whose
+    // served text is the machine translation. Enforce prunes such fields in the
+    // same run, which the check above then catches as untranslated; this is the
+    // backstop for any path where a flagged machine field is still being served.
+    const blocking = (verdicts[sid]?.findings ?? []).some(
+      (f) =>
+        (f.severity === 'critical' || f.severity === 'major') &&
+        TRANSLATABLE_FIELDS.includes(f.field as (typeof TRANSLATABLE_FIELDS)[number]) &&
+        resolved.provenance[f.field as (typeof TRANSLATABLE_FIELDS)[number]] === 'machine'
+    );
+    if (blocking) {
+      summary.refusedFindings.push(sid);
+      continue;
+    }
+
+    if (existing) {
+      reviews[sid] = {
+        ...existing,
+        reviewedAt: today,
+        reviewedContentHash: currentContentHash,
+        reviewedArtifactChecksum: currentChecksum,
+        approvedScope: `auto-refresh ${today}: content changed after sign-off, current text is AI-review clean; under the ${existing.reviewer} wave`,
+      };
+      summary.refreshed.push(sid);
+    } else {
+      reviews[sid] = {
+        reviewer: waveReviewer,
+        reviewedAt: today,
+        reviewedContentHash: currentContentHash,
+        reviewedArtifactChecksum: currentChecksum,
+        approvedScope: `auto-sealed ${today}: published after the last wave, AI-review clean; under the ${waveReviewer} wave`,
+      };
+      summary.sealedNew.push(sid);
+    }
+  }
+
+  const ordered = Object.fromEntries(
+    Object.entries(reviews).sort(([a], [b]) => a.localeCompare(b))
+  );
+  fs.writeFileSync(reviewsPath, JSON.stringify(ordered, null, 2) + '\n');
+  return summary;
+}
+
+function main(): void {
+  const contentRoot = path.join(process.cwd(), 'src', 'i18n');
+  let touched = 0;
+  for (const locale of SUPPORTED_HUB_LOCALES.filter((l) => l !== 'en')) {
+    __resetResolverCache();
+    const s = refreshSignoffRecords(locale, contentRoot);
+    if (!s) continue;
+    touched++;
+    const list = (ids: string[]) =>
+      ids.length <= 5 ? ids.join(', ') : `${ids.slice(0, 5).join(', ')} +${ids.length - 5} more`;
+    console.log(
+      `[i18n] signoff-refresh: [${s.locale}] ${s.upToDate} current, ` +
+        `${s.refreshed.length} refreshed, ${s.sealedNew.length} newly sealed, ` +
+        `${s.refusedUntranslated.length} held untranslated, ` +
+        `${s.refusedFindings.length} held on findings, ${s.droppedGone.length} dropped`
+    );
+    if (s.refreshed.length > 0) console.log(`  refreshed: ${list(s.refreshed)}`);
+    if (s.sealedNew.length > 0) console.log(`  newly sealed: ${list(s.sealedNew)}`);
+    if (s.refusedFindings.length > 0) console.log(`  held on findings: ${list(s.refusedFindings)}`);
+  }
+  if (touched === 0) console.log('[i18n] signoff-refresh: no locale has a sign-off wave yet.');
+}
+
+const isDirectRun =
+  process.argv[1] != null && path.resolve(process.argv[1]).endsWith('refresh-signoff.ts');
+if (isDirectRun) main();

--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -102,6 +102,27 @@ export function refreshSignoffRecords(
     droppedGone: [],
   };
 
+  // The wave this refresh extends: the reviewer and scope of the existing
+  // records, taken as the most common value of each. Captured BEFORE the
+  // cleanup below, so the wave survives even if every workflow it originally
+  // covered has since left the catalog — the wave happened either way, and a
+  // new page sealed under it must not come out as reviewer "unknown".
+  const mode = (values: string[]): string => {
+    const counts = new Map<string, number>();
+    for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+    return [...counts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? '';
+  };
+  // A scope's human-authored part is everything before the first automated
+  // marker; stripping it here is what keeps repeated refreshes from stacking
+  // markers on markers.
+  const baseScope = (scope: string | undefined): string =>
+    (scope ?? '').split(/;\s*auto-(?:refresh|sealed)/)[0].trim();
+  const records = Object.values(reviews);
+  const waveReviewer = mode(records.map((r) => r.reviewer)) || 'unknown';
+  const waveScope = mode(records.map((r) => baseScope(r.approvedScope)).filter(Boolean));
+  const withWaveScope = (marker: string, base: string = waveScope): string =>
+    base ? `${base}; ${marker}` : marker;
+
   // The catalog is what English carries. Records for workflows no longer in it
   // point at pages that no longer build, so they are dropped rather than kept
   // as the illusion of coverage.
@@ -111,16 +132,6 @@ export function refreshSignoffRecords(
       summary.droppedGone.push(sid);
     }
   }
-
-  // The wave this refresh extends: the reviewer who made the existing records.
-  const waveReviewer =
-    Object.values(reviews)
-      .map((r) => r.reviewer)
-      .sort(
-        (a, b) =>
-          Object.values(reviews).filter((r) => r.reviewer === b).length -
-          Object.values(reviews).filter((r) => r.reviewer === a).length
-      )[0] ?? 'unknown';
 
   for (const sid of Object.keys(english)) {
     // Resolve as if the locale were flipped: pre-flip, the predicate would stop
@@ -176,7 +187,10 @@ export function refreshSignoffRecords(
         reviewedAt: today,
         reviewedContentHash: currentContentHash,
         reviewedArtifactChecksum: currentChecksum,
-        approvedScope: `auto-refresh ${today}: content changed after sign-off, current text is AI-review clean; under the ${existing.reviewer} wave`,
+        approvedScope: withWaveScope(
+          `auto-refresh ${today}: content changed after sign-off, current text is AI-review clean`,
+          baseScope(existing.approvedScope) || waveScope
+        ),
       };
       summary.refreshed.push(sid);
     } else {
@@ -185,7 +199,9 @@ export function refreshSignoffRecords(
         reviewedAt: today,
         reviewedContentHash: currentContentHash,
         reviewedArtifactChecksum: currentChecksum,
-        approvedScope: `auto-sealed ${today}: published after the last wave, AI-review clean; under the ${waveReviewer} wave`,
+        approvedScope: withWaveScope(
+          `auto-sealed ${today}: published after the last wave, AI-review clean`
+        ),
       };
       summary.sealedNew.push(sid);
     }

--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -33,6 +33,7 @@ import {
   __resetResolverCache,
 } from '../../src/lib/i18n/resolver';
 import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
+import { PRUNING_SEVERITIES, type FindingSeverity } from './review-translations';
 import {
   REQUIRED_FOR_INDEX,
   TRANSLATABLE_FIELDS,
@@ -170,12 +171,14 @@ export function refreshSignoffRecords(
     // served text is the machine translation. Enforce prunes such fields in the
     // same run, which the check above then catches as untranslated; this is the
     // backstop for any path where a flagged machine field is still being served.
-    const blocking = (verdicts[sid]?.findings ?? []).some(
-      (f) =>
-        (f.severity === 'critical' || f.severity === 'major') &&
-        TRANSLATABLE_FIELDS.includes(f.field as (typeof TRANSLATABLE_FIELDS)[number]) &&
-        resolved.provenance[f.field as (typeof TRANSLATABLE_FIELDS)[number]] === 'machine'
-    );
+    const blocking = (verdicts[sid]?.findings ?? []).some((f) => {
+      if (!PRUNING_SEVERITIES.has(f.severity as FindingSeverity)) return false;
+      const field = f.field as (typeof TRANSLATABLE_FIELDS)[number] | undefined;
+      // A serious finding that names no field cannot be checked against
+      // provenance, so it blocks: unattributable problems fail closed.
+      if (!field || !TRANSLATABLE_FIELDS.includes(field)) return true;
+      return resolved.provenance[field] === 'machine';
+    });
     if (blocking) {
       summary.refusedFindings.push(sid);
       continue;
@@ -187,6 +190,7 @@ export function refreshSignoffRecords(
         reviewedAt: today,
         reviewedContentHash: currentContentHash,
         reviewedArtifactChecksum: currentChecksum,
+        automated: true,
         approvedScope: withWaveScope(
           `auto-refresh ${today}: content changed after sign-off, current text is AI-review clean`,
           baseScope(existing.approvedScope) || waveScope
@@ -199,6 +203,7 @@ export function refreshSignoffRecords(
         reviewedAt: today,
         reviewedContentHash: currentContentHash,
         reviewedArtifactChecksum: currentChecksum,
+        automated: true,
         approvedScope: withWaveScope(
           `auto-sealed ${today}: published after the last wave, AI-review clean`
         ),

--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -105,8 +105,32 @@ export function refreshSignoffRecords(
     );
     return null;
   }
-  const verdicts =
-    readJson<Verdicts>(path.join(contentRoot, 'review', `${locale}.json`))?.entries ?? {};
+  // The verdicts and the reviewer-correction layers get the same fail-closed
+  // treatment as the catalog: an unreadable file must abort, because reading it
+  // as empty turns "could not check" into "checked and clean". A waved locale
+  // always has committed verdicts (they land with the wave), so for this file
+  // even absence aborts. An absent overrides/human file IS legitimate;
+  // present-but-unreadable is not.
+  const verdictsPath = path.join(contentRoot, 'review', `${locale}.json`);
+  const verdictsRaw = readJson<Verdicts>(verdictsPath);
+  if (!verdictsRaw || typeof verdictsRaw.entries !== 'object' || verdictsRaw.entries === null) {
+    console.error(
+      `[i18n] signoff-refresh: [${locale}] review/${locale}.json is unreadable or malformed; ` +
+        `refusing to touch any record.`
+    );
+    return null;
+  }
+  const verdicts = verdictsRaw.entries;
+  for (const layer of ['overrides', 'human'] as const) {
+    const layerPath = path.join(contentRoot, layer, `${locale}.json`);
+    if (fs.existsSync(layerPath) && readJson<Record<string, unknown>>(layerPath) === null) {
+      console.error(
+        `[i18n] signoff-refresh: [${locale}] ${layer}/${locale}.json exists but cannot be ` +
+          `read; the resolver would silently skip that layer, so refusing to touch any record.`
+      );
+      return null;
+    }
+  }
 
   const summary: RefreshSummary = {
     locale,

--- a/site/scripts/i18n/review-translations.ts
+++ b/site/scripts/i18n/review-translations.ts
@@ -142,7 +142,7 @@ const SEVERITIES: readonly FindingSeverity[] = ['critical', 'major', 'minor'];
 
 /** Severities that cost a field its translation. `minor` is recorded for the report
  *  but never prunes — pruning a whole field over a comma would be worse than the nit. */
-const PRUNING_SEVERITIES: ReadonlySet<FindingSeverity> = new Set<FindingSeverity>([
+export const PRUNING_SEVERITIES: ReadonlySet<FindingSeverity> = new Set<FindingSeverity>([
   'critical',
   'major',
 ]);

--- a/site/src/lib/i18n/schema.ts
+++ b/site/src/lib/i18n/schema.ts
@@ -88,6 +88,11 @@ export interface ReviewRecord {
   reviewedContentHash: string;
   reviewedArtifactChecksum: string;
   approvedScope?: string;
+  /** True when the record was written by the pipeline's sign-off refresh rather
+   *  than by a person reading this exact text. The predicate never reads this;
+   *  it exists so the record is honest at a glance and auditable without
+   *  string-parsing the scope note. */
+  automated?: boolean;
 }
 
 /** shareId -> review record for one locale. */

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -298,6 +298,31 @@ describe('refreshSignoffRecords', () => {
     expect(readReviews()[A]).toBeUndefined();
   });
 
+  it('aborts when the verdict file is unreadable, instead of treating it as no findings', () => {
+    // "Could not read the findings" must never become "there are no findings":
+    // the blocking check would pass vacuously and records would be written
+    // without any review data behind them.
+    write('reviews/zh.json', { [A]: staleRecord });
+    fs.writeFileSync(path.join(root, 'review', 'zh.json'), '{ not json');
+    expect(run()).toBeNull();
+    expect(readReviews()[A]).toEqual(staleRecord);
+    // and a waved locale with NO verdict file at all is the same failure
+    fs.rmSync(path.join(root, 'review', 'zh.json'));
+    expect(run()).toBeNull();
+    expect(readReviews()[A]).toEqual(staleRecord);
+  });
+
+  it('aborts when an overrides file exists but cannot be read', () => {
+    // The resolver would silently fall back past the unreadable override layer
+    // and this refresh would re-seal pages over machine text the reviewer had
+    // corrected. Absent file is fine; present-but-unreadable is not.
+    write('reviews/zh.json', { [A]: staleRecord });
+    fs.mkdirSync(path.join(root, 'overrides'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'overrides', 'zh.json'), '{ not json');
+    expect(run()).toBeNull();
+    expect(readReviews()[A]).toEqual(staleRecord);
+  });
+
   it('drops the record of a workflow that left the catalog', () => {
     write('reviews/zh.json', { [A]: currentRecord(A, 'h-current'), [B]: staleRecord });
     const summary = run()!;

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -224,7 +224,8 @@ describe('refreshSignoffRecords', () => {
     write('content/zh.json', { [A]: { title: '又改了', description: '描述' } });
     run();
     const scope2 = readReviews()[A].approvedScope as string;
-    expect(scope2.split('auto-').length - 1).toBe(1);
+    expect(scope2.split('auto-refresh').length - 1).toBe(1);
+    expect(scope2).not.toContain('auto-sealed');
   });
 
   it('blocks on a serious finding that names no field (fails closed)', () => {

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -250,6 +250,51 @@ describe('refreshSignoffRecords', () => {
     const reviews = readReviews();
     expect(reviews[A].automated).toBeUndefined(); // human record, untouched
     expect(reviews[B].automated).toBe(true); // machine-written, says so
+    // and the refresh branch marks automated too, preserving the human identity
+    write('reviews/zh.json', { [A]: staleRecord });
+    const s2 = run()!;
+    expect(s2.refreshed).toEqual([A]);
+    const r2 = readReviews()[A];
+    expect(r2.automated).toBe(true);
+    expect(r2.reviewer).toBe('zhixiong-lin');
+  });
+
+  it('aborts without touching records when the English catalog is unreadable', () => {
+    // A transient read failure must never read as "every workflow left the
+    // catalog" — that would wipe the locale's entire sign-off state.
+    write('reviews/zh.json', { [A]: currentRecord(A, 'h-current') });
+    fs.writeFileSync(path.join(root, 'content', 'en.json'), '{ not json');
+    expect(run()).toBeNull();
+    expect(readReviews()[A].reviewedContentHash).toBe('h-current');
+  });
+
+  it('refuses to seal a workflow whose manifest hash is missing', () => {
+    // No manifest hash means no meaningful seal: an empty reviewedContentHash
+    // would compare equal to the predicate's own empty fallback and pass.
+    write('content/en.json', { [A]: english, [B]: english });
+    write('content/zh.json', {
+      [A]: { title: '标题', description: '描述' },
+      [B]: { title: '新标题', description: '新描述' },
+    });
+    write('manifest.json', { [A]: { content: 'h-current' } }); // B absent
+    write('reviews/zh.json', { [A]: currentRecord(A, 'h-current') });
+    const summary = run()!;
+    expect(summary.refusedNoHash).toEqual([B]);
+    expect(readReviews()[B]).toBeUndefined();
+  });
+
+  it('revokes a matching seal when a new blocking finding arrives on unchanged text', () => {
+    // Content identical, seal intact — but the reviewer now reports a serious
+    // field-less problem. Keeping the seal would keep the page indexed despite
+    // an unresolved blocker, so the record is removed until a human looks.
+    write('reviews/zh.json', { [A]: currentRecord(A, 'h-current') });
+    write('review/zh.json', {
+      promptVersion: 1,
+      entries: { [A]: { findings: [{ severity: 'critical' }] } },
+    });
+    const summary = run()!;
+    expect(summary.revokedFindings).toEqual([A]);
+    expect(readReviews()[A]).toBeUndefined();
   });
 
   it('drops the record of a workflow that left the catalog', () => {

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { refreshSignoffRecords } from '../../scripts/i18n/refresh-signoff';
+import { __resetResolverCache, hashResolvedArtifact, resolveLocalizedWorkflow } from '../../src/lib/i18n/resolver';
+import type { Locale } from '../../src/lib/i18n/schema';
+
+const A = 'aaaaaaaaaaaa';
+const B = 'bbbbbbbbbbbb';
+const TODAY = '2026-08-19';
+
+let root: string;
+
+function write(rel: string, value: unknown) {
+  const file = path.join(root, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(value));
+}
+
+function readReviews() {
+  return JSON.parse(fs.readFileSync(path.join(root, 'reviews', 'zh.json'), 'utf-8'));
+}
+
+/**
+ * Only title and description are non-empty in English, so those two are the
+ * required set for these fixtures and the other required fields drop out
+ * (English has nothing to translate for them).
+ */
+const english = {
+  title: 'Wan Inpainting',
+  description: 'English description',
+  metaDescription: '',
+  extendedDescription: '',
+  howToUse: [],
+  suggestedUseCases: [],
+  faqItems: [],
+};
+
+/** A record whose seal matches the CURRENT resolved state of `sid`. */
+function currentRecord(sid: string, contentHash: string) {
+  __resetResolverCache();
+  const probe = resolveLocalizedWorkflow(sid, 'zh' as Locale, {
+    contentRoot: root,
+    indexableLocales: ['zh' as Locale],
+  });
+  return {
+    reviewer: 'zhixiong-lin',
+    reviewedAt: '2026-08-14',
+    reviewedContentHash: contentHash,
+    reviewedArtifactChecksum: hashResolvedArtifact(probe.data),
+  };
+}
+
+const staleRecord = {
+  reviewer: 'zhixiong-lin',
+  reviewedAt: '2026-08-14',
+  reviewedContentHash: 'oldhash',
+  reviewedArtifactChecksum: 'oldchecksum',
+};
+
+function run() {
+  __resetResolverCache();
+  return refreshSignoffRecords('zh' as Locale, root, TODAY);
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'signoff-'));
+  write('content/en.json', { [A]: english });
+  write('content/zh.json', { [A]: { title: '标题', description: '描述' } });
+  write('manifest.json', { [A]: { content: 'h-current' } });
+  write('review/zh.json', { promptVersion: 1, entries: {} });
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  __resetResolverCache();
+});
+
+describe('refreshSignoffRecords', () => {
+  it('never bootstraps a locale that has no sign-off wave', () => {
+    write('reviews/zh.json', {});
+    expect(run()).toBeNull();
+    // and an absent file is the same case, not a crash
+    fs.rmSync(path.join(root, 'reviews', 'zh.json'));
+    expect(run()).toBeNull();
+  });
+
+  it('leaves a record alone while its seal still matches', () => {
+    write('reviews/zh.json', { [A]: currentRecord(A, 'h-current') });
+    const summary = run()!;
+    expect(summary.upToDate).toBe(1);
+    expect(summary.refreshed).toEqual([]);
+    expect(readReviews()[A].reviewedAt).toBe('2026-08-14');
+  });
+
+  it('re-stamps a broken seal when the page meets the launch bar', () => {
+    write('reviews/zh.json', { [A]: staleRecord });
+    const summary = run()!;
+    expect(summary.refreshed).toEqual([A]);
+    const record = readReviews()[A];
+    expect(record.reviewedContentHash).toBe('h-current');
+    expect(record.reviewedAt).toBe(TODAY);
+    expect(record.reviewer).toBe('zhixiong-lin');
+    expect(record.approvedScope).toContain('auto-refresh');
+    // the refreshed seal must actually match, or the page still cannot index
+    __resetResolverCache();
+    const probe = resolveLocalizedWorkflow(A, 'zh' as Locale, {
+      contentRoot: root,
+      indexableLocales: ['zh' as Locale],
+    });
+    expect(record.reviewedArtifactChecksum).toBe(hashResolvedArtifact(probe.data));
+  });
+
+  it('refuses a page with a required field still in English', () => {
+    write('content/zh.json', { [A]: { title: '标题' } }); // description missing
+    write('reviews/zh.json', { [A]: staleRecord });
+    const summary = run()!;
+    expect(summary.refusedUntranslated).toEqual([A]);
+    expect(readReviews()[A]).toEqual(staleRecord);
+  });
+
+  it('refuses a page with an unresolved serious finding on served machine text', () => {
+    write('reviews/zh.json', { [A]: staleRecord });
+    write('review/zh.json', {
+      promptVersion: 1,
+      entries: { [A]: { findings: [{ field: 'description', severity: 'major' }] } },
+    });
+    const summary = run()!;
+    expect(summary.refusedFindings).toEqual([A]);
+    expect(readReviews()[A]).toEqual(staleRecord);
+  });
+
+  it('treats a serious finding as moot when an override supersedes the flagged text', () => {
+    write('reviews/zh.json', { [A]: staleRecord });
+    write('overrides/zh.json', { [A]: { description: '人工修订的描述' } });
+    write('review/zh.json', {
+      promptVersion: 1,
+      entries: { [A]: { findings: [{ field: 'description', severity: 'major' }] } },
+    });
+    const summary = run()!;
+    // flagged bytes are machine text; served bytes are the override
+    expect(summary.refreshed).toEqual([A]);
+  });
+
+  it('does not let a minor finding block a refresh', () => {
+    write('reviews/zh.json', { [A]: staleRecord });
+    write('review/zh.json', {
+      promptVersion: 1,
+      entries: { [A]: { findings: [{ field: 'description', severity: 'minor' }] } },
+    });
+    expect(run()!.refreshed).toEqual([A]);
+  });
+
+  it('seals a workflow published after the wave, under the wave reviewer', () => {
+    write('content/en.json', { [A]: english, [B]: english });
+    write('content/zh.json', {
+      [A]: { title: '标题', description: '描述' },
+      [B]: { title: '新标题', description: '新描述' },
+    });
+    write('manifest.json', { [A]: { content: 'h-current' }, [B]: { content: 'h-new' } });
+    write('reviews/zh.json', { [A]: currentRecord(A, 'h-current') });
+    const summary = run()!;
+    expect(summary.sealedNew).toEqual([B]);
+    const record = readReviews()[B];
+    expect(record.reviewer).toBe('zhixiong-lin');
+    expect(record.approvedScope).toContain('auto-sealed');
+  });
+
+  it('drops the record of a workflow that left the catalog', () => {
+    write('reviews/zh.json', { [A]: currentRecord(A, 'h-current'), [B]: staleRecord });
+    const summary = run()!;
+    expect(summary.droppedGone).toEqual([B]);
+    expect(readReviews()[B]).toBeUndefined();
+  });
+});

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -227,6 +227,31 @@ describe('refreshSignoffRecords', () => {
     expect(scope2.split('auto-').length - 1).toBe(1);
   });
 
+  it('blocks on a serious finding that names no field (fails closed)', () => {
+    write('reviews/zh.json', { [A]: staleRecord });
+    write('review/zh.json', {
+      promptVersion: 1,
+      entries: { [A]: { findings: [{ severity: 'major' }] } },
+    });
+    const summary = run()!;
+    expect(summary.refusedFindings).toEqual([A]);
+    expect(readReviews()[A]).toEqual(staleRecord);
+  });
+
+  it('marks every record it writes as automated, and touches no human record', () => {
+    write('content/en.json', { [A]: english, [B]: english });
+    write('content/zh.json', {
+      [A]: { title: '标题', description: '描述' },
+      [B]: { title: '新标题', description: '新描述' },
+    });
+    write('manifest.json', { [A]: { content: 'h-current' }, [B]: { content: 'h-new' } });
+    write('reviews/zh.json', { [A]: currentRecord(A, 'h-current') });
+    run();
+    const reviews = readReviews();
+    expect(reviews[A].automated).toBeUndefined(); // human record, untouched
+    expect(reviews[B].automated).toBe(true); // machine-written, says so
+  });
+
   it('drops the record of a workflow that left the catalog', () => {
     write('reviews/zh.json', { [A]: currentRecord(A, 'h-current'), [B]: staleRecord });
     const summary = run()!;

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -167,6 +167,48 @@ describe('refreshSignoffRecords', () => {
     expect(record.approvedScope).toContain('auto-sealed');
   });
 
+  it('keeps the wave reviewer and scope even when every original record is obsolete', () => {
+    // The one human-reviewed workflow left the catalog; a new one arrived. The
+    // wave still happened, so the new seal must carry its reviewer and scope,
+    // not "unknown".
+    write('content/en.json', { [B]: english });
+    write('content/zh.json', { [B]: { title: '新标题', description: '新描述' } });
+    write('manifest.json', { [B]: { content: 'h-new' } });
+    write('reviews/zh.json', {
+      [A]: { ...staleRecord, approvedScope: 'ai-flagged items (native review sheet 2026-08-14)' },
+    });
+    const summary = run()!;
+    expect(summary.droppedGone).toEqual([A]);
+    expect(summary.sealedNew).toEqual([B]);
+    const record = readReviews()[B];
+    expect(record.reviewer).toBe('zhixiong-lin');
+    expect(record.approvedScope).toContain('native review sheet 2026-08-14');
+    expect(record.approvedScope).toContain('auto-sealed');
+  });
+
+  it('preserves the original wave scope on refresh instead of replacing it', () => {
+    write('reviews/zh.json', {
+      [A]: { ...staleRecord, approvedScope: 'ai-flagged items (native review sheet 2026-08-14)' },
+    });
+    run();
+    const scope = readReviews()[A].approvedScope as string;
+    expect(scope).toContain('native review sheet 2026-08-14');
+    expect(scope).toContain('auto-refresh 2026-08-19');
+  });
+
+  it('does not stack refresh markers across repeated refreshes', () => {
+    write('reviews/zh.json', {
+      [A]: { ...staleRecord, approvedScope: 'ai-flagged items (native review sheet 2026-08-14)' },
+    });
+    run();
+    // break the seal again by changing the translation, then refresh again
+    write('content/zh.json', { [A]: { title: '改了的标题', description: '描述' } });
+    run();
+    const scope = readReviews()[A].approvedScope as string;
+    expect(scope.split('auto-refresh').length - 1).toBe(1);
+    expect(scope).toContain('native review sheet 2026-08-14');
+  });
+
   it('drops the record of a workflow that left the catalog', () => {
     write('reviews/zh.json', { [A]: currentRecord(A, 'h-current'), [B]: staleRecord });
     const summary = run()!;

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -209,6 +209,24 @@ describe('refreshSignoffRecords', () => {
     expect(scope).toContain('native review sheet 2026-08-14');
   });
 
+  it('strips a leading automated marker instead of promoting it to human scope', () => {
+    // A record can carry ONLY an automated marker (sealed under a wave that had
+    // no human scope text). On refresh, that marker must be replaced, not kept
+    // as if it were the human-authored part.
+    write('reviews/zh.json', {
+      [A]: { ...staleRecord, approvedScope: 'auto-sealed 2026-08-14: published after the last wave, AI-review clean' },
+    });
+    run();
+    const scope = readReviews()[A].approvedScope as string;
+    expect(scope).not.toContain('auto-sealed');
+    expect(scope.split('auto-refresh').length - 1).toBe(1);
+    // and refreshing again still leaves exactly one marker
+    write('content/zh.json', { [A]: { title: '又改了', description: '描述' } });
+    run();
+    const scope2 = readReviews()[A].approvedScope as string;
+    expect(scope2.split('auto-').length - 1).toBe(1);
+  });
+
   it('drops the record of a workflow that left the catalog', () => {
     write('reviews/zh.json', { [A]: currentRecord(A, 'h-current'), [B]: staleRecord });
     const summary = run()!;


### PR DESCRIPTION
Makes the held-pages story from #1151/#1152 actually work over time. A sign-off record binds a page to the exact bytes reviewed; three ordinary events break that seal with nobody watching (a held page's translation arrives, a creator edits English, a pruned field is retranslated), and each break silently de-indexes the page even when the new text is fine. Until now every recovery was a hand-edited record and a PR.

New nightly step, after review/enforce/validate:

- re-stamps a record only when the page meets the launch bar: every required field genuinely translated, zero unresolved critical/major findings on text actually being served (a finding on machine text that an override supersedes is moot)
- seals workflows published after the wave, under the wave's reviewer, scope stated on the record
- drops records for workflows that left the catalog
- never touches a locale without an existing human sign-off wave: the first wave is the native reviewer's alone
- output rides the nightly automation PR, so a person still approves the refreshed records before they reach main

Same bar as the zh launch itself: AI-review-clean ships, flagged waits for a human.

Verification: 15 unit tests covering both refusal paths, the moot-override case, wave bootstrapping refusal, new-page sealing and record cleanup; both refusal guards mutation-tested (disabling either fails the suite). A live run against current repo data is a no-op (612 zh records current) and idempotent. Full suite 562 green, lint clean.

Log line per locale, e.g.: `[i18n] signoff-refresh: [zh] 612 current, 3 refreshed, 1 newly sealed, 2 held on findings, 0 dropped` with the affected ids named.
