### PR TITLE
fix(i18n): remove the duplicated flip guard that breaks the build

### DIFF
--- a/site/src/lib/i18n/locales.ts
+++ b/site/src/lib/i18n/locales.ts
@@ -78,35 +78,6 @@ export function assertFlippedLocalesIndexable(
 }
 
 /**
- * Fail-closed guard for a flipped locale, asserted once per build after the
- * locale routes have resolved every page.
- *
- * An individual page the predicate rejects is NOT a build failure: it is held
- * back (rendered in-locale for humans, canonical to English, absent from the
- * sitemap and from every hreflang cluster), which is the graceful degradation
- * the design specifies. Holds are the steady state, not an anomaly — workflows
- * are published to the hub between translation runs, so a flipped locale always
- * trails the catalog by however many entries landed since its last run.
- *
- * A flipped locale with ZERO indexable pages is a different animal: its
- * translation artifacts are missing or unreadable, and the language would
- * silently serve English under its own URLs. That fails the build.
- */
-export function assertFlippedLocalesIndexable(
-  indexablePageCounts: ReadonlyMap<string, number>,
-  flipped: readonly Locale[] = INDEXABLE_LOCALES
-): void {
-  const empty = flipped.filter((locale) => (indexablePageCounts.get(locale) ?? 0) === 0);
-  if (empty.length > 0) {
-    throw new Error(
-      `[i18n] flipped locale(s) ${empty.join(', ')} resolved zero indexable pages. ` +
-        `Their translation artifacts are missing or unreadable — fix those, or drop ` +
-        `the locale from INDEXABLE_LOCALES rather than serving English under its URLs.`
-    );
-  }
-}
-
-/**
  * Assert SUPPORTED ⊆ AVAILABLE (and INDEXABLE ⊆ SUPPORTED). Called from CI; throws
  * with the offending locales so a config drift fails the build, not production.
  */


### PR DESCRIPTION
main does not build since the flip chain merged: `locales.ts` declares `assertFlippedLocalesIndexable` twice and esbuild rejects the duplicate export, which failed the zh launch deploy (run 32175109581).

Cause: #1152 was stacked on #1151's branch. #1151 squash-merged, #1152 was retargeted to main and squash-merged; git's merge base still pointed at pre-#1151 main, so #1152's squash re-applied the function #1151 had already landed. No textual conflict, so the merge showed clean while the result was duplicated.

Diff is the deletion of the second, byte-identical copy. No behavior change. Verified: the module compiles and its unit tests pass with the dedupe.

**This blocks every deploy including the zh launch, so a fast approve is appreciated.**