### PR TITLE
fix(i18n): stop the footer offering languages that 404

### DIFF
--- a/site/src/components/hub/SiteFooter.astro
+++ b/site/src/components/hub/SiteFooter.astro
@@ -3,39 +3,22 @@
  * SiteFooter - Blue footer matching the Figma design
  * Blue background, Comfy logo, social icons, 4-column link grid
  */
-import { LANGUAGES, DEFAULT_LOCALE, type Locale } from '../../i18n/config';
-import { getLocaleFromPath, localizeUrl } from '../../i18n/utils';
-import { INDEXABLE_LOCALES } from '../../lib/i18n/locales';
+import { footerLanguageLinks } from '../../lib/i18n/footer-languages';
 
-// Language switcher. Self-derives from the current URL so no caller
-// has to thread props: the current locale is the path's locale prefix, and the
-// un-prefixed base path is what every alternate URL is rebuilt from.
-const currentLocale = getLocaleFromPath(Astro.url.pathname);
-const strippedPath =
-  currentLocale === DEFAULT_LOCALE
-    ? Astro.url.pathname
-    : Astro.url.pathname.replace(new RegExp(`^/${currentLocale}`), '') || '/';
-const basePath = strippedPath.startsWith('/') ? strippedPath : `/${strippedPath}`;
+interface Props {
+  /**
+   * Whether localized variants of this route exist, mirroring the declaration
+   * the page already makes to HreflangTags. When false the switcher is not
+   * rendered, so an English-only route cannot offer a link to a 404.
+   */
+  localized?: boolean;
+}
 
-// Predicate-gated links: only offer languages whose pages are actually live.
-// INDEXABLE_LOCALES is the language-level rollout gate and is empty until a
-// language passes native review, so today this renders nothing and the footer
-// stays byte-identical. English is always offered as the return path. Per-page
-// refinement (a workflow untranslated in an otherwise-live locale) is handled by
-// the indexability predicate.
-const offeredLocales: Locale[] = [
-  DEFAULT_LOCALE,
-  ...INDEXABLE_LOCALES.filter((l) => l !== DEFAULT_LOCALE),
-];
-const languageLinks =
-  offeredLocales.length > 1
-    ? offeredLocales.map((locale) => ({
-        locale,
-        nativeName: LANGUAGES[locale].nativeName,
-        url: localizeUrl(basePath, locale),
-        isCurrent: locale === currentLocale,
-      }))
-    : [];
+const { localized = true } = Astro.props;
+
+// The current locale and every alternate URL derive from the path, so no caller
+// has to thread them; only the existence of localized variants is a page fact.
+const languageLinks = footerLanguageLinks(Astro.url.pathname, { localized });
 ---
 
 <footer class="bg-page text-content">

