### PR TITLE
fix(i18n): unfreeze translation runs (JSON mode) and save partial progress on failure

### DIFF
--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -287,3 +287,57 @@ jobs:
               --title "chore(i18n): update hub workflow translations" \
               --body "Automated hub translation refresh. English content regenerated from the Hub index, human seeds applied, gaps machine-translated, deterministic validators run. A partial (rate-limited) run still commits its progress to this same branch so the next run resumes. Does not flip any locale to indexable."
           fi
+
+      # A failed night must still save its translation progress. Without this, a
+      # from-scratch backfill (the ru/ar retranslation) can never converge: the
+      # run rate-limits partway, enforce/validate correctly refuse the partial
+      # result, the success()-gated publish above skips, and the night's OpenAI
+      # spend is discarded — so the next night restarts from the same point
+      # forever. This step commits the partial output to the same stable branch
+      # the "Restore partial progress" step reads, so consecutive nights
+      # accumulate until a run finally completes and publishes normally.
+      #
+      # Merging stays gated exactly as before: this step never creates a PR, and
+      # if the automation PR is already open its own Validate Translations check
+      # goes red on the partial head, so nobody can merge a state main's
+      # validators reject. Only what gets REMEMBERED changes, not what gets
+      # published.
+      - name: Save partial progress on failure
+        if: failure()
+        run: |
+          set -euo pipefail
+          STABLE_BRANCH="i18n/hub-translations"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add site/src/i18n
+          # A truncated write (the process can die mid-file on this path) must
+          # not poison the branch the next run restores from: drop any staged
+          # .json the next run could not parse. Deletions are skipped (nothing
+          # to parse) and stay staged.
+          while IFS= read -r f; do
+            case "$f" in
+              *.json)
+                if ! node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$f" 2>/dev/null; then
+                  echo "::warning::Excluding unparseable $f from the partial save"
+                  git restore --staged -- "$f"
+                fi
+                ;;
+            esac
+          done < <(git diff --cached --name-only --diff-filter=d)
+          if git diff --cached --quiet; then
+            echo "Run failed before producing any translation changes; nothing to save."
+            exit 0
+          fi
+          # Same no-op guard as the publish step: an identical rerun (e.g. a
+          # night that failed before translating) must not force-push a new head
+          # and rerun the automation PR's CI for zero progress.
+          if git rev-parse --verify --quiet "refs/remotes/origin/$STABLE_BRANCH" >/dev/null; then
+            if git diff --quiet "refs/remotes/origin/$STABLE_BRANCH" -- site/src/i18n; then
+              echo "No change vs the saved partial progress; leaving the branch untouched."
+              exit 0
+            fi
+          fi
+          git checkout -B "$STABLE_BRANCH"
+          git commit -m "chore(i18n): save partial translation progress (run failed, do not merge)"
+          git push --force-with-lease origin "$STABLE_BRANCH"
+          echo "Partial progress saved to $STABLE_BRANCH; the next run resumes from it."

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -330,7 +330,9 @@ jobs:
           # A FULLY misaligned content file (model-mangled keys, none in the
           # English source) fails validation and enforce cannot prune it, so
           # banking it would carry the mangled keys forward. Partially stale
-          # files still bank, matching the validator's tolerance.
+          # files still bank, matching the validator's tolerance. MUST run
+          # after the parse pass above: it reads en.json from the worktree,
+          # which that pass has already restored to a good version if truncated.
           while IFS= read -r f; do
             case "$f" in
               site/src/i18n/content/en.json) ;;

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -319,7 +319,19 @@ jobs:
               *.json)
                 if ! node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$f" 2>/dev/null; then
                   echo "::warning::Excluding unparseable $f from the partial save"
-                  git restore --staged -- "$f"
+                  # Excluding must not UNDO banked progress: a plain staged
+                  # restore resets the path to main's version, so a previously
+                  # saved translation regenerated as malformed would silently
+                  # drop off the stable branch at commit time. Take the last
+                  # good version from the branch when it has one, else main's,
+                  # else drop the new file entirely.
+                  if git cat-file -e "refs/remotes/origin/$STABLE_BRANCH:$f" 2>/dev/null; then
+                    git restore --source="refs/remotes/origin/$STABLE_BRANCH" --staged --worktree -- "$f"
+                  elif git cat-file -e "HEAD:$f" 2>/dev/null; then
+                    git restore --source=HEAD --staged --worktree -- "$f"
+                  else
+                    git rm -qf --ignore-unmatch -- "$f"
+                  fi
                 fi
                 ;;
             esac
