### PR TITLE
Enhance preview deployment workflow with status updates

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Mark preview comment as rebuilding
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: vercel-preview
+          message: |
+            ⏳ **Preview rebuilding** for `${{ github.event.pull_request.head.sha }}` — [watch the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). The link will appear here when the deploy finishes.
+
       - name: Setup
         uses: ./.github/actions/site-setup
 
@@ -81,6 +89,7 @@ jobs:
             fi
 
             echo "preview-url=$preview_url" >> "$GITHUB_OUTPUT"
+            echo "deployed-at=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
           else
             cat "$stderr_file" >&2
             cat "$stdout_file"
@@ -94,3 +103,13 @@ jobs:
           header: vercel-preview
           message: |
             🚀 **Preview deployed:** ${{ steps.deploy.outputs.preview-url }}
+
+            Built from `${{ github.event.pull_request.head.sha }}` at ${{ steps.deploy.outputs.deployed-at }} ([run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})).
+
+      - name: Comment build failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: vercel-preview
+          message: |
+            ❌ **Preview build failed** for `${{ github.event.pull_request.head.sha }}` — [see the run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Any earlier preview link is outdated.


### PR DESCRIPTION
## Summary
Improved the Vercel preview deployment workflow to provide better visibility into the deployment process by adding status comments at key stages: when the build starts, when it completes successfully, and when it fails.

## Key Changes
- **Build start notification**: Added a sticky PR comment that appears immediately when the preview build begins, showing the commit SHA and a link to the workflow run
- **Deployment timestamp**: Captured the deployment completion time in UTC format for inclusion in the success message
- **Enhanced success message**: Updated the preview deployed comment to include the commit SHA, deployment timestamp, and workflow run link for better traceability
- **Failure notification**: Added a new sticky comment that appears when the preview build fails, alerting reviewers that any previous preview link is outdated and providing a link to the failed run

## Implementation Details
- All status comments use the `marocchino/sticky-pull-request-comment@v2` action with the `vercel-preview` header to maintain a single, updated comment per status type
- Status updates only apply to pull request events (`github.event_name == 'pull_request'`)
- The failure comment uses the `failure()` condition to trigger only when the deployment job fails
- Timestamps are generated in UTC format using `date -u '+%Y-%m-%d %H:%M UTC'` for consistency

https://claude.ai/code/session_01GnBN4zKV4QJ61SSygNbftK