--- a/site/src/components/workflow-pages/SeoIndexPage.astro
+++ b/site/src/components/workflow-pages/SeoIndexPage.astro
@@ -74,6 +74,6 @@ const breadcrumbStructuredData = buildWorkflowBreadcrumb(locale, { name: heading
   />
 
   <Fragment slot="footer">
-    <SiteFooter />
+    <SiteFooter localized={false} />
   </Fragment>
 </BaseLayout>

--- a/site/src/lib/i18n/footer-languages.ts
+++ b/site/src/lib/i18n/footer-languages.ts
@@ -1,0 +1,56 @@
+/**
+ * The footer language switcher's links.
+ *
+ * Separate from the component so the one rule that matters is testable: the
+ * switcher must never offer a language whose page does not exist. Routes with no
+ * localized variant (the use-case pages, the model and use-case index pages) say
+ * so with `localized: false`, the same declaration they already make to
+ * HreflangTags, and get no switcher at all rather than a link to a 404.
+ */
+import { LANGUAGES, DEFAULT_LOCALE, type Locale } from '../../i18n/config';
+import { getLocaleFromPath, localizeUrl } from '../../i18n/utils';
+import { INDEXABLE_LOCALES } from './locales';
+
+export interface FooterLanguageLink {
+  locale: Locale;
+  nativeName: string;
+  url: string;
+  isCurrent: boolean;
+}
+
+/** The current path with any locale prefix removed, always leading-slashed. */
+export function unprefixedPath(pathname: string, currentLocale: Locale): string {
+  const stripped =
+    currentLocale === DEFAULT_LOCALE
+      ? pathname
+      : pathname.replace(new RegExp(`^/${currentLocale}`), '') || '/';
+  return stripped.startsWith('/') ? stripped : `/${stripped}`;
+}
+
+/**
+ * Links for the switcher, or an empty list when there is nothing honest to
+ * offer: either no language has been rolled out yet, or this route is
+ * English-only.
+ */
+export function footerLanguageLinks(
+  pathname: string,
+  options: { localized?: boolean; indexableLocales?: readonly Locale[] } = {}
+): FooterLanguageLink[] {
+  const { localized = true, indexableLocales = INDEXABLE_LOCALES } = options;
+  if (!localized) return [];
+
+  const currentLocale = getLocaleFromPath(pathname);
+  const basePath = unprefixedPath(pathname, currentLocale);
+  const offeredLocales: Locale[] = [
+    DEFAULT_LOCALE,
+    ...indexableLocales.filter((locale) => locale !== DEFAULT_LOCALE),
+  ];
+  if (offeredLocales.length < 2) return [];
+
+  return offeredLocales.map((locale) => ({
+    locale,
+    nativeName: LANGUAGES[locale].nativeName,
+    url: localizeUrl(basePath, locale),
+    isCurrent: locale === currentLocale,
+  }));
+}

--- a/site/src/pages/workflows/use-cases/[slug].astro
+++ b/site/src/pages/workflows/use-cases/[slug].astro
@@ -289,6 +289,6 @@ const relatedCards = resolveRailImages(
   }
 
   <Fragment slot="footer">
-    <SiteFooter />
+    <SiteFooter localized={false} />
   </Fragment>
 </BaseLayout>

--- a/site/tests/unit/i18n-footer-languages.test.ts
+++ b/site/tests/unit/i18n-footer-languages.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The footer switcher must never link a page that does not exist.
+ *
+ * Flipping zh to indexable made the switcher render on every hub page, including
+ * the routes that have no localized variant, so the use-case pages and the two
+ * index pages offered 中文 links to 404s in production. These lock the rule that
+ * an English-only route gets no switcher.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { footerLanguageLinks, unprefixedPath } from '../../src/lib/i18n/footer-languages';
+
+const ZH_ONLY = ['zh'] as const;
+
+describe('footerLanguageLinks', () => {
+  it('offers the rolled-out languages on a localized route', () => {
+    const links = footerLanguageLinks('/workflows/', { indexableLocales: ZH_ONLY });
+
+    expect(links.map((l) => l.locale)).toEqual(['en', 'zh']);
+    expect(links.map((l) => l.url)).toEqual(['/workflows/', '/zh/workflows/']);
+    expect(links.find((l) => l.locale === 'en')?.isCurrent).toBe(true);
+  });
+
+  it('marks the current language when already on a localized page', () => {
+    const links = footerLanguageLinks('/zh/workflows/', { indexableLocales: ZH_ONLY });
+
+    expect(links.find((l) => l.locale === 'zh')?.isCurrent).toBe(true);
+    expect(links.find((l) => l.locale === 'en')?.url).toBe('/workflows/');
+  });
+
+  it('offers nothing on a route with no localized variant', () => {
+    // The regression: these paths render the footer but have no [locale] route.
+    for (const pathname of [
+      '/workflows/use-cases/',
+      '/workflows/use-cases/ai-headshot-generator/',
+      '/workflows/model/',
+    ]) {
+      expect(
+        footerLanguageLinks(pathname, { localized: false, indexableLocales: ZH_ONLY }),
+        pathname
+      ).toEqual([]);
+    }
+  });
+
+  it('offers nothing before any language is rolled out', () => {
+    expect(footerLanguageLinks('/workflows/', { indexableLocales: [] })).toEqual([]);
+  });
+
+  it('rebuilds alternates from the un-prefixed path', () => {
+    expect(unprefixedPath('/zh/workflows/tag/character/', 'zh')).toBe('/workflows/tag/character/');
+    expect(unprefixedPath('/workflows/', 'en')).toBe('/workflows/');
+    expect(unprefixedPath('/zh', 'zh')).toBe('/');
+  });
+});
+
+/**
+ * A guard against forgetting: a route that tells HreflangTags it has no
+ * localized variants must not then let the footer advertise them. Keyed off the
+ * existing declaration so the two can never drift apart.
+ */
+describe('English-only routes', () => {
+  const SRC = path.join(process.cwd(), 'src');
+
+  function astroFilesIn(dir: string): string[] {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return astroFilesIn(full);
+      return entry.name.endsWith('.astro') ? [full] : [];
+    });
+  }
+
+  const declaringFiles = astroFilesIn(SRC)
+    .map((file) => ({ file: path.relative(SRC, file), source: fs.readFileSync(file, 'utf-8') }))
+    .filter(({ source }) => source.includes('hreflangLocalized={false}'));
+
+  it('finds the routes it is meant to be checking', () => {
+    // Without this the suite passes vacuously if the prop is ever renamed.
+    expect(declaringFiles.length).toBeGreaterThan(0);
+  });
+
+  it('never render a language switcher', () => {
+    for (const { file, source } of declaringFiles) {
+      if (!source.includes('<SiteFooter')) continue;
+      expect(source, `${file} renders SiteFooter without localized={false}`).toMatch(
+        /<SiteFooter[^>]*localized={false}/
+      );
+    }
+  });
+});