@@ -330,9 +342,11 @@ jobs:
           fi
           # Same no-op guard as the publish step: an identical rerun (e.g. a
           # night that failed before translating) must not force-push a new head
-          # and rerun the automation PR's CI for zero progress.
+          # and rerun the automation PR's CI for zero progress. --cached, because
+          # the commit below is built from the index and an excluded malformed
+          # file may legitimately leave the worktree differing from the branch.
           if git rev-parse --verify --quiet "refs/remotes/origin/$STABLE_BRANCH" >/dev/null; then
-            if git diff --quiet "refs/remotes/origin/$STABLE_BRANCH" -- site/src/i18n; then
+            if git diff --cached --quiet "refs/remotes/origin/$STABLE_BRANCH" -- site/src/i18n; then
               echo "No change vs the saved partial progress; leaving the branch untouched."
               exit 0
             fi

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -288,20 +288,12 @@ jobs:
               --body "Automated hub translation refresh. English content regenerated from the Hub index, human seeds applied, gaps machine-translated, deterministic validators run. A partial (rate-limited) run still commits its progress to this same branch so the next run resumes. Does not flip any locale to indexable."
           fi
 
-      # A failed night must still save its translation progress. Without this, a
-      # from-scratch backfill (the ru/ar retranslation) can never converge: the
-      # run rate-limits partway, enforce/validate correctly refuse the partial
-      # result, the success()-gated publish above skips, and the night's OpenAI
-      # spend is discarded — so the next night restarts from the same point
-      # forever. This step commits the partial output to the same stable branch
-      # the "Restore partial progress" step reads, so consecutive nights
-      # accumulate until a run finally completes and publishes normally.
-      #
-      # Merging stays gated exactly as before: this step never creates a PR, and
-      # if the automation PR is already open its own Validate Translations check
-      # goes red on the partial head, so nobody can merge a state main's
-      # validators reject. Only what gets REMEMBERED changes, not what gets
-      # published.
+      # A failed night still saves its translation progress: without this, a
+      # from-scratch backfill can never converge — a rate-limited run fails
+      # enforce/validate, the success()-gated publish skips, and the spend is
+      # discarded. Saves to the same branch the restore step reads, so nights
+      # accumulate. Merging stays gated: never creates a PR, and the automation
+      # PR's own Validate Translations check is red on a partial head.
       - name: Save partial progress on failure
         if: failure()
         run: |
@@ -310,11 +302,10 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add site/src/i18n
-          # Excluding a file must not UNDO banked progress: a plain staged
-          # restore resets the path to main's version, so a previously saved
-          # translation regenerated as bad would silently drop off the stable
-          # branch at commit time. Take the last good version from the branch
-          # when it has one, else main's, else drop the new file entirely.
+          # Excluding must not UNDO banked progress (a plain staged restore
+          # resets to main's version and the commit drops the file from the
+          # branch): take the branch's last good version, else main's, else
+          # drop the new file.
           exclude_from_save() {
             if git cat-file -e "refs/remotes/origin/$STABLE_BRANCH:$1" 2>/dev/null; then
               git restore --source="refs/remotes/origin/$STABLE_BRANCH" --staged --worktree -- "$1"
@@ -324,10 +315,8 @@ jobs:
               git rm -qf --ignore-unmatch -- "$1"
             fi
           }
-          # A truncated write (the process can die mid-file on this path) must
-          # not poison the branch the next run restores from: drop any staged
-          # .json the next run could not parse. Deletions are skipped (nothing
-          # to parse) and stay staged.
+          # A truncated mid-file write must not poison the branch the next run
+          # restores from. Deletions stay staged (nothing to parse).
           while IFS= read -r f; do
             case "$f" in
               *.json)
@@ -338,13 +327,10 @@ jobs:
                 ;;
             esac
           done < <(git diff --cached --name-only --diff-filter=d)
