### PR TITLE
perf(hub): give hub videos their poster frames back

### DIFF
--- a/site/src/lib/video-thumbnail.ts
+++ b/site/src/lib/video-thumbnail.ts
@@ -1,18 +1,39 @@
 /**
- * Generates a Cloudflare video frame extraction URL for use as a poster/fallback image.
- * Only works for videos hosted on Cloudflare CDN (engcomfy.com domains).
- * Returns null for local/relative video URLs.
+ * Poster/fallback image for a video, via Cloudflare's frame extraction.
+ *
+ * Only hosts served through Cloudflare Media can do this, so the allowlist is
+ * explicit rather than "anything on our domain": media.comfy.org sits on the
+ * same apex and answers those URLs with a 404, which would put a broken poster
+ * on every marketing video.
  *
  * @param videoUrl - The video URL (full HTTPS or relative path)
- * @param timeSeconds - The time offset in seconds to extract the frame from (default: 1)
- * @returns The Cloudflare frame extraction URL, or null if not applicable
+ * @param timeSeconds - Offset of the frame to extract (default: 1)
+ * @returns The frame URL, or null when the host cannot produce one
  */
-const CLOUDFLARE_CDN_DOMAIN = 'engcomfy.com';
+
+/**
+ * Hosts whose videos support `cdn-cgi/media` frame extraction. `engcomfy.com`
+ * covers the test buckets; `comfy-hub-assets.comfy.org` is where the hub's
+ * production uploads actually live, and it was missing, so every poster on the
+ * live site resolved to null and every video rendered with nothing behind it.
+ */
+const FRAME_EXTRACTION_HOSTS = [
+  'engcomfy.com',
+  'comfy-hub-assets.comfy.org'
+] as const;
+
+function supportsFrameExtraction(hostname: string): boolean {
+  // Suffix-matched rather than substring-matched: `includes` would also accept
+  // engcomfy.com.example.net, which is not ours.
+  return FRAME_EXTRACTION_HOSTS.some(
+    (host) => hostname === host || hostname.endsWith(`.${host}`)
+  );
+}
 
 export function getVideoFrameUrl(videoUrl: string, timeSeconds: number = 1): string | null {
   try {
     const parsed = new URL(videoUrl);
-    if (!parsed.hostname.includes(CLOUDFLARE_CDN_DOMAIN)) return null;
+    if (!supportsFrameExtraction(parsed.hostname)) return null;
     // Insert cdn-cgi/media/mode=frame,time={N}s/ between the origin and the path
     const framePath = `cdn-cgi/media/mode=frame,time=${timeSeconds}s`;
     return `${parsed.origin}/${framePath}${parsed.pathname}`;

--- a/site/tests/unit/video-thumbnail.test.ts
+++ b/site/tests/unit/video-thumbnail.test.ts
@@ -17,6 +17,29 @@ describe('getVideoFrameUrl', () => {
     );
   });
 
+  it('extracts a frame for the production hub asset host', () => {
+    // The bug this fixes: the live hub serves its uploads from
+    // comfy-hub-assets.comfy.org, which was not on the allowlist, so every
+    // poster resolved to null and the carousel rendered bare <video> elements.
+    const url =
+      'https://comfy-hub-assets.comfy.org/uploads/306cccad-6557-40d5-9bea-db46db4ab789.mp4';
+    expect(getVideoFrameUrl(url)).toBe(
+      'https://comfy-hub-assets.comfy.org/cdn-cgi/media/mode=frame,time=1s/uploads/306cccad-6557-40d5-9bea-db46db4ab789.mp4'
+    );
+  });
+
+  it('returns null for media.comfy.org, which answers frame URLs with 404', () => {
+    // Same apex domain, different service: a blanket comfy.org rule would put a
+    // broken poster on every marketing video.
+    expect(getVideoFrameUrl('https://media.comfy.org/website/clip.mp4')).toBeNull();
+  });
+
+  it('matches hosts by suffix, not substring', () => {
+    // `includes('engcomfy.com')` also accepted a lookalike domain.
+    expect(getVideoFrameUrl('https://engcomfy.com.example.net/uploads/v.mp4')).toBeNull();
+    expect(getVideoFrameUrl('https://notcomfy-hub-assets.comfy.org.evil.net/v.mp4')).toBeNull();
+  });
+
   it('returns null for relative paths', () => {
     expect(getVideoFrameUrl('template-name-1.mp4')).toBeNull();
     expect(getVideoFrameUrl('/workflows/thumbnails/video.mp4')).toBeNull();


### PR DESCRIPTION
First item of GTM-265. The hub listing paints a bare autoplaying video as its largest element, so LCP measures how long the video takes to start rather than when something appeared.

## The fix is one line, because the machinery already exists

`FeaturedCarousel.vue` already computes `posterUrl`, already binds `:poster` on the video, already splits `preload` auto/metadata by slide, and already keeps a poster-`<img>` fallback with `fetchpriority="high"` for the first slide. All of that shipped in #1048 back in July.

None of it fires. `getVideoFrameUrl()` returns `null` unless the hostname contains `engcomfy.com`, and the live uploads are served from `comfy-hub-assets.comfy.org`. So the poster is always null and every video renders with nothing behind it — not only in the carousel, but in `HubWorkflowCard`, `SearchPopover` and `ThumbnailDisplay`, which all call the same helper.

I checked before assuming the URL shape works there:

```
https://comfy-hub-assets.comfy.org/cdn-cgi/media/mode=frame,time=1s/uploads/306cccad-....mp4
  -> 200 image/jpeg
```

The host is behind Cloudflare (`server: cloudflare`, `cf-ray` present) and serves real frames.

## Measured against a build

| | live today | this build |
| --- | --- | --- |
| `poster=` attributes on `/workflows/` | **0** | **28** |

A poster URL from the build returns `200 image/jpeg`, 20,185 bytes.

## Why the allowlist stays explicit

`media.comfy.org` is the same apex domain and answers those frame URLs with **404**, so "any comfy.org host" would put a broken poster on every marketing video. Matching is also by suffix now: `includes('engcomfy.com')` accepted `engcomfy.com.example.net`.

## Tests

Three new cases (11 total): the production host produces a frame URL, `media.comfy.org` still returns null, and lookalike domains are rejected. Confirmed failing first — removing the host from the allowlist fails the first of them.

Gate: eslint clean, `astro check` 0 errors, vitest 622 passing.

## Next in GTM-265, not here

With posters existing, `featuredPreloadImage()` can preload one instead of returning null for video-first slates, which is the other half of the LCP work. Worth doing once this lands and the numbers can be compared. Deploys are manual, so this needs a "Deploy Template Site" dispatch before PageSpeed will show anything.