### PR DESCRIPTION
## The bug, live in production

Every English use-case page, the use-cases index and the model index offer a 中文 link in the footer that returns **404**:

```
curl -sL https://comfy.org/workflows/use-cases/ai-headshot-generator/ | grep -o 'href="/zh/workflows/use-cases/[^"]*"'
  href="/zh/workflows/use-cases/ai-headshot-generator/"
curl -s -o /dev/null -w "%{http_code}" https://comfy.org/zh/workflows/use-cases/ai-headshot-generator/
  404
```

Introduced by flipping zh to indexable. The switcher renders once a language is rolled out and rebuilds the current path under each locale, but those routes have no `[locale]` variant, so the rebuilt URL points at nothing. 19 pages today (17 use-case pages + 2 index pages).

`/workflows/category/video/` has the same symptom from a different cause and is fixed in #1164.

## The fix

The routes already declare this fact to `HreflangTags` as `hreflangLocalized={false}`, a prop that exists so we "never advertise per-locale URLs that would 404". The footer now takes the same declaration and renders no switcher when there is no localized variant.

Link building moves into `footer-languages.ts` so the rule is testable, and a guard test keys off the existing `hreflangLocalized={false}` declaration: a route that makes it must not render a switcher. That is what stops this reopening when someone adds the next English-only page.

## Verified against a real build

| page | before | after |
| --- | --- | --- |
| `/workflows/use-cases/` | 1 zh link (404) | 0 |
| `/workflows/use-cases/ai-headshot-generator/` | 1 zh link (404) | 0 |
| `/workflows/model/` | 1 zh link (404) | 0 |
| `/workflows/` | 1 zh link (200) | 1 |
| `/workflows/tag/character/` | 1 zh link (200) | 1 |
| `/workflows/model/wan/` | 1 zh link (200) | 1 |
| `/workflows/creators/` | 1 zh link (200) | 1 |

`pnpm run lint`, `pnpm run check` (0 errors), `npx vitest run` (626 passing, +7 new). The guard test was confirmed failing before the fix.

## Not in scope

Building the localized use-case routes. Those pages carry 142 KB of English editorial copy that no pipeline translates today (the i18n content pipeline covers hub workflow entries only, keyed by shareId), so a `[locale]` route would publish English body text under indexable Chinese URLs. Suppressing the dead links is the correct first step; the routes come when there is Chinese copy to put in them.