-          # A FULLY misaligned content file (every entry keyed to nothing in
-          # the regenerated English source, i.e. model-mangled keys) fails
-          # validation as a whole and cannot be repaired by enforce's pruning,
-          # which leaves unmatched entries alone by design. Banking it would
-          # carry the mangled keys forward as permanent cruft, so exclude it.
-          # A PARTIALLY stale file still banks: the validator tolerates it and
-          # its valid entries are real progress.
+          # A FULLY misaligned content file (model-mangled keys, none in the
+          # English source) fails validation and enforce cannot prune it, so
+          # banking it would carry the mangled keys forward. Partially stale
+          # files still bank, matching the validator's tolerance.
           while IFS= read -r f; do
             case "$f" in
               site/src/i18n/content/en.json) ;;
@@ -362,13 +348,10 @@ jobs:
                 ;;
             esac
           done < <(git diff --cached --name-only --diff-filter=d)
-          # Never bank UI chrome (locales/) from a failed run. Content is safe
-          # to bank because enforce has already pruned every validator-failing
-          # field to disk (it reuses collectViolations and re-prunes restored
-          # content each night), but nothing prunes locales/ and locale:ui only
-          # fills MISSING keys, so a parseable-but-invalid UI string banked here
-          # would be restored and fail validate forever. UI strings are cheap to
-          # regenerate; keep the branch's (or main's) last good version instead.
+          # Never bank UI chrome from a failed run: nothing prunes locales/ and
+          # locale:ui fills only MISSING keys, so an invalid UI string banked
+          # here would restore and fail validate forever. (Content is safe:
+          # enforce prunes it to disk and re-prunes restored content nightly.)
           if git cat-file -e "refs/remotes/origin/$STABLE_BRANCH:site/src/i18n/locales" 2>/dev/null; then
             git restore --source="refs/remotes/origin/$STABLE_BRANCH" --staged --worktree -- site/src/i18n/locales
           else
@@ -378,11 +361,9 @@ jobs:
             echo "Run failed before producing any translation changes; nothing to save."
             exit 0
           fi
-          # Same no-op guard as the publish step: an identical rerun (e.g. a
-          # night that failed before translating) must not force-push a new head
-          # and rerun the automation PR's CI for zero progress. --cached, because
-          # the commit below is built from the index and an excluded malformed
-          # file may legitimately leave the worktree differing from the branch.
+          # Same no-op guard as the publish step; --cached because the commit
+          # is built from the index and an excluded file may leave the worktree
+          # differing from the branch.
           if git rev-parse --verify --quiet "refs/remotes/origin/$STABLE_BRANCH" >/dev/null; then
             if git diff --cached --quiet "refs/remotes/origin/$STABLE_BRANCH" -- site/src/i18n; then
               echo "No change vs the saved partial progress; leaving the branch untouched."
@@ -391,9 +372,8 @@ jobs:
           fi
           git checkout -B "$STABLE_BRANCH"
           git commit -m "chore(i18n): save partial translation progress (run failed, do not merge)"
-          # Retry transient push failures: the very first live run of this step
-          # lost its save to a GitHub-side HTTP 500, and on this unattended
-          # nightly path a dropped push is a night's progress gone.
+          # Retry transient push failures (a GitHub-side 500 here costs a full
+          # night's progress).
           for attempt in 1 2 3; do
             if git push --force-with-lease origin "$STABLE_BRANCH"; then
               echo "Partial progress saved to $STABLE_BRANCH; the next run resumes from it."

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -310,6 +310,20 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add site/src/i18n
+          # Excluding a file must not UNDO banked progress: a plain staged
+          # restore resets the path to main's version, so a previously saved
+          # translation regenerated as bad would silently drop off the stable
+          # branch at commit time. Take the last good version from the branch
+          # when it has one, else main's, else drop the new file entirely.
+          exclude_from_save() {
+            if git cat-file -e "refs/remotes/origin/$STABLE_BRANCH:$1" 2>/dev/null; then
+              git restore --source="refs/remotes/origin/$STABLE_BRANCH" --staged --worktree -- "$1"
+            elif git cat-file -e "HEAD:$1" 2>/dev/null; then
+              git restore --source=HEAD --staged --worktree -- "$1"
+            else
+              git rm -qf --ignore-unmatch -- "$1"
+            fi
+          }
           # A truncated write (the process can die mid-file on this path) must
           # not poison the branch the next run restores from: drop any staged
           # .json the next run could not parse. Deletions are skipped (nothing
