### PR TITLE
feat(i18n): apply the French native review to the ACE Step use cases

### DIFF
--- a/site/src/i18n/overrides/fr.json
+++ b/site/src/i18n/overrides/fr.json
@@ -1,0 +1,11 @@
+{
+  "4f8b62bfd681": {
+    "suggestedUseCases": [
+      "Transformer une chanson pop en version jazz en modifiant son style.",
+      "Actualiser d’anciens morceaux avec des paroles modernes pour leur donner un nouveau souffle.",
+      "Créer des versions instrumentales de chansons en ajustant le volume des voix.",
+      "Expérimenter la production musicale en gérant différents genres.",
+      "Personnaliser des pistes musicales pour des projets vidéo ou cinématographiques."
+    ]
+  }
+}

--- a/site/tests/unit/i18n-fr-native-review.test.ts
+++ b/site/tests/unit/i18n-fr-native-review.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The French native review, encoded so the correction cannot silently regress.
+ *
+ * Unlike Turkish, this one IS applicable as a content override: the reviewer
+ * covered all five elements of one field, so the array can be rebuilt whole,
+ * which is what an override has to supply. The field is currently absent from
+ * the French machine layer (pruned for the finding below) and renders English.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { collectViolations } from '../../scripts/i18n/validate-translations';
+import type { WorkflowContent } from '../../src/lib/i18n/schema';
+
+const SHARE_ID = '4f8b62bfd681'; // ACE Step v1 M2M Editing, a music workflow
+
+const overrides = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), 'src', 'i18n', 'overrides', 'fr.json'), 'utf-8')
+) as Record<string, Partial<WorkflowContent>>;
+
+const english = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), 'src', 'i18n', 'content', 'en.json'), 'utf-8')
+) as Record<string, WorkflowContent>;
+
+describe('French override for the ACE Step use cases', () => {
+  it('replaces the whole field, which is what the resolver serves', () => {
+    // A partial array would render a French list with English holes.
+    const cases = overrides[SHARE_ID]?.suggestedUseCases;
+    expect(cases).toHaveLength(english[SHARE_ID].suggestedUseCases.length);
+  });
+
+  it('is about music, not 3D', () => {
+    // The finding: the machine layer had pasted 3D-modelling copy into a music
+    // workflow's use cases. Every element the reviewer approved is on-topic.
+    const cases = overrides[SHARE_ID]!.suggestedUseCases as string[];
+    expect(cases.some((c) => /3D|modélisation/i.test(c))).toBe(false);
+    expect(cases.filter((c) => /musi|chanson|morceaux|pistes|jazz/i.test(c))).toHaveLength(
+      cases.length
+    );
+  });
+
+  it('passes the validator against its English source', () => {
+    const violations = collectViolations(
+      SHARE_ID,
+      'fr',
+      english[SHARE_ID],
+      { suggestedUseCases: overrides[SHARE_ID]!.suggestedUseCases },
+      [],
+      {}
+    );
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
Second native review folded back in. French, 5 rows reviewed, all on one field of one workflow.

## What the reviewer found

The machine layer had pasted **3D-modelling copy into a music workflow's suggested use cases** — all five elements were about 3D assets, product visualisation and modelling tutorials, on a workflow for editing songs. Not a wording problem; the content was from somewhere else entirely.

The AI review caught every one as `critical / accuracy`, so `enforce` pruned the field. `/fr/workflows/…-4f8b62bfd681/` renders the English use cases today.

## Why this one is a content override

Unlike the Turkish review (#1168), where every reviewed field was pruned and only glossary terms survive a retranslation, here the reviewer covered **all five elements of the array**, so it can be rebuilt whole — which is exactly what an override has to supply. A partial array would render a French list with English holes.

Three elements take the AI's suggested wording (verdict `Fix OK`), two take the reviewer's own (`New wording`). One judgement call, flagged: their second suggestion reads "pour **leu** donner un nouveau souffle", a typo for "leur", and I corrected it rather than publish the typo.

## Tests

`i18n-fr-native-review.test.ts`: the override covers the full array length taken from the English source, every element is on-topic for music with no 3D vocabulary left, and the result passes the validator against its English source.

Gate: eslint clean, `astro check` 0 errors, vitest 622 passing.

Related: #1168 does the same for Turkish, via the glossary rather than content.
