### PR TITLE
fix(i18n): stop the automation branch reverting human-authored sources

### DIFF
--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -84,7 +84,19 @@ jobs:
           # have a real base. Absent branch (first run) -> fetch fails, start fresh.
           if git fetch origin "$STABLE_BRANCH:refs/remotes/origin/$STABLE_BRANCH" 2>/dev/null; then
             git checkout "origin/$STABLE_BRANCH" -- site/src/i18n || true
-            echo "Restored partial translations from $STABLE_BRANCH."
+            # The restore shadows EVERY file under site/src/i18n, including the
+            # ones this pipeline does not author. Any key a person adds to the
+            # English UI source (or to the human translation layer) on main after
+            # the automation branch was last updated would otherwise come back
+            # deleted in the next automation PR: that is how the navbar keys were
+            # lost on 2026-08-12, and the API-section strings were about to go the
+            # same way. Take those back from main; the machine layers this
+            # pipeline owns (other locales, verdicts, sign-off records) still
+            # accumulate across runs.
+            git checkout HEAD -- \
+              site/src/i18n/locales/en.json \
+              site/src/i18n/human 2>/dev/null || true
+            echo "Restored partial translations from $STABLE_BRANCH (human-authored sources kept from main)."
           else
             echo "No automation branch yet; starting fresh from main."
           fi

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -84,15 +84,18 @@ jobs:
           # have a real base. Absent branch (first run) -> fetch fails, start fresh.
           if git fetch origin "$STABLE_BRANCH:refs/remotes/origin/$STABLE_BRANCH" 2>/dev/null; then
             git checkout "origin/$STABLE_BRANCH" -- site/src/i18n || true
-            # The restore above shadows every file under site/src/i18n, including
-            # the human-authored ones this pipeline does not write, so a key added
-            # to the English UI source since the branch last updated comes back
-            # deleted (it took the navbar keys on 2026-08-12). Take those paths
-            # back from the checkout; restore rather than checkout so a file
-            # deleted on main cannot be resurrected from the branch, and unguarded
-            # so this can never silently no-op.
+            # The restore above shadows every file under site/src/i18n with the
+            # branch's older copy, so an edit landed on main since the branch was
+            # last updated comes back as a deletion (it took the navbar keys on
+            # 2026-08-12). Take the layers a person edits back from the checkout:
+            # the UI source nothing regenerates, the override layer nothing here
+            # writes, and the sign-off records, whose missing entries this pipeline
+            # would otherwise re-stamp as machine-authored. restore, not checkout,
+            # so a file deleted on main cannot be resurrected from the branch.
             git restore --source=HEAD --staged --worktree -- \
               site/src/i18n/locales/en.json \
+              site/src/i18n/overrides \
+              site/src/i18n/reviews \
               site/src/i18n/human
             echo "Restored partial translations from $STABLE_BRANCH (human-authored sources kept from the checkout)."
           else

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -84,19 +84,17 @@ jobs:
           # have a real base. Absent branch (first run) -> fetch fails, start fresh.
           if git fetch origin "$STABLE_BRANCH:refs/remotes/origin/$STABLE_BRANCH" 2>/dev/null; then
             git checkout "origin/$STABLE_BRANCH" -- site/src/i18n || true
-            # The restore shadows EVERY file under site/src/i18n, including the
-            # ones this pipeline does not author. Any key a person adds to the
-            # English UI source (or to the human translation layer) on main after
-            # the automation branch was last updated would otherwise come back
-            # deleted in the next automation PR: that is how the navbar keys were
-            # lost on 2026-08-12, and the API-section strings were about to go the
-            # same way. Take those back from main; the machine layers this
-            # pipeline owns (other locales, verdicts, sign-off records) still
-            # accumulate across runs.
-            git checkout HEAD -- \
+            # The restore above shadows every file under site/src/i18n, including
+            # the human-authored ones this pipeline does not write, so a key added
+            # to the English UI source since the branch last updated comes back
+            # deleted (it took the navbar keys on 2026-08-12). Take those paths
+            # back from the checkout; restore rather than checkout so a file
+            # deleted on main cannot be resurrected from the branch, and unguarded
+            # so this can never silently no-op.
+            git restore --source=HEAD --staged --worktree -- \
               site/src/i18n/locales/en.json \
-              site/src/i18n/human 2>/dev/null || true
-            echo "Restored partial translations from $STABLE_BRANCH (human-authored sources kept from main)."
+              site/src/i18n/human
+            echo "Restored partial translations from $STABLE_BRANCH (human-authored sources kept from the checkout)."
           else
             echo "No automation branch yet; starting fresh from main."
           fi


### PR DESCRIPTION
## The bug, live right now

The open automation PR proposes to **delete all 13 `template.api.*` strings** from `site/src/i18n/locales/en.json` — the UI labels for the API section that merged today. Same mechanism took the navbar keys on 2026-08-12; the branch was patched then, the pipeline was not.

## Cause

"Restore partial progress from automation branch" does:

```
git checkout "origin/$STABLE_BRANCH" -- site/src/i18n
```

That shadows **every** file under `site/src/i18n` with the automation branch's copy, including the layers a person edits. Anything landed on main after the branch last updated comes back as a deletion in the next automation PR, and the branch is force-pushed nightly, so it persists until someone notices.

## Fix

After the restore, take the person-edited layers back from the checkout:

- `locales/en.json` — load-bearing. Nothing regenerates it; `.i18nrc.ui.cjs` reads it as its entry and only ever writes the other locales.
- `overrides/` — load-bearing. Hand-authored (native-review corrections), highest precedence in the resolver, never written here.
- `reviews/` — written here, but entries missing from a stale copy get re-stamped as machine-authored, silently downgrading a human wave's provenance.
- `human/` — belt-and-braces. `build-content-source` rewrites it from the templates index on the very next step; kept for a run that fails before that.

`git restore` rather than `git checkout`, so a file deleted on main cannot be resurrected from the branch, and unguarded so the protection cannot silently no-op. The machine layers (other locales' content and UI strings, verdicts) still accumulate across runs, so rate-limited progress is unaffected.

## Verification

Scratch-repo repro, both directions: a key added to `en.json` on main and an edit to `overrides/zh.json` are both reverted by the current restore and both survive with this change, while a stale file the branch resurrects is correctly removed and the machine layer still restores.

After this merges, re-running the workflow rebuilds the automation branch on current main, which clears the conflict on the open translation PR.