@@ -319,19 +333,31 @@ jobs:
               *.json)
                 if ! node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$f" 2>/dev/null; then
                   echo "::warning::Excluding unparseable $f from the partial save"
-                  # Excluding must not UNDO banked progress: a plain staged
-                  # restore resets the path to main's version, so a previously
-                  # saved translation regenerated as malformed would silently
-                  # drop off the stable branch at commit time. Take the last
-                  # good version from the branch when it has one, else main's,
-                  # else drop the new file entirely.
-                  if git cat-file -e "refs/remotes/origin/$STABLE_BRANCH:$f" 2>/dev/null; then
-                    git restore --source="refs/remotes/origin/$STABLE_BRANCH" --staged --worktree -- "$f"
-                  elif git cat-file -e "HEAD:$f" 2>/dev/null; then
-                    git restore --source=HEAD --staged --worktree -- "$f"
-                  else
-                    git rm -qf --ignore-unmatch -- "$f"
-                  fi
+                  exclude_from_save "$f"
+                fi
+                ;;
+            esac
+          done < <(git diff --cached --name-only --diff-filter=d)
+          # A FULLY misaligned content file (every entry keyed to nothing in
+          # the regenerated English source, i.e. model-mangled keys) fails
+          # validation as a whole and cannot be repaired by enforce's pruning,
+          # which leaves unmatched entries alone by design. Banking it would
+          # carry the mangled keys forward as permanent cruft, so exclude it.
+          # A PARTIALLY stale file still banks: the validator tolerates it and
+          # its valid entries are real progress.
+          while IFS= read -r f; do
+            case "$f" in
+              site/src/i18n/content/en.json) ;;
+              site/src/i18n/content/*.json)
+                if ! node -e '
+                  const fs = require("fs");
+                  const en = JSON.parse(fs.readFileSync("site/src/i18n/content/en.json", "utf8"));
+                  const loc = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                  const keys = Object.keys(loc);
+                  process.exit(keys.length > 0 && keys.every((k) => !(k in en)) ? 1 : 0);
+                ' "$f" 2>/dev/null; then
+                  echo "::warning::Excluding fully misaligned $f from the partial save"
+                  exclude_from_save "$f"
                 fi
                 ;;
             esac

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -336,6 +336,18 @@ jobs:
                 ;;
             esac
           done < <(git diff --cached --name-only --diff-filter=d)
+          # Never bank UI chrome (locales/) from a failed run. Content is safe
+          # to bank because enforce has already pruned every validator-failing
+          # field to disk (it reuses collectViolations and re-prunes restored
+          # content each night), but nothing prunes locales/ and locale:ui only
+          # fills MISSING keys, so a parseable-but-invalid UI string banked here
+          # would be restored and fail validate forever. UI strings are cheap to
+          # regenerate; keep the branch's (or main's) last good version instead.
+          if git cat-file -e "refs/remotes/origin/$STABLE_BRANCH:site/src/i18n/locales" 2>/dev/null; then
+            git restore --source="refs/remotes/origin/$STABLE_BRANCH" --staged --worktree -- site/src/i18n/locales
+          else
+            git restore --source=HEAD --staged --worktree -- site/src/i18n/locales
+          fi
           if git diff --cached --quiet; then
             echo "Run failed before producing any translation changes; nothing to save."
             exit 0

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -339,5 +339,16 @@ jobs:
           fi
           git checkout -B "$STABLE_BRANCH"
           git commit -m "chore(i18n): save partial translation progress (run failed, do not merge)"
-          git push --force-with-lease origin "$STABLE_BRANCH"
-          echo "Partial progress saved to $STABLE_BRANCH; the next run resumes from it."
+          # Retry transient push failures: the very first live run of this step
+          # lost its save to a GitHub-side HTTP 500, and on this unattended
+          # nightly path a dropped push is a night's progress gone.
+          for attempt in 1 2 3; do
+            if git push --force-with-lease origin "$STABLE_BRANCH"; then
+              echo "Partial progress saved to $STABLE_BRANCH; the next run resumes from it."
+              exit 0
+            fi
+            echo "Push attempt $attempt failed; retrying in $((attempt * 20))s."
+            sleep $((attempt * 20))
+          done
+          echo "::error::Could not push partial progress after 3 attempts."
+          exit 1

--- a/site/.i18nrc.cjs
+++ b/site/.i18nrc.cjs
@@ -103,6 +103,17 @@ module.exports = defineConfig({
   // Serial: paced for the org's OpenAI tier (30k TPM). Raise once the tier is bumped.
   concurrency: 1,
   saveImmediately: true,
+  // Force OpenAI's JSON mode (response_format: json_object) on every translation
+  // call. gpt-5.2 in plain-text mode appends a stray closing brace after otherwise
+  // complete, correct JSON (likely miscounting the {{PTnn}} placeholder braces in
+  // the content), lobe's JSON.parse AND its dirty-json fallback both reject that
+  // one byte, and the CLI then discards the whole chunk — which froze every
+  // locale's translation run from 2026-08-14 on. JSON mode makes the API itself
+  // guarantee syntactically valid output, so the failure is impossible at the
+  // protocol level rather than merely unlikely. lobe only sends the flag when
+  // this experimental option is set. If a future model id rejects json_object,
+  // the call fails loudly with a 400, not silently.
+  experimental: { jsonMode: true },
   // content/ holds ONLY locale files, so it is a clean lobe entry/output dir.
   entry: 'src/i18n/content/en.json',
   entryLocale: 'en',

--- a/site/.i18nrc.cjs
+++ b/site/.i18nrc.cjs
@@ -103,16 +103,11 @@ module.exports = defineConfig({
   // Serial: paced for the org's OpenAI tier (30k TPM). Raise once the tier is bumped.
   concurrency: 1,
   saveImmediately: true,
-  // Force OpenAI's JSON mode (response_format: json_object) on every translation
-  // call. gpt-5.2 in plain-text mode appends a stray closing brace after otherwise
-  // complete, correct JSON (likely miscounting the {{PTnn}} placeholder braces in
-  // the content), lobe's JSON.parse AND its dirty-json fallback both reject that
-  // one byte, and the CLI then discards the whole chunk — which froze every
-  // locale's translation run from 2026-08-14 on. JSON mode makes the API itself
-  // guarantee syntactically valid output, so the failure is impossible at the
-  // protocol level rather than merely unlikely. lobe only sends the flag when
-  // this experimental option is set. If a future model id rejects json_object,
-  // the call fails loudly with a 400, not silently.
+  // Force OpenAI's JSON mode (response_format: json_object). gpt-5.2 in
+  // plain-text mode appends a stray closing brace after otherwise valid JSON
+  // (miscounting the {{PTnn}} placeholder braces); lobe rejects the chunk, which
+  // froze every locale's translation run from 2026-08-14 on. JSON mode makes the
+  // API guarantee parseable output. A model rejecting the flag fails with a 400.
   experimental: { jsonMode: true },
   // content/ holds ONLY locale files, so it is a clean lobe entry/output dir.
   entry: 'src/i18n/content/en.json',

--- a/site/scripts/i18n/check-config.ts
+++ b/site/scripts/i18n/check-config.ts
@@ -7,14 +7,19 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { assertLocaleSets } from '../../src/lib/i18n/locales';
-import { readCliContextWindows, effectiveSplitToken } from './cli-context-windows';
+import {
+  readCliContextWindows,
+  readCliJsonModeSupport,
+  effectiveSplitToken,
+} from './cli-context-windows';
 
 const require = createRequire(import.meta.url);
 
-/** Only the two fields this check reads; `.i18nrc.cjs` carries many more. */
+/** Only the fields this check reads; `.i18nrc.cjs` carries many more. */
 interface I18nConfig {
   modelName: string;
   splitToken: number;
+  experimental?: { jsonMode?: boolean };
 }
 
 /**
@@ -87,8 +92,39 @@ if (!contextWindows) {
   }
 }
 
+// 4. JSON mode must stay wired end to end. Without response_format json_object,
+// gpt-5.2 appends a stray closing brace that lobe rejects, which froze every
+// locale's translation run from 2026-08-14 on. The option is experimental in
+// lobe, so an upgrade that renames or drops it degrades SILENTLY back to that
+// path (an ignored config key does not 400 the way a rejected response_format
+// would) — so both halves are asserted here, before any spend.
+const { experimental } = require(path.join(process.cwd(), '.i18nrc.cjs')) as I18nConfig;
+if (experimental?.jsonMode !== true) {
+  errors.push(
+    '.i18nrc.cjs no longer sets experimental.jsonMode — without OpenAI JSON mode the ' +
+      'translator returns unparseable chunks (the stray-brace freeze). Restore the option.'
+  );
+}
+const cliJsonMode = readCliJsonModeSupport();
+if (cliJsonMode === null) {
+  // Same stance as the context-window table: an unreadable bundle says nothing
+  // about the option, so be loud without blocking.
+  console.warn(
+    '[i18n] config check: could not read the @lobehub/i18n-cli bundle to verify jsonMode ' +
+      'support. Re-verify the option is still honoured before trusting a dependency bump.'
+  );
+} else if (!cliJsonMode) {
+  errors.push(
+    'the installed @lobehub/i18n-cli no longer honours experimental.jsonMode / json_object. ' +
+      'Translation would silently run in plain-text mode, where gpt-5.2 output is unparseable. ' +
+      'Pin back to a version that supports it, or re-wire JSON mode before translating.'
+  );
+}
+
 if (errors.length > 0) {
   for (const e of errors) console.error(`[i18n] config check: ${e}`);
   process.exit(1);
 }
-console.log('[i18n] config check: entry present, locale sets valid, translator model sizable.');
+console.log(
+  '[i18n] config check: entry present, locale sets valid, translator model sizable, JSON mode wired.'
+);

--- a/site/scripts/i18n/cli-context-windows.ts
+++ b/site/scripts/i18n/cli-context-windows.ts
@@ -36,14 +36,29 @@ function readCliSource(): string | null {
 
 /**
  * Whether a CLI bundle both reads the `experimental.jsonMode` config option and
- * forwards OpenAI's `json_object` response format. Both markers are property
- * names / wire literals, which minification leaves intact. A version that
- * renames or drops the option would silently fall back to plain-text mode,
- * where gpt-5.2's stray-brace output froze every locale from 2026-08-14 — an
- * ignored config key gives no signal, unlike a rejected response_format.
+ * forwards OpenAI's `json_object` response format from a completions call. A
+ * version that renames or drops the option would silently fall back to
+ * plain-text mode, where gpt-5.2's stray-brace output froze every locale from
+ * 2026-08-14 — an ignored config key gives no signal, unlike a rejected
+ * response_format.
+ *
+ * Checked as the wiring expressions (property access + wire literal near a
+ * `chat.completions.create` call), not bare literals anywhere in the bundle,
+ * so unrelated occurrences cannot satisfy the check. Property names and wire
+ * literals survive minification. A true behavioural assertion is not on the
+ * table: the package's lib entry exports only `defineConfig`; the translation
+ * class lives solely in the CLI bundle, whose import has side effects.
  */
 export function cliSourceSupportsJsonMode(source: string): boolean {
-  return source.includes('jsonMode') && source.includes('json_object');
+  if (!/\.experimental\??\.\s*jsonMode/.test(source)) return false;
+  for (const m of source.matchAll(/response_format\s*:\s*\{\s*type\s*:\s*"json_object"\s*\}/g)) {
+    // The flag must sit inside a completions call's argument span; the bundle
+    // builds the request object inline, so the call name appears just before.
+    if (source.slice(Math.max(0, m.index - 2000), m.index).includes('chat.completions.create')) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /** jsonMode support of the installed CLI, or `null` when the bundle is unreadable. */

--- a/site/scripts/i18n/cli-context-windows.ts
+++ b/site/scripts/i18n/cli-context-windows.ts
@@ -25,14 +25,36 @@ const require = createRequire(import.meta.url);
  * `null` means the bundle's shape changed, not that the model is bad, so callers
  * should say so rather than treat it as a failed lookup.
  */
-export function readCliContextWindows(): Record<string, number> | null {
-  let source: string;
+function readCliSource(): string | null {
   try {
     const entry = require.resolve('@lobehub/i18n-cli');
-    source = fs.readFileSync(path.join(path.dirname(entry), 'cli.js'), 'utf-8');
+    return fs.readFileSync(path.join(path.dirname(entry), 'cli.js'), 'utf-8');
   } catch {
     return null;
   }
+}
+
+/**
+ * Whether a CLI bundle both reads the `experimental.jsonMode` config option and
+ * forwards OpenAI's `json_object` response format. Both markers are property
+ * names / wire literals, which minification leaves intact. A version that
+ * renames or drops the option would silently fall back to plain-text mode,
+ * where gpt-5.2's stray-brace output froze every locale from 2026-08-14 — an
+ * ignored config key gives no signal, unlike a rejected response_format.
+ */
+export function cliSourceSupportsJsonMode(source: string): boolean {
+  return source.includes('jsonMode') && source.includes('json_object');
+}
+
+/** jsonMode support of the installed CLI, or `null` when the bundle is unreadable. */
+export function readCliJsonModeSupport(): boolean | null {
+  const source = readCliSource();
+  return source === null ? null : cliSourceSupportsJsonMode(source);
+}
+
+export function readCliContextWindows(): Record<string, number> | null {
+  const source = readCliSource();
+  if (source === null) return null;
 
   // The bundle is minified, so anchor on a stable key rather than a variable
   // name. The table holds only numbers, so the first brace after it closes it.

--- a/site/tests/unit/i18n-translator-model.test.ts
+++ b/site/tests/unit/i18n-translator-model.test.ts
@@ -95,9 +95,27 @@ describe('JSON mode wiring', () => {
     expect(cliSourceSupportsJsonMode('const t = await client.chat.completions.create({messages, model})')).toBe(false);
     // Reading the flag without forwarding it is equally broken.
     expect(cliSourceSupportsJsonMode('this.x=!!this.config?.experimental?.jsonMode')).toBe(false);
+  });
+
+  it('is not satisfied by unwired occurrences of the two markers', () => {
+    // Both strings present but on separate code paths: the flag is read, and
+    // json_object appears somewhere unrelated, with no completions call
+    // forwarding it. Bare-literal matching would wave this through.
     expect(
       cliSourceSupportsJsonMode(
-        'this.x=!!this.config?.experimental?.jsonMode;...this.x&&{response_format:{type:"json_object"}}'
+        'this.x=!!this.config?.experimental?.jsonMode;' +
+          'const docs="response_format : { type : \\"json_object\\" } is unsupported";' +
+          'x'.repeat(3000) +
+          'await client.chat.completions.create({messages, model})'
+      )
+    ).toBe(false);
+  });
+
+  it('accepts the real wiring shape', () => {
+    expect(
+      cliSourceSupportsJsonMode(
+        'this.x=!!this.config?.experimental?.jsonMode;' +
+          'await this.client.chat.completions.create({messages:o,model:m,...this.x&&{response_format:{type:"json_object"}}})'
       )
     ).toBe(true);
   });

--- a/site/tests/unit/i18n-translator-model.test.ts
+++ b/site/tests/unit/i18n-translator-model.test.ts
@@ -11,6 +11,8 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import {
   readCliContextWindows,
+  readCliJsonModeSupport,
+  cliSourceSupportsJsonMode,
   effectiveSplitToken,
 } from '../../scripts/i18n/cli-context-windows';
 
@@ -18,7 +20,11 @@ const require = createRequire(import.meta.url);
 const CONFIG_PATH = path.join(process.cwd(), '.i18nrc.cjs');
 
 /** The committed config, read with any local env override removed. */
-function committedConfig(): { modelName: string; splitToken: number } {
+function committedConfig(): {
+  modelName: string;
+  splitToken: number;
+  experimental?: { jsonMode?: boolean };
+} {
   const previous = process.env.HUB_I18N_MODEL;
   delete process.env.HUB_I18N_MODEL;
   try {
@@ -64,5 +70,35 @@ describe('translator model', () => {
     const limit = effectiveSplitToken(undefined, 8000, 6000);
     expect(Number.isNaN(limit)).toBe(true);
     expect(100 <= limit).toBe(false);
+  });
+});
+
+describe('JSON mode wiring', () => {
+  it('is set in the committed config', () => {
+    // Without response_format json_object, gpt-5.2 appends a stray closing
+    // brace that lobe rejects, which froze every locale from 2026-08-14 on.
+    expect(committedConfig().experimental?.jsonMode).toBe(true);
+  });
+
+  it('is still honoured by the installed CLI', () => {
+    expect(
+      readCliJsonModeSupport(),
+      'The installed @lobehub/i18n-cli no longer reads experimental.jsonMode or sends ' +
+        'json_object. Translation would silently run in plain-text mode, where gpt-5.2 ' +
+        'output is unparseable. Pin back or re-wire JSON mode before translating.'
+    ).toBe(true);
+  });
+
+  it('detects a bundle that dropped the option', () => {
+    // The silent-regression shape the assertion exists for: a CLI that neither
+    // reads the flag nor sends the response format must fail the check.
+    expect(cliSourceSupportsJsonMode('const t = await client.chat.completions.create({messages, model})')).toBe(false);
+    // Reading the flag without forwarding it is equally broken.
+    expect(cliSourceSupportsJsonMode('this.x=!!this.config?.experimental?.jsonMode')).toBe(false);
+    expect(
+      cliSourceSupportsJsonMode(
+        'this.x=!!this.config?.experimental?.jsonMode;...this.x&&{response_format:{type:"json_object"}}'
+      )
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What was broken

Every `i18n: Update Hub Translations` run with content to translate has failed since 2026-08-14, so no locale (zh included) has received translations for newly published workflows, and the ru/ar retranslation could never start.

Root cause, from the run logs: gpt-5.2 in plain-text mode returns a complete, correct JSON translation and then appends one stray trailing `}` (the content is full of `{{PTnn}}` placeholder braces, which likely throws off its brace counting). `JSON.parse` and lobe's dirty-json fallback both reject that byte, lobe discards the whole chunk and aborts the locale, enforce sees "0 entries", the run fails, and the success-gated publish step throws the night's spend away. Deterministic, every night. The failing payload from run 32145071626 parses cleanly up to its final character.

## The fix, three commits

1. **Force OpenAI JSON mode** (`site/.i18nrc.cjs`): lobe's `experimental.jsonMode` makes it send `response_format: {type: "json_object"}`, so the API itself guarantees syntactically valid output. The stray brace becomes impossible at the protocol level rather than merely unlikely. (The reference prompt already contains the word "JSON", which json_object requires; a model that rejected the flag would fail loudly with a 400.)

2. **Save partial progress on failure** (workflow): a failed night now commits its translation output to the same stable automation branch the existing restore step already reads, so a genuinely rate-limited backfill night accumulates instead of discarding. Guards: staged files that don't parse as JSON are excluded (a truncated mid-write file must not poison the branch), nothing-to-save exits clean, an unchanged rerun never force-pushes, and the failure path never creates a PR. Merging stays gated exactly as before: the automation PR's own Validate Translations check is red on a partial head.

3. **Retry the partial-progress push**: the first live exercise of the save path lost its commit to a GitHub-side HTTP 500 on push. Three attempts with backoff.

## How it was tested

- Local scratch-repo simulation of the save step, five cases: first save creates the branch; corrupt JSON is excluded while valid progress commits; an early failure saves nothing; an identical rerun no-ops; a second night accumulates a new locale on top of restored progress.
- Live end-to-end on a throwaway branch (stable branch renamed so the real one is untouched, a test-only step forces "progress then failure"): run [32225067559](https://github.com/Comfy-Org/workflow_templates/actions/runs/32225067559) proved the failure path fires and exposed the HTTP 500 (hence commit 3); run [32227947002](https://github.com/Comfy-Org/workflow_templates/actions/runs/32227947002) then saved and pushed the branch successfully, and, with JSON mode active, **gpt-5.2 translated 190k tokens of real zh backlog with zero parse failures**, the first successful gpt-5.2 translation in this pipeline. The throwaway branches will be deleted after review.
- `pnpm run lint`, `pnpm run check`, `npx vitest run` (590/590) all green on the branch.

## After merge

Dispatch `locale: ru`, then `locale: ar`; each run now either finishes or banks its progress, so the backfill converges over a small number of runs. ru/ar remain non-indexable regardless; this only restores the machine layer.
