### PR TITLE
fix(i18n): give the translator and the reviewer the same glossary

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -52,3 +52,5 @@ playwright/.cache/
 
 # Generated glossary mirror (rebuilt from the ComfyUI_frontend locales by pnpm i18n:glossary)
 i18n/glossary/mirror/
+# Selected from the mirror at sync time; regenerated, never hand-edited.
+i18n/glossary/effective/

--- a/site/.i18nrc.cjs
+++ b/site/.i18nrc.cjs
@@ -37,22 +37,21 @@ const ALL_LOCALES = ['zh', 'zh-TW', 'ja', 'ko', 'es', 'fr', 'ru', 'tr', 'ar', 'p
 const singleLocale = process.env.HUB_I18N_LOCALE || null;
 const outputLocales = singleLocale ? [singleLocale] : ALL_LOCALES;
 
-// Cap the bulk-harvested mirror so the prompt stays bounded; curated overrides
-// are always kept in full and win over the mirror. Longest English terms first —
-// they are the most specific and least likely to misfire as substrings.
-const MAX_MIRROR_PAIRS = 200;
-
+// The glossary is selected once by `pnpm i18n:glossary` and written to
+// effective/<locale>.json, which the AI reviewer reads too. Selecting it here as
+// well is what broke the Russian run: this side capped the mirror and the
+// reviewer did not, so the reviewer enforced terms the translator never saw.
+// Falls back to the raw mirror for a local run that has not synced the glossary.
 function terminologyBlock(locale) {
-  const mirror = readJson(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {});
-  const overrides = readJson(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {});
+  const effective = readJson(path.join(GLOSSARY_DIR, 'effective', `${locale}.json`), null);
   const merged = new Map(
-    Object.entries(mirror)
-      .sort((a, b) => b[0].length - a[0].length)
-      .slice(0, MAX_MIRROR_PAIRS)
+    Object.entries(
+      effective ?? {
+        ...readJson(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {}),
+        ...readJson(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {}),
+      }
+    )
   );
-  for (const [en, loc] of Object.entries(overrides)) {
-    if (typeof loc === 'string' && loc.trim()) merged.set(en, loc);
-  }
   if (merged.size === 0) return '';
   const lines = [...merged.entries()].map(([en, loc]) => `- ${en} → ${loc}`).join('\n');
   return `\n\nProduct-UI terminology for this locale — when the English text contains one of these terms, translate it to exactly the paired term so hub content matches the ComfyUI app UI:\n${lines}`;

--- a/site/scripts/i18n/review-translations.ts
+++ b/site/scripts/i18n/review-translations.ts
@@ -134,6 +134,15 @@ export interface EntryVerdict {
 
 export interface ReviewState {
   promptVersion: number;
+  /**
+   * Fingerprint of the glossary the stored verdicts were produced under.
+   *
+   * The glossary is part of the rubric but is not in `entryHash`, and it cannot
+   * be: it is identical for every entry in a locale, so it belongs here beside
+   * `promptVersion` rather than in each entry's key. Absent on state files
+   * written before this field existed, which is treated as "unknown, re-review".
+   */
+  glossary?: string;
   entries: Record<string, EntryVerdict>;
 }
 
@@ -172,6 +181,20 @@ export function entryHash(
 }
 
 /**
+ * Identity of the glossary a review was produced under.
+ *
+ * Sorted so key order in the file cannot change the fingerprint, and covering the
+ * translations as well as the terms: changing what `Workflow` must become is as
+ * much a rubric change as adding the term in the first place.
+ */
+export function glossaryFingerprint(terminology: Record<string, string>): string {
+  const sorted = Object.keys(terminology)
+    .sort()
+    .map((term) => [term, terminology[term]]);
+  return createHash('sha256').update(JSON.stringify(sorted)).digest('hex').slice(0, 32);
+}
+
+/**
  * The entries whose verdict is missing or stale. Everything else already has a
  * verdict for this exact (source, translation, rubric) triple and is reused as-is.
  */
@@ -205,7 +228,7 @@ export function pruneOrphanedVerdicts(
   for (const [shareId, verdict] of Object.entries(state.entries)) {
     if (live.has(shareId)) entries[shareId] = verdict;
   }
-  return { promptVersion: state.promptVersion, entries };
+  return { promptVersion: state.promptVersion, glossary: state.glossary, entries };
 }
 
 /** JSON schema the model's answer is constrained to. Structured output means the
@@ -406,15 +429,21 @@ export function reviewStatePath(locale: Locale, dir: string = REVIEW_DIR): strin
  * would report NaN) or a non-array `findings` reach a `for…of` (which throws and
  * takes down the run). Both are avoidable by validating once, here.
  */
-export function loadReviewState(locale: Locale, dir: string = REVIEW_DIR): ReviewState {
+export function loadReviewState(
+  locale: Locale,
+  dir: string = REVIEW_DIR,
+  glossary?: string
+): ReviewState {
   const state = readJson<ReviewState>(reviewStatePath(locale, dir), {
     promptVersion: PROMPT_VERSION,
     entries: {},
   });
   // A rubric change makes every stored verdict incomparable, so discard them all
-  // rather than mixing verdicts from two different rubrics in one report.
-  if (state?.promptVersion !== PROMPT_VERSION) {
-    return { promptVersion: PROMPT_VERSION, entries: {} };
+  // rather than mixing verdicts from two different rubrics in one report. The
+  // glossary is part of that rubric: a verdict reached under a different set of
+  // required terms says nothing about the terms in force now.
+  if (state?.promptVersion !== PROMPT_VERSION || (glossary && state.glossary !== glossary)) {
+    return { promptVersion: PROMPT_VERSION, glossary, entries: {} };
   }
   const entries: Record<string, EntryVerdict> = {};
   for (const [shareId, verdict] of Object.entries(state.entries ?? {})) {
@@ -423,7 +452,9 @@ export function loadReviewState(locale: Locale, dir: string = REVIEW_DIR): Revie
     // filter — a stored finding names a field that may legitimately be absent now.
     entries[shareId] = { hash: verdict.hash, findings: sanitizeFindings(verdict.findings) };
   }
-  return { promptVersion: PROMPT_VERSION, entries };
+  // Callers with no glossary to declare (tests, ad-hoc reads) must not erase the
+  // fingerprint the last real run recorded.
+  return { promptVersion: PROMPT_VERSION, glossary: glossary ?? state.glossary, entries };
 }
 
 /** Run `worker` over `items` with a bounded number in flight. */
@@ -545,7 +576,7 @@ async function main(): Promise<void> {
       ),
     };
 
-    const priorState = loadReviewState(locale);
+    const priorState = loadReviewState(locale, REVIEW_DIR, glossaryFingerprint(terminology));
     const pending = selectEntriesForReview(
       localeContent,
       english,

--- a/site/scripts/i18n/review-translations.ts
+++ b/site/scripts/i18n/review-translations.ts
@@ -530,7 +530,14 @@ async function main(): Promise<void> {
     );
     if (Object.keys(localeContent).length === 0) continue;
 
-    const terminology = {
+    // The same selection the translator's prompt carries, read from the one
+    // artifact `pnpm i18n:glossary` writes. Reading the uncapped mirror here is
+    // what made the reviewer demand terms the translator was never given.
+    const effective = readJson<Record<string, string> | null>(
+      path.join(GLOSSARY_DIR, 'effective', `${locale}.json`),
+      null
+    );
+    const terminology = effective ?? {
       ...readJson<Record<string, string>>(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {}),
       ...readJson<Record<string, string>>(
         path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`),

--- a/site/scripts/i18n/sync-glossary.ts
+++ b/site/scripts/i18n/sync-glossary.ts
@@ -146,9 +146,12 @@ export function selectGlossary(
 ): Record<string, string> {
   const frequency = (term: string): number => {
     if (!term) return 0;
-    // Whole-term matches only: "AI" should not score inside "Explain".
+    // Whole-term matches only: "AI" should not score inside "Explain", nor inside
+    // "AI2" or "AI_model" — this corpus is full of identifiers like `wan2_2`, so
+    // digits and underscores have to count as term characters or a short term
+    // inflates its own frequency and displaces a genuinely common one at the cap.
     const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return (corpus.match(new RegExp(`(?<![A-Za-z])${escaped}(?![A-Za-z])`, 'gi')) ?? []).length;
+    return (corpus.match(new RegExp(`(?<!\\w)${escaped}(?!\\w)`, 'gi')) ?? []).length;
   };
 
   const ranked = Object.entries(mirror)

--- a/site/scripts/i18n/sync-glossary.ts
+++ b/site/scripts/i18n/sync-glossary.ts
@@ -119,6 +119,52 @@ export function buildMirror(
   return mirror;
 }
 
+/**
+ * How many harvested pairs reach the translator's prompt. The prompt has to stay
+ * bounded, so the mirror is trimmed; which pairs survive is the important part.
+ */
+export const MAX_MIRROR_PAIRS = 200;
+
+/**
+ * The glossary both sides actually use, chosen by how often a term appears in
+ * the English corpus rather than by how long it is.
+ *
+ * Length-first ranking is what broke the Russian run: it drops the SHORTEST
+ * terms first, and "Workflow" is the most frequent term in the product, so the
+ * translator was never shown it while the reviewer went on enforcing it. Every
+ * field mentioning a workflow was then flagged, 27% of the locale, and the
+ * systemic-prune guard failed the run.
+ *
+ * Curated overrides are always kept, on top of the cap, because someone chose
+ * them deliberately.
+ */
+export function selectGlossary(
+  mirror: Record<string, string>,
+  overrides: Record<string, string>,
+  corpus: string,
+  limit: number = MAX_MIRROR_PAIRS
+): Record<string, string> {
+  const frequency = (term: string): number => {
+    if (!term) return 0;
+    // Whole-term matches only: "AI" should not score inside "Explain".
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return (corpus.match(new RegExp(`(?<![A-Za-z])${escaped}(?![A-Za-z])`, 'gi')) ?? []).length;
+  };
+
+  const ranked = Object.entries(mirror)
+    .map(([en, localized]) => ({ en, localized, count: frequency(en) }))
+    // Frequency first; longer term wins a tie, since it is the more specific one.
+    .sort((a, b) => b.count - a.count || b.en.length - a.en.length)
+    .slice(0, limit);
+
+  const selected: Record<string, string> = {};
+  for (const { en, localized } of ranked) selected[en] = localized;
+  for (const [en, localized] of Object.entries(overrides)) {
+    if (typeof localized === 'string' && localized.trim()) selected[en] = localized;
+  }
+  return selected;
+}
+
 /** Flatten a nested JSON dictionary to flat "a.b.c" → string entries. */
 export function flattenStrings(obj: unknown, prefix = ''): Record<string, string> {
   const out: Record<string, string> = {};
@@ -168,6 +214,28 @@ function loadAppStrings(localesDir: string, locale: string): Record<string, stri
   return merged;
 }
 
+function readJson<T>(file: string, fallback: T): T {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8')) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * The English content the translator will see, as one string for term counting.
+ * Absent before the first build-source run, in which case ranking falls back to
+ * term length via the zero-count tie-break.
+ */
+function readEnglishCorpus(): string {
+  const file = path.join(process.cwd(), 'src', 'i18n', 'content', 'en.json');
+  try {
+    return fs.readFileSync(file, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
 function writeJson(file: string, value: unknown): void {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify(value, null, 2) + '\n');
@@ -186,19 +254,30 @@ function main(): void {
   }
 
   const enStrings = loadAppStrings(localesDir, 'en');
+  // Rank against the text being translated, so the terms that survive the cap
+  // are the ones the corpus actually uses.
+  const corpus = readEnglishCorpus();
   let mirrorTotal = 0;
+  let effectiveTotal = 0;
   for (const locale of SUPPORTED_HUB_LOCALES) {
     if (locale === 'en') continue;
     const mirror = buildMirror(enStrings, loadAppStrings(localesDir, locale));
     writeJson(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), mirror);
     const overridePath = path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`);
     if (!fs.existsSync(overridePath)) writeJson(overridePath, {});
+    const overrides = readJson<Record<string, string>>(overridePath, {});
+    // ONE artifact, read verbatim by the translator config and the reviewer, so
+    // neither can enforce a term the other was never shown.
+    const effective = selectGlossary(mirror, overrides, corpus);
+    writeJson(path.join(GLOSSARY_DIR, 'effective', `${locale}.json`), effective);
     mirrorTotal += Object.keys(mirror).length;
+    effectiveTotal += Object.keys(effective).length;
   }
 
   console.log(
     `[i18n] glossary: ${PRESERVE_TERMS.length} preserve terms, ` +
-      `${mirrorTotal} mirror pairs across ${SUPPORTED_HUB_LOCALES.length - 1} locales ` +
+      `${mirrorTotal} mirror pairs (${effectiveTotal} effective) across ` +
+      `${SUPPORTED_HUB_LOCALES.length - 1} locales ` +
       `(from ${localesDir}).`
   );
 }

--- a/site/tests/unit/i18n-glossary.test.ts
+++ b/site/tests/unit/i18n-glossary.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildMirror, flattenStrings, PRESERVE_TERMS } from '../../scripts/i18n/sync-glossary';
+import {
+  buildMirror,
+  flattenStrings,
+  PRESERVE_TERMS,
+  selectGlossary,
+} from '../../scripts/i18n/sync-glossary';
 
 describe('flattenStrings', () => {
   it('flattens nested dictionaries to dot paths, keeping only strings', () => {
@@ -50,5 +55,61 @@ describe('PRESERVE_TERMS', () => {
 
   it('has no duplicates', () => {
     expect(new Set(PRESERVE_TERMS).size).toBe(PRESERVE_TERMS.length);
+  });
+});
+
+describe('selectGlossary', () => {
+  // The Russian failure: 27% of fields pruned, every violation the same term.
+  // The translator capped the mirror longest-term-first, so the shortest and
+  // most common word in the product fell off the list, while the reviewer read
+  // the uncapped mirror and went on demanding it.
+  const corpus = JSON.stringify({
+    a: { title: 'Workflow for video', description: 'Run this workflow, then open the workflow' },
+    b: { title: 'Another workflow', description: 'Latent Consistency Model sampler' },
+  });
+
+  it('keeps a short, frequent term over a long, unused one', () => {
+    const mirror = {
+      Workflow: 'Рабочий процесс',
+      'Latent Consistency Model Sampler Settings': 'Настройки сэмплера LCM',
+    };
+    const selected = selectGlossary(mirror, {}, corpus, 1);
+
+    expect(Object.keys(selected)).toEqual(['Workflow']);
+  });
+
+  it('ranked by length instead, the frequent term is the one that is lost', () => {
+    // Pinning the old behaviour so the regression cannot come back unnoticed.
+    const byLength = Object.entries({
+      Workflow: 'Рабочий процесс',
+      'Latent Consistency Model Sampler Settings': 'Настройки сэмплера LCM',
+    })
+      .sort((a, b) => b[0].length - a[0].length)
+      .slice(0, 1);
+
+    expect(byLength[0][0]).not.toBe('Workflow');
+  });
+
+  it('always keeps curated overrides, even past the cap', () => {
+    const selected = selectGlossary({ Workflow: 'Рабочий процесс' }, { Seed: 'Сид' }, corpus, 1);
+
+    expect(selected).toMatchObject({ Workflow: 'Рабочий процесс', Seed: 'Сид' });
+  });
+
+  it('lets an override win over the harvested pair', () => {
+    const selected = selectGlossary({ Workflow: 'Поток' }, { Workflow: 'Рабочий процесс' }, corpus);
+
+    expect(selected.Workflow).toBe('Рабочий процесс');
+  });
+
+  it('counts whole terms only, so a short term cannot ride inside a longer word', () => {
+    const selected = selectGlossary(
+      { AI: 'ИИ', Workflow: 'Рабочий процесс' },
+      {},
+      JSON.stringify({ a: { title: 'Explain the workflow', description: 'workflow again' } }),
+      1
+    );
+
+    expect(Object.keys(selected)).toEqual(['Workflow']);
   });
 });

--- a/site/tests/unit/i18n-glossary.test.ts
+++ b/site/tests/unit/i18n-glossary.test.ts
@@ -112,4 +112,34 @@ describe('selectGlossary', () => {
 
     expect(Object.keys(selected)).toEqual(['Workflow']);
   });
+
+  it('does not let a term score inside an identifier', () => {
+    // The corpus is full of names like `wan2_2`, so a term riding inside one
+    // would out-rank a term that is genuinely used in prose.
+    const selected = selectGlossary(
+      { AI: 'ИИ', Workflow: 'Рабочий процесс' },
+      {},
+      JSON.stringify({
+        a: { title: 'AI2 and AI_model and 3AI', description: 'the workflow' },
+      }),
+      1
+    );
+
+    expect(Object.keys(selected)).toEqual(['Workflow']);
+  });
+
+  it('prefers the longer term when two are equally frequent', () => {
+    // The tie-break is the only thing choosing between them, so without this the
+    // `b.en.length` comparison can be dropped or reversed and nothing fails.
+    // Disjoint terms, so neither can score inside the other and the counts are
+    // genuinely equal at one each.
+    const selected = selectGlossary(
+      { Seed: 'Сид', Sampler: 'Сэмплер' },
+      {},
+      JSON.stringify({ a: { title: 'Seed', description: 'Sampler' } }),
+      1
+    );
+
+    expect(Object.keys(selected)).toEqual(['Sampler']);
+  });
 });

--- a/site/tests/unit/i18n-review-translations.test.ts
+++ b/site/tests/unit/i18n-review-translations.test.ts
@@ -9,6 +9,7 @@ import {
   buildSystemPrompt,
   buildUserPrompt,
   entryHash,
+  glossaryFingerprint,
   parseFindings,
   pruneOrphanedVerdicts,
   reviewViolations,
@@ -538,6 +539,47 @@ describe('loadReviewState (reads a committed, therefore corruptible, file)', () 
     expect(loadReviewState('zh', dir).entries).toEqual({});
   });
 
+  it('discards everything when the glossary has changed under it', () => {
+    // entryHash covers the source and the translation, never the glossary, so a
+    // verdict reached under different required terms would otherwise be reused
+    // as though it still applied.
+    write({
+      promptVersion: PROMPT_VERSION,
+      glossary: glossaryFingerprint({ Workflow: 'Рабочий процесс' }),
+      entries: { wf1: { hash: 'h', findings: [] } },
+    });
+
+    const reloaded = loadReviewState('zh', dir, glossaryFingerprint({ Workflow: 'Поток' }));
+
+    expect(reloaded.entries).toEqual({});
+  });
+
+  it('keeps verdicts when the glossary is unchanged', () => {
+    const fingerprint = glossaryFingerprint({ Workflow: 'Рабочий процесс' });
+    write({
+      promptVersion: PROMPT_VERSION,
+      glossary: fingerprint,
+      entries: { wf1: { hash: 'h', findings: [] } },
+    });
+
+    expect(Object.keys(loadReviewState('zh', dir, fingerprint).entries)).toEqual(['wf1']);
+  });
+
+  it('discards verdicts stored before the fingerprint existed', () => {
+    write({ promptVersion: PROMPT_VERSION, entries: { wf1: { hash: 'h', findings: [] } } });
+
+    expect(loadReviewState('zh', dir, glossaryFingerprint({ Seed: 'Сид' })).entries).toEqual({});
+  });
+
+  it('does not erase a stored fingerprint when the caller declares none', () => {
+    // Otherwise a read with no glossary in hand would blank the field and make
+    // the next real run re-review the whole locale for nothing.
+    const fingerprint = glossaryFingerprint({ Seed: 'Сид' });
+    write({ promptVersion: PROMPT_VERSION, glossary: fingerprint, entries: {} });
+
+    expect(loadReviewState('zh', dir).glossary).toBe(fingerprint);
+  });
+
   it('drops malformed verdicts instead of throwing', () => {
     write({
       promptVersion: PROMPT_VERSION,
@@ -629,5 +671,26 @@ describe('resolveReviewModel (blank env is not a model choice)', () => {
     for (const raw of [undefined, '', ' ', '\t', '\n  \n']) {
       expect(resolveReviewModel(raw).length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('glossaryFingerprint', () => {
+  it('ignores key order, so a re-serialised glossary is not a new rubric', () => {
+    expect(glossaryFingerprint({ Seed: 'Сид', Workflow: 'Поток' })).toBe(
+      glossaryFingerprint({ Workflow: 'Поток', Seed: 'Сид' })
+    );
+  });
+
+  it('changes when a required translation changes', () => {
+    // The term is the same; what the reviewer will demand for it is not.
+    expect(glossaryFingerprint({ Workflow: 'Поток' })).not.toBe(
+      glossaryFingerprint({ Workflow: 'Рабочий процесс' })
+    );
+  });
+
+  it('changes when a term is added', () => {
+    expect(glossaryFingerprint({ Workflow: 'Поток' })).not.toBe(
+      glossaryFingerprint({ Workflow: 'Поток', Seed: 'Сид' })
+    );
   });
 });


### PR DESCRIPTION
Unblocks the Russian backfill, and every locale behind it.

## What happened

Russian finished translating all 616 workflows today (credits restored this morning), then failed at `enforce`:

```
[i18n] enforce: [ru] pruned 1179/4312 field(s) (27.3%) -> English fallback. { glossary: 1382 }
[i18n] enforce: pruning is systemic, not a tail — failing the run
```

The guard was right to fail it. But those ~1,382 violations are not 1,382 problems. They are **one term, repeated**:

```
[ru] ... (glossary): The product-UI term 'Workflow' must be rendered as 'Рабочий процесс'
[ru] ... (glossary): 'Workflow' must be translated as 'Рабочий процесс' per the required glossary
[ru] ... (glossary): Required translation for 'Workflow' is 'Рабочий процесс'
```

## Why the translator never used it

The two sides read different glossaries:

- **Translator** (`.i18nrc.cjs`): the harvested mirror, capped at 200 pairs, sorted **longest English term first**.
- **Reviewer** (`review-translations.ts`): the same mirror, **uncapped**.

Russian harvests **4,547 pairs**, so the reviewer was enforcing roughly 95% of a glossary the translator was never shown. And sorting longest-first drops the *shortest* terms first, which is how `Workflow` — the most frequent term in the product — ended up on the reviewer's list and off the translator's.

Verified against the real mirror rather than reasoned about:

| | `Workflow` in the translator's prompt? |
| --- | --- |
| old rule (length-first, 200) | **no** |
| new rule (frequency-first, 200) | **yes** |

## The fix

Selection happens **once**, in `pnpm i18n:glossary`, and is written to `effective/<locale>.json`. The translator config and the reviewer both read that file verbatim, so neither can enforce a term the other was never given. Ranking is by how often the term appears in the English corpus, with the longer term winning ties; curated overrides are still kept in full on top of the cap.

Both consumers fall back to the raw mirror when the artifact is absent, so a local run that has not synced the glossary behaves as before.

## Tests

Five new cases: a short frequent term beats a long unused one, curated overrides survive the cap, an override outranks the harvested pair, whole-term counting so `AI` cannot score inside `Explain`, and one that pins the *old* length-first behaviour as the regression it was.

Gate: eslint clean, `astro check` 0 errors, vitest 624 passing, and `.i18nrc.cjs` still loads with its model and JSON-mode settings intact.

## After merge

Re-dispatch Russian. Its 616 translated entries are already banked on the automation branch, so the rerun re-translates against a prompt that finally contains the term it was being judged on. Arabic is running now on the old rule and will likely fail the same way; that is expected, and its progress banks either way.
