### PR TITLE
feat(i18n): allow a first sign-off wave by policy, defaulted off

### DIFF
--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -78,16 +78,37 @@ function isNonEmpty(value: unknown): boolean {
  * Refresh one locale's records in place. Pure apart from reading and writing
  * under `contentRoot`, so tests run it against a fixture tree.
  */
+/**
+ * Locales the pipeline may grant a FIRST sign-off to, rather than only
+ * maintaining an existing human wave.
+ *
+ * Empty by default, so a locale still waits for its native reviewer exactly as
+ * before. Listing a locale here says the team has decided that AI-review-clean
+ * text is enough to index it, and that corrections will land afterwards as
+ * overrides instead of gating the ranking. It does NOT weaken the other half of
+ * the gate: a page whose required fields are not genuinely translated stays
+ * non-indexable either way, because the predicate checks that separately.
+ */
+export function bootstrapLocales(raw: string | undefined = process.env.I18N_BOOTSTRAP_LOCALES): Set<string> {
+  return new Set(
+    (raw ?? '')
+      .split(/[,\s]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
+}
+
 export function refreshSignoffRecords(
   locale: Locale,
   contentRoot: string,
-  today: string = new Date().toISOString().slice(0, 10)
+  today: string = new Date().toISOString().slice(0, 10),
+  mayBootstrap: boolean = bootstrapLocales().has(locale)
 ): RefreshSummary | null {
   const reviewsPath = path.join(contentRoot, 'reviews', `${locale}.json`);
-  const reviews = readJson<LocaleReviews>(reviewsPath);
-  // No first wave, nothing to maintain. Never bootstrap a locale here: granting
-  // the first sign-off is the native reviewer's act, not the pipeline's.
-  if (!reviews || Object.keys(reviews).length === 0) return null;
+  const reviews = readJson<LocaleReviews>(reviewsPath) ?? (mayBootstrap ? {} : null);
+  // Nothing to maintain and no permission to start a wave. Granting the first
+  // sign-off is the native reviewer's act unless the locale is listed above.
+  if (!reviews || (Object.keys(reviews).length === 0 && !mayBootstrap)) return null;
 
   // Fail closed on unreadable inputs. A read/parse failure must never look like
   // an empty catalog: that would make the cleanup below "drop" every record and
@@ -160,7 +181,11 @@ export function refreshSignoffRecords(
   const baseScope = (scope: string | undefined): string =>
     (scope ?? '').split(/(?:^|;\s*)auto-(?:refresh|sealed)\b/)[0].trim();
   const records = Object.values(reviews);
-  const waveReviewer = mode(records.map((r) => r.reviewer)) || 'unknown';
+  // A bootstrapped locale has no wave to inherit a name from, and 'unknown'
+  // would read as "somebody signed this off and we lost track of who". Name the
+  // pipeline instead, so the audit trail says plainly that no human read it.
+  const waveReviewer =
+    mode(records.map((r) => r.reviewer)) || (mayBootstrap ? 'ai-review' : 'unknown');
   const waveScope = mode(records.map((r) => baseScope(r.approvedScope)).filter(Boolean));
   const withWaveScope = (marker: string, base: string = waveScope): string =>
     base ? `${base}; ${marker}` : marker;
@@ -258,7 +283,9 @@ export function refreshSignoffRecords(
         reviewedArtifactChecksum: currentChecksum,
         automated: true,
         approvedScope: withWaveScope(
-          `auto-sealed ${today}: published after the last wave, AI-review clean`
+          records.length === 0
+            ? `auto-sealed ${today}: first wave granted by policy, AI-review clean, no human pass`
+            : `auto-sealed ${today}: published after the last wave, AI-review clean`
         ),
       };
       summary.sealedNew.push(sid);

--- a/site/scripts/i18n/refresh-signoff.ts
+++ b/site/scripts/i18n/refresh-signoff.ts
@@ -44,6 +44,12 @@ import {
   type WorkflowContent,
 } from '../../src/lib/i18n/schema';
 
+/**
+ * Written when a wave has no reviewer name to inherit. It is a sentinel, not a
+ * name, so it must never be treated as one when picking the wave's reviewer.
+ */
+const UNKNOWN_REVIEWER = 'unknown';
+
 interface Verdicts {
   entries?: Record<string, { findings?: { field?: string; severity?: string }[] }>;
 }
@@ -105,7 +111,19 @@ export function refreshSignoffRecords(
   mayBootstrap: boolean = bootstrapLocales().has(locale)
 ): RefreshSummary | null {
   const reviewsPath = path.join(contentRoot, 'reviews', `${locale}.json`);
-  const reviews = readJson<LocaleReviews>(reviewsPath) ?? (mayBootstrap ? {} : null);
+  const storedReviews = readJson<LocaleReviews>(reviewsPath);
+  // A missing file and an unreadable one both read as null, but they mean
+  // opposite things here. Bootstrapping may start from no file; starting from a
+  // file it could not parse would rewrite the locale from `{}` and take every
+  // persisted sign-off with it.
+  if (!storedReviews && mayBootstrap && fs.existsSync(reviewsPath)) {
+    console.error(
+      `[i18n] signoff-refresh: [${locale}] reviews/${locale}.json exists but could not be ` +
+        `read; refusing to bootstrap over it.`
+    );
+    return null;
+  }
+  const reviews = storedReviews ?? (mayBootstrap ? {} : null);
   // Nothing to maintain and no permission to start a wave. Granting the first
   // sign-off is the native reviewer's act unless the locale is listed above.
   if (!reviews || (Object.keys(reviews).length === 0 && !mayBootstrap)) return null;
@@ -184,8 +202,13 @@ export function refreshSignoffRecords(
   // A bootstrapped locale has no wave to inherit a name from, and 'unknown'
   // would read as "somebody signed this off and we lost track of who". Name the
   // pipeline instead, so the audit trail says plainly that no human read it.
+  // 'unknown' is this function's own "no name available" sentinel, so letting it
+  // win the mode would make it masquerade as an inherited reviewer and skip the
+  // fallback below — a bootstrapped record would then claim a human wave that
+  // never happened. Filtered out so it can only ever be the fallback's answer.
   const waveReviewer =
-    mode(records.map((r) => r.reviewer)) || (mayBootstrap ? 'ai-review' : 'unknown');
+    mode(records.map((r) => r.reviewer).filter((name) => name && name !== UNKNOWN_REVIEWER)) ||
+    (mayBootstrap ? 'ai-review' : UNKNOWN_REVIEWER);
   const waveScope = mode(records.map((r) => baseScope(r.approvedScope)).filter(Boolean));
   const withWaveScope = (marker: string, base: string = waveScope): string =>
     base ? `${base}; ${marker}` : marker;

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { refreshSignoffRecords } from '../../scripts/i18n/refresh-signoff';
+import { bootstrapLocales, refreshSignoffRecords } from '../../scripts/i18n/refresh-signoff';
 import { __resetResolverCache, hashResolvedArtifact, resolveLocalizedWorkflow } from '../../src/lib/i18n/resolver';
 import type { Locale } from '../../src/lib/i18n/schema';
 
@@ -84,6 +84,43 @@ describe('refreshSignoffRecords', () => {
     // and an absent file is the same case, not a crash
     fs.rmSync(path.join(root, 'reviews', 'zh.json'));
     expect(run()).toBeNull();
+  });
+
+  it('grants a first wave only when the locale is listed in the policy', () => {
+    // The decoupling switch: a locale opted in gets its first sign-off from the
+    // pipeline, so indexing no longer waits on a native reviewer. Everything
+    // else about the bar is unchanged, and the default is still to refuse.
+    write('reviews/zh.json', {});
+    expect(refreshSignoffRecords('zh' as Locale, root, TODAY, false)).toBeNull();
+
+    __resetResolverCache();
+    const summary = refreshSignoffRecords('zh' as Locale, root, TODAY, true)!;
+    expect(summary.sealedNew).toEqual([A]);
+    const record = readReviews()[A];
+    // Honest attribution: no human read this, and the record says so rather
+    // than inheriting a reviewer name or reading as 'unknown'.
+    expect(record.reviewer).toBe('ai-review');
+    expect(record.automated).toBe(true);
+    expect(record.approvedScope).toContain('first wave granted by policy');
+    expect(record.approvedScope).toContain('no human pass');
+  });
+
+  it('still refuses untranslated pages when bootstrapping', () => {
+    // The other half of the gate is untouched: policy decides who may seal
+    // AI-clean text, never whether English fallback counts as translated.
+    write('content/zh.json', { [A]: { title: '标题' } }); // description missing
+    write('reviews/zh.json', {});
+
+    const summary = refreshSignoffRecords('zh' as Locale, root, TODAY, true)!;
+
+    expect(summary.sealedNew).toEqual([]);
+    expect(summary.refusedUntranslated).toEqual([A]);
+  });
+
+  it('reads the opted-in locales from the environment', () => {
+    expect([...bootstrapLocales('tr, fr')]).toEqual(['tr', 'fr']);
+    expect([...bootstrapLocales('')]).toEqual([]);
+    expect([...bootstrapLocales(undefined)]).toEqual([]);
   });
 
   it('leaves a record alone while its seal still matches', () => {

--- a/site/tests/unit/i18n-refresh-signoff.test.ts
+++ b/site/tests/unit/i18n-refresh-signoff.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -117,10 +117,54 @@ describe('refreshSignoffRecords', () => {
     expect(summary.refusedUntranslated).toEqual([A]);
   });
 
-  it('reads the opted-in locales from the environment', () => {
+  it('refuses to bootstrap over an unreadable reviews file', () => {
+    // A parse failure and a missing file both read as null. Treating the first
+    // as an empty catalog would rewrite the locale from {} and take every
+    // persisted sign-off with it.
+    write('reviews/zh.json', {}); // creates the directory
+    fs.writeFileSync(path.join(root, 'reviews', 'zh.json'), '{ this is not json');
+
+    __resetResolverCache();
+    expect(refreshSignoffRecords('zh' as Locale, root, TODAY, true)).toBeNull();
+    // Still on disk, untouched.
+    expect(fs.readFileSync(path.join(root, 'reviews', 'zh.json'), 'utf-8')).toBe(
+      '{ this is not json'
+    );
+  });
+
+  it('does not inherit the unknown sentinel as a bootstrap reviewer', () => {
+    // 'unknown' is written when no name was available. If it wins the mode it
+    // skips the fallback, and the record claims a human wave that never ran.
+    write('reviews/zh.json', {
+      other: { ...staleRecord, reviewer: 'unknown' },
+    });
+    write('content/en.json', { [A]: english, other: english });
+    write('content/zh.json', {
+      [A]: { title: '标题', description: '描述' },
+      other: { title: '标题', description: '描述' },
+    });
+    write('manifest.json', { [A]: { content: 'h-current' }, other: { content: 'h-current' } });
+
+    __resetResolverCache();
+    refreshSignoffRecords('zh' as Locale, root, TODAY, true);
+
+    expect(readReviews()[A].reviewer).toBe('ai-review');
+  });
+
+  it('parses an explicit opt-in list', () => {
     expect([...bootstrapLocales('tr, fr')]).toEqual(['tr', 'fr']);
     expect([...bootstrapLocales('')]).toEqual([]);
+  });
+
+  it('falls back to the environment when given no value', () => {
+    // Stubbed in BOTH directions rather than asserting [] on the ambient value:
+    // a developer or a CI job with I18N_BOOTSTRAP_LOCALES set would otherwise
+    // fail a test that has nothing to do with their change.
+    vi.stubEnv('I18N_BOOTSTRAP_LOCALES', 'ru');
+    expect([...bootstrapLocales(undefined)]).toEqual(['ru']);
+    vi.stubEnv('I18N_BOOTSTRAP_LOCALES', '');
     expect([...bootstrapLocales(undefined)]).toEqual([]);
+    vi.unstubAllEnvs();
   });
 
   it('leaves a record alone while its seal still matches', () => {


### PR DESCRIPTION
Builds the switch for the "decouple review from indexation" discussion, so the decision can ship the day it is made. **Behaviour is unchanged until someone sets the variable.**

## Why

Indexing a language waits for a native reviewer to grant its first sign-off. The reviewer sheets now argue that the wait buys less than assumed:

- Every row in every sheet is text carrying a critical or major finding, which is exactly what `enforce` prunes. **None of it was ever going to be published.**
- Where reviewers have engaged, they agree with the AI's fixes: Turkish covered all 12 critical rows plus 30 majors and agreed on 41 of 42; French approved all 5 of its critical fixes.

So the human pass is currently validating the pruning layer, not the text we index.

## What this changes

`I18N_BOOTSTRAP_LOCALES` names the locales the pipeline may grant a *first* sign-off wave to. Unset (the default, and the state this PR merges in) every locale waits for its reviewer exactly as today.

**The other half of the gate is untouched.** A page whose required fields are not genuinely translated stays non-indexable, because the predicate checks translation completeness separately from sign-off. That is the check that stops us publishing English text under a localized URL and asking Google to index it, and no policy setting can switch it off. There is a test for exactly that.

## Honest attribution

A record granted this way carries `reviewer: 'ai-review'`, `automated: true`, and a scope that reads `first wave granted by policy, AI-review clean, no human pass`. Without this it would have inherited `unknown`, which reads as "a human signed this and we lost track of who".

## Tests

Four new cases in `i18n-refresh-signoff.test.ts` (23 total, all passing): refuses to bootstrap by default, seals with honest attribution when opted in, still refuses untranslated pages while bootstrapping, and parses the locale list from the environment.

Gate: eslint clean, `astro check` 0 errors, vitest 622 passing.

## What I would still do before flipping a language on

A 30-row random sample of **unflagged** text per language, half an hour of a native's time. That is the one thing nobody has measured, and it is what the sheets cannot tell us.
