### PR TITLE
fix(i18n): let the glossary retract a harvested pair, and retract es Video

### DIFF
--- a/site/.i18nrc.cjs
+++ b/site/.i18nrc.cjs
@@ -42,14 +42,31 @@ const outputLocales = singleLocale ? [singleLocale] : ALL_LOCALES;
 // well is what broke the Russian run: this side capped the mirror and the
 // reviewer did not, so the reviewer enforced terms the translator never saw.
 // Falls back to the raw mirror for a local run that has not synced the glossary.
+// Mirror of `applyOverrides` in scripts/i18n/sync-glossary.ts, duplicated because
+// this file is CommonJS and cannot import the TypeScript module. A `null` in the
+// overrides file RETRACTS the harvested pair; spreading the override object over
+// the mirror instead would keep the key with a null value and emit `- Video → null`.
+function withOverrides(base, overrides) {
+  const result = { ...base };
+  for (const [en, localized] of Object.entries(overrides)) {
+    if (localized === null) {
+      delete result[en];
+      continue;
+    }
+    if (typeof localized === 'string' && localized.trim()) result[en] = localized;
+  }
+  return result;
+}
+
 function terminologyBlock(locale) {
   const effective = readJson(path.join(GLOSSARY_DIR, 'effective', `${locale}.json`), null);
   const merged = new Map(
     Object.entries(
-      effective ?? {
-        ...readJson(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {}),
-        ...readJson(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {}),
-      }
+      effective ??
+        withOverrides(
+          readJson(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {}),
+          readJson(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {})
+        )
     )
   );
   if (merged.size === 0) return '';

--- a/site/.i18nrc.cjs
+++ b/site/.i18nrc.cjs
@@ -15,6 +15,10 @@
 const { defineConfig } = require('@lobehub/i18n-cli');
 const fs = require('node:fs');
 const path = require('node:path');
+// The one implementation of the override layer, shared with the TypeScript
+// scripts under scripts/i18n. It lives in CommonJS because node requires this
+// config directly and cannot load a TypeScript module.
+const { applyOverrides } = require('./scripts/i18n/glossary-overrides.cjs');
 
 const GLOSSARY_DIR = path.join(__dirname, 'i18n', 'glossary');
 
@@ -41,29 +45,15 @@ const outputLocales = singleLocale ? [singleLocale] : ALL_LOCALES;
 // effective/<locale>.json, which the AI reviewer reads too. Selecting it here as
 // well is what broke the Russian run: this side capped the mirror and the
 // reviewer did not, so the reviewer enforced terms the translator never saw.
-// Falls back to the raw mirror for a local run that has not synced the glossary.
-// Mirror of `applyOverrides` in scripts/i18n/sync-glossary.ts, duplicated because
-// this file is CommonJS and cannot import the TypeScript module. A `null` in the
-// overrides file RETRACTS the harvested pair; spreading the override object over
-// the mirror instead would keep the key with a null value and emit `- Video → null`.
-function withOverrides(base, overrides) {
-  const result = { ...base };
-  for (const [en, localized] of Object.entries(overrides)) {
-    if (localized === null) {
-      delete result[en];
-      continue;
-    }
-    if (typeof localized === 'string' && localized.trim()) result[en] = localized;
-  }
-  return result;
-}
-
+// Falls back to the raw mirror for a local run that has not synced the glossary,
+// merged through the shared `applyOverrides` so this side honours a retraction
+// (a `null` in the overrides file) exactly as the reviewer and the validator do.
 function terminologyBlock(locale) {
   const effective = readJson(path.join(GLOSSARY_DIR, 'effective', `${locale}.json`), null);
   const merged = new Map(
     Object.entries(
       effective ??
-        withOverrides(
+        applyOverrides(
           readJson(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {}),
           readJson(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {})
         )

--- a/site/i18n/glossary/overrides/es.json
+++ b/site/i18n/glossary/overrides/es.json
@@ -1,1 +1,4 @@
-{}
+{
+  "Video": null,
+  "VIDEO": null
+}

--- a/site/scripts/i18n/enforce-translations.ts
+++ b/site/scripts/i18n/enforce-translations.ts
@@ -26,7 +26,7 @@ import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
 import type { Locale, WorkflowContent } from '../../src/lib/i18n/schema';
 import { collectViolations, type Violation } from './validate-translations';
 import { loadReviewState, reviewViolations } from './review-translations';
-import { enforceableOverrides, type GlossaryOverrides } from './sync-glossary';
+import { enforceableOverrides, type GlossaryOverrides } from './glossary-overrides.cjs';
 
 const CONTENT_DIR = path.join(process.cwd(), 'src', 'i18n', 'content');
 const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');

--- a/site/scripts/i18n/enforce-translations.ts
+++ b/site/scripts/i18n/enforce-translations.ts
@@ -26,6 +26,7 @@ import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
 import type { Locale, WorkflowContent } from '../../src/lib/i18n/schema';
 import { collectViolations, type Violation } from './validate-translations';
 import { loadReviewState, reviewViolations } from './review-translations';
+import { enforceableOverrides, type GlossaryOverrides } from './sync-glossary';
 
 const CONTENT_DIR = path.join(process.cwd(), 'src', 'i18n', 'content');
 const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');
@@ -182,9 +183,10 @@ function main(): void {
     const file = path.join(CONTENT_DIR, `${locale}.json`);
     const localeContent = readJson<Record<string, Partial<WorkflowContent>>>(file, {});
     if (Object.keys(localeContent).length === 0) continue;
-    const overrides = readJson<Record<string, string>>(
-      path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`),
-      {}
+    // Retractions (`null`) drop a bad harvested pair; they are not requirements,
+    // so they must never reach the deterministic check. See `GlossaryOverrides`.
+    const overrides = enforceableOverrides(
+      readJson<GlossaryOverrides>(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {})
     );
 
     // Quality findings from the AI reviewer prune through the same path. Absent

--- a/site/scripts/i18n/glossary-overrides.cjs
+++ b/site/scripts/i18n/glossary-overrides.cjs
@@ -1,0 +1,79 @@
+/**
+ * The glossary override layer: ONE implementation, in CommonJS.
+ *
+ * Both sides of the pipeline need it and they cannot share a TypeScript module.
+ * `.i18nrc.cjs` is the @lobehub/i18n-cli config, which node `require`s directly,
+ * so it can only load CommonJS; the scripts under `scripts/i18n` are TypeScript
+ * run through tsx. A `.cjs` file is the one shape both can load, and JSDoc types
+ * give the TypeScript side real types (`allowJs` is on) without a second copy of
+ * the logic to keep in step.
+ *
+ * Keep it a single module. Two copies of these rules is exactly the bug #1173
+ * existed to fix: the translator's prompt quietly enforcing different terms than
+ * the reviewer and the validator.
+ */
+
+/**
+ * The on-disk shape of `i18n/glossary/overrides/{locale}.json`.
+ *
+ * A string is the curated translation a term MUST use. `null` is a RETRACTION:
+ * it says the harvested mirror pair for that term is wrong and must not be
+ * enforced by anyone. Retraction is the only way to drop a bad harvested pair,
+ * because the mirror is regenerated from the app's locale files on every run and
+ * hand-edits to it would not survive.
+ *
+ * Needed because the harvest cannot see when the app's own UI contradicts
+ * itself. `buildMirror` skips identity pairs, so where the Spanish UI leaves a
+ * term untranslated the pair is dropped as uninformative and only a divergent
+ * outlier survives: es harvested `Video -> Vídeo` from one standalone label
+ * while `Descargar video`, `Subir un video` and ten other phrases in the same
+ * file leave it unaccented. The reviewer then flagged 401 fields for using the
+ * spelling the app itself uses everywhere else, and `enforce` pruned them to
+ * English, 19.2% of the locale, over the 15% systemic threshold.
+ *
+ * @typedef {Record<string, string | null>} GlossaryOverrides
+ */
+
+/**
+ * Lay the curated override layer over a set of harvested pairs: a string wins
+ * over the harvested value, a `null` retracts the harvested pair entirely, and a
+ * blank string stays ignored (an accident, not a deliberate retraction).
+ *
+ * Every consumer that merges overrides into a glossary must go through here.
+ * Merging the override object over the mirror instead (`{...mirror, ...overrides}`)
+ * silently gets retraction wrong: the retracted key survives as an explicit
+ * `null`, and the translator prompt renders `- Video → null`.
+ *
+ * @param {Record<string, string>} base harvested pairs, not mutated
+ * @param {GlossaryOverrides} overrides
+ * @returns {Record<string, string>}
+ */
+function applyOverrides(base, overrides) {
+  const result = { ...base };
+  for (const [en, localized] of Object.entries(overrides)) {
+    if (localized === null) {
+      delete result[en];
+      continue;
+    }
+    if (typeof localized === 'string' && localized.trim()) result[en] = localized;
+  }
+  return result;
+}
+
+/**
+ * The subset of an overrides file that may be ENFORCED: curated translations,
+ * with retractions dropped.
+ *
+ * Every consumer that checks content against the override layer must read it
+ * through here. `collectViolations` treats an override as a hard requirement
+ * ("term X must be rendered as Y") with no model in the loop, so a raw `null`
+ * reaching it would demand that fields render as the literal `null`.
+ *
+ * @param {GlossaryOverrides} overrides
+ * @returns {Record<string, string>}
+ */
+function enforceableOverrides(overrides) {
+  return applyOverrides({}, overrides);
+}
+
+module.exports = { applyOverrides, enforceableOverrides };

--- a/site/scripts/i18n/review-translations.ts
+++ b/site/scripts/i18n/review-translations.ts
@@ -30,7 +30,7 @@ import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
 import { TRANSLATABLE_FIELDS } from '../../src/lib/i18n/schema';
 import type { Locale, TranslatableField, WorkflowContent } from '../../src/lib/i18n/schema';
 import type { Violation } from './validate-translations';
-import { applyOverrides, type GlossaryOverrides } from './sync-glossary';
+import { applyOverrides, type GlossaryOverrides } from './glossary-overrides.cjs';
 
 const CONTENT_DIR = path.join(process.cwd(), 'src', 'i18n', 'content');
 const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');

--- a/site/scripts/i18n/review-translations.ts
+++ b/site/scripts/i18n/review-translations.ts
@@ -30,6 +30,7 @@ import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
 import { TRANSLATABLE_FIELDS } from '../../src/lib/i18n/schema';
 import type { Locale, TranslatableField, WorkflowContent } from '../../src/lib/i18n/schema';
 import type { Violation } from './validate-translations';
+import { applyOverrides, type GlossaryOverrides } from './sync-glossary';
 
 const CONTENT_DIR = path.join(process.cwd(), 'src', 'i18n', 'content');
 const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');
@@ -568,13 +569,15 @@ async function main(): Promise<void> {
       path.join(GLOSSARY_DIR, 'effective', `${locale}.json`),
       null
     );
-    const terminology = effective ?? {
-      ...readJson<Record<string, string>>(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {}),
-      ...readJson<Record<string, string>>(
-        path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`),
-        {}
-      ),
-    };
+    // `applyOverrides`, not a spread: a retraction has to DELETE the harvested
+    // pair here too, or the fallback would enforce the very pair the override
+    // file retracts (and render it as `- Video → null` in the prompt).
+    const terminology =
+      effective ??
+      applyOverrides(
+        readJson<Record<string, string>>(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), {}),
+        readJson<GlossaryOverrides>(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {})
+      );
 
     const priorState = loadReviewState(locale, REVIEW_DIR, glossaryFingerprint(terminology));
     const pending = selectEntriesForReview(

--- a/site/scripts/i18n/sync-glossary.ts
+++ b/site/scripts/i18n/sync-glossary.ts
@@ -18,7 +18,8 @@
  *                          (created empty here; reviewers/CODEOWNERS extend them).
  *                          A `null` value RETRACTS a harvested pair instead of
  *                          replacing it, for the cases where the app's own UI
- *                          contradicts itself. See `GlossaryOverrides`.
+ *                          contradicts itself. The override layer itself lives
+ *                          in glossary-overrides.cjs, shared with .i18nrc.cjs.
  *
  * The pure functions are exported and unit-tested; `main()` only does IO.
  */
@@ -26,6 +27,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
+import { applyOverrides, type GlossaryOverrides } from './glossary-overrides.cjs';
 
 const GLOSSARY_DIR = path.join(process.cwd(), 'i18n', 'glossary');
 
@@ -136,64 +138,6 @@ export function buildMirror(
  * bounded, so the mirror is trimmed; which pairs survive is the important part.
  */
 export const MAX_MIRROR_PAIRS = 200;
-
-/**
- * The on-disk shape of `overrides/{locale}.json`.
- *
- * A string is the curated translation a term MUST use. `null` is a RETRACTION:
- * it says the harvested mirror pair for that term is wrong and must not be
- * enforced by anyone. Retraction is the only way to drop a bad harvested pair,
- * because the mirror is regenerated from the app's locale files on every run and
- * hand-edits to it would not survive.
- *
- * Needed because the harvest cannot see when the app's own UI contradicts
- * itself. `buildMirror` skips identity pairs, so where the Spanish UI leaves a
- * term untranslated the pair is dropped as uninformative and only a divergent
- * outlier survives: es harvested `Video -> Vídeo` from one standalone label
- * while `Descargar video`, `Subir un video` and ten other phrases in the same
- * file leave it unaccented. The reviewer then flagged 401 fields for using the
- * spelling the app itself uses everywhere else, and `enforce` pruned them to
- * English, 19.2% of the locale, over the 15% systemic threshold.
- */
-export type GlossaryOverrides = Record<string, string | null>;
-
-/**
- * Lay the curated override layer over a set of harvested pairs: a string wins
- * over the harvested value, a `null` retracts the harvested pair entirely.
- *
- * ONE implementation on purpose. Retraction has to mean "delete" in the capped
- * selection AND in the raw-mirror fallback both consumers use when
- * `effective/` has not been built. Merging the override object over the mirror
- * instead (`{...mirror, ...overrides}`) silently gets that wrong: the retracted
- * key survives as an explicit `null`, and the prompt renders `- Video → null`.
- */
-export function applyOverrides(
-  base: Record<string, string>,
-  overrides: GlossaryOverrides
-): Record<string, string> {
-  const result = { ...base };
-  for (const [en, localized] of Object.entries(overrides)) {
-    if (localized === null) {
-      delete result[en];
-      continue;
-    }
-    if (typeof localized === 'string' && localized.trim()) result[en] = localized;
-  }
-  return result;
-}
-
-/**
- * The subset of an overrides file that may be ENFORCED: curated translations,
- * with retractions dropped.
- *
- * Every consumer that checks content against the override layer must read it
- * through here. `collectViolations` treats an override as a hard requirement
- * ("term X must be rendered as Y") with no model in the loop, so a raw `null`
- * reaching it would demand that fields render as the literal `null`.
- */
-export function enforceableOverrides(overrides: GlossaryOverrides): Record<string, string> {
-  return applyOverrides({}, overrides);
-}
 
 /**
  * The glossary both sides actually use, chosen by how often a term appears in

--- a/site/scripts/i18n/sync-glossary.ts
+++ b/site/scripts/i18n/sync-glossary.ts
@@ -16,6 +16,9 @@
  *                          the product UI already uses (workflow, node, queue…).
  *   overrides/{locale}.json — hand-curated fixes that win over the mirror
  *                          (created empty here; reviewers/CODEOWNERS extend them).
+ *                          A `null` value RETRACTS a harvested pair instead of
+ *                          replacing it, for the cases where the app's own UI
+ *                          contradicts itself. See `GlossaryOverrides`.
  *
  * The pure functions are exported and unit-tested; `main()` only does IO.
  */
@@ -135,6 +138,64 @@ export function buildMirror(
 export const MAX_MIRROR_PAIRS = 200;
 
 /**
+ * The on-disk shape of `overrides/{locale}.json`.
+ *
+ * A string is the curated translation a term MUST use. `null` is a RETRACTION:
+ * it says the harvested mirror pair for that term is wrong and must not be
+ * enforced by anyone. Retraction is the only way to drop a bad harvested pair,
+ * because the mirror is regenerated from the app's locale files on every run and
+ * hand-edits to it would not survive.
+ *
+ * Needed because the harvest cannot see when the app's own UI contradicts
+ * itself. `buildMirror` skips identity pairs, so where the Spanish UI leaves a
+ * term untranslated the pair is dropped as uninformative and only a divergent
+ * outlier survives: es harvested `Video -> Vídeo` from one standalone label
+ * while `Descargar video`, `Subir un video` and ten other phrases in the same
+ * file leave it unaccented. The reviewer then flagged 401 fields for using the
+ * spelling the app itself uses everywhere else, and `enforce` pruned them to
+ * English, 19.2% of the locale, over the 15% systemic threshold.
+ */
+export type GlossaryOverrides = Record<string, string | null>;
+
+/**
+ * Lay the curated override layer over a set of harvested pairs: a string wins
+ * over the harvested value, a `null` retracts the harvested pair entirely.
+ *
+ * ONE implementation on purpose. Retraction has to mean "delete" in the capped
+ * selection AND in the raw-mirror fallback both consumers use when
+ * `effective/` has not been built. Merging the override object over the mirror
+ * instead (`{...mirror, ...overrides}`) silently gets that wrong: the retracted
+ * key survives as an explicit `null`, and the prompt renders `- Video → null`.
+ */
+export function applyOverrides(
+  base: Record<string, string>,
+  overrides: GlossaryOverrides
+): Record<string, string> {
+  const result = { ...base };
+  for (const [en, localized] of Object.entries(overrides)) {
+    if (localized === null) {
+      delete result[en];
+      continue;
+    }
+    if (typeof localized === 'string' && localized.trim()) result[en] = localized;
+  }
+  return result;
+}
+
+/**
+ * The subset of an overrides file that may be ENFORCED: curated translations,
+ * with retractions dropped.
+ *
+ * Every consumer that checks content against the override layer must read it
+ * through here. `collectViolations` treats an override as a hard requirement
+ * ("term X must be rendered as Y") with no model in the loop, so a raw `null`
+ * reaching it would demand that fields render as the literal `null`.
+ */
+export function enforceableOverrides(overrides: GlossaryOverrides): Record<string, string> {
+  return applyOverrides({}, overrides);
+}
+
+/**
  * The glossary both sides actually use, chosen by how often a term appears in
  * the English corpus rather than by how long it is.
  *
@@ -149,7 +210,7 @@ export const MAX_MIRROR_PAIRS = 200;
  */
 export function selectGlossary(
   mirror: Record<string, string>,
-  overrides: Record<string, string>,
+  overrides: GlossaryOverrides,
   corpus: string,
   limit: number = MAX_MIRROR_PAIRS
 ): Record<string, string> {
@@ -171,10 +232,15 @@ export function selectGlossary(
 
   const selected: Record<string, string> = {};
   for (const { en, localized } of ranked) selected[en] = localized;
-  for (const [en, localized] of Object.entries(overrides)) {
-    if (typeof localized === 'string' && localized.trim()) selected[en] = localized;
-  }
-  return selected;
+  // Overrides are laid on AFTER the cap, retractions included. A retraction must
+  // never filter the mirror before ranking: dropping a term earlier promotes
+  // whatever sits at rank 200 into the glossary, so retracting one bad pair would
+  // silently start enforcing a term nobody vetted. Measured on es, retracting
+  // Video/VIDEO before the cap would have promoted `Top -> Arriba` and
+  // `Number of Frames -> Número de fotogramas`, and `Top` is an ordinary word in
+  // this corpus. After the cap it is purely subtractive: 200 -> 198, nothing else
+  // moves.
+  return applyOverrides(selected, overrides);
 }
 
 /** Flatten a nested JSON dictionary to flat "a.b.c" → string entries. */
@@ -277,7 +343,7 @@ function main(): void {
     writeJson(path.join(GLOSSARY_DIR, 'mirror', `${locale}.json`), mirror);
     const overridePath = path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`);
     if (!fs.existsSync(overridePath)) writeJson(overridePath, {});
-    const overrides = readJson<Record<string, string>>(overridePath, {});
+    const overrides = readJson<GlossaryOverrides>(overridePath, {});
     // ONE artifact, read verbatim by the translator config and the reviewer, so
     // neither can enforce a term the other was never shown.
     const effective = selectGlossary(mirror, overrides, corpus);

--- a/site/scripts/i18n/validate-translations.ts
+++ b/site/scripts/i18n/validate-translations.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
+import { enforceableOverrides, type GlossaryOverrides } from './sync-glossary';
 import {
   TRANSLATABLE_FIELDS,
   type FaqItem,
@@ -333,9 +334,10 @@ function main(): void {
       );
     }
     // Curated per-locale terms that must be honored (the override layer's teeth).
-    const overrides = readJson<Record<string, string>>(
-      path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`),
-      {}
+    // Read through `enforceableOverrides` so a retraction (a `null`, which drops a
+    // bad harvested pair) can never become a requirement to render the literal null.
+    const overrides = enforceableOverrides(
+      readJson<GlossaryOverrides>(path.join(GLOSSARY_DIR, 'overrides', `${locale}.json`), {})
     );
     for (const [shareId, localized] of Object.entries(localeContent)) {
       const en = english[shareId];

--- a/site/scripts/i18n/validate-translations.ts
+++ b/site/scripts/i18n/validate-translations.ts
@@ -20,7 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
-import { enforceableOverrides, type GlossaryOverrides } from './sync-glossary';
+import { enforceableOverrides, type GlossaryOverrides } from './glossary-overrides.cjs';
 import {
   TRANSLATABLE_FIELDS,
   type FaqItem,

--- a/site/tests/unit/i18n-es-video-retraction.test.ts
+++ b/site/tests/unit/i18n-es-video-retraction.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The Spanish `Video` retraction, encoded so it keeps applying.
+ *
+ * The harvest cannot see when the app's own UI contradicts itself. `buildMirror`
+ * skips identity pairs, so wherever the Spanish app locale leaves a term
+ * untranslated the pair is dropped as uninformative and only a divergent outlier
+ * survives. For `video` the surviving pair is the accented one, harvested from a
+ * standalone label, while twelve phrases in the same file leave it unaccented:
+ *
+ *   'Video'             -> 'Vídeo'      <- harvested, rank 5 of 200
+ *   'VIDEO'             -> 'VÍDEO'      <- harvested, rank 6 of 200
+ *   'Download video'    -> 'Descargar video'
+ *   'Upload a video'    -> 'Subir un video'
+ *   'Generating video…' -> 'Generando video…'
+ *   'Seek video'        -> 'Buscar en el video'
+ *   ... 8 more, all unaccented
+ *
+ * The reviewer was handed those two pairs as required terminology and filed 401
+ * major terminology findings against fields using the spelling the app itself
+ * uses everywhere else. `enforce` pruned them to English: 827 of 4312 fields,
+ * 19.2% of the locale, over the 15% systemic threshold, which failed the nightly
+ * run of 2026-08-24. Dropping these two pairs takes the same review data to 381
+ * fields, 8.8%.
+ *
+ * Retraction, not a curated override to the unaccented form. An override is
+ * enforced deterministically by `collectViolations` with no model in the loop, so
+ * asserting `Video -> video` would prune every field that used the accent. We do
+ * not have a native reviewer's answer on vídeo (Spain) versus video (Latin
+ * America), and both are correct Spanish, so the honest position is to enforce
+ * neither and let the translator choose.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  applyOverrides,
+  enforceableOverrides,
+  selectGlossary,
+  type GlossaryOverrides,
+} from '../../scripts/i18n/sync-glossary';
+import { collectViolations } from '../../scripts/i18n/validate-translations';
+import type { WorkflowContent } from '../../src/lib/i18n/schema';
+
+const readOverrides = (locale: string) =>
+  JSON.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), 'i18n', 'glossary', 'overrides', `${locale}.json`),
+      'utf-8'
+    )
+  ) as GlossaryOverrides;
+
+const esOverrides = readOverrides('es');
+
+describe('the Spanish overrides file', () => {
+  it('retracts both casings of the harvested video pair', () => {
+    // Both are in the top 200, so retracting only one leaves the other enforcing
+    // the same accent.
+    expect(esOverrides).toEqual({ Video: null, VIDEO: null });
+  });
+
+  it('asserts no replacement wording of its own', () => {
+    expect(enforceableOverrides(esOverrides)).toEqual({});
+  });
+});
+
+describe('a retraction at the glossary boundary', () => {
+  const corpus = JSON.stringify({
+    a: { title: 'Video to video workflow', description: 'Upload a video, then queue it' },
+  });
+  const mirror = { Video: 'Vídeo', VIDEO: 'VÍDEO', Workflow: 'Flujo de trabajo' };
+
+  it('drops the retracted pairs from the selected glossary', () => {
+    const selected = selectGlossary(mirror, esOverrides, corpus);
+
+    expect(selected).toEqual({ Workflow: 'Flujo de trabajo' });
+  });
+
+  it('is purely subtractive: retracting never promotes another term past the cap', () => {
+    // The guard on the design decision. Retracting by filtering the mirror BEFORE
+    // ranking would free slots at the cap and pull unvetted terms in; measured on
+    // the real es mirror those were `Top -> Arriba` and `Number of Frames ->
+    // Número de fotogramas`. Applying overrides after the cap cannot do that.
+    const capped = selectGlossary(mirror, {}, corpus, 2);
+    const retracted = selectGlossary(mirror, esOverrides, corpus, 2);
+
+    expect(Object.keys(retracted).length).toBeLessThan(Object.keys(capped).length);
+    expect(Object.keys(retracted).every((term) => term in capped)).toBe(true);
+  });
+
+  it('deletes from the raw-mirror fallback rather than leaving a null behind', () => {
+    // The fallback both the translator config and the reviewer use when
+    // effective/ has not been built. A plain spread would keep the key with a
+    // null value and render `- Video → null` into the prompt.
+    const fallback = applyOverrides(mirror, esOverrides);
+
+    expect(fallback).toEqual({ Workflow: 'Flujo de trabajo' });
+    expect('Video' in fallback).toBe(false);
+  });
+});
+
+describe('a retraction at the enforcement boundary', () => {
+  // These run the deterministic checker, so they fail if a retraction ever
+  // reaches it as a requirement — the failure that would prune every field for
+  // not rendering the literal `null`.
+  const english = {
+    title: 'Wan 2.2 Video to Video',
+    description: 'Upload a video and queue the workflow to restyle it.',
+  } as unknown as WorkflowContent;
+
+  it('lets the unaccented spelling through', () => {
+    const translated = {
+      title: 'Wan 2.2 video a video',
+      description: 'Sube un video y pon en cola el flujo de trabajo para reestilizarlo.',
+    };
+
+    expect(
+      collectViolations('sid', 'es', english, translated, [], enforceableOverrides(esOverrides))
+    ).toEqual([]);
+  });
+
+  it('lets the accented spelling through too, since neither is enforced', () => {
+    const translated = {
+      title: 'Wan 2.2 vídeo a vídeo',
+      description: 'Sube un vídeo y pon en cola el flujo de trabajo para reestilizarlo.',
+    };
+
+    expect(
+      collectViolations('sid', 'es', english, translated, [], enforceableOverrides(esOverrides))
+    ).toEqual([]);
+  });
+});
+
+describe('other locales', () => {
+  it('keeps the Turkish curated terms enforceable', () => {
+    // The only populated overrides file besides es. Retraction must not have
+    // changed how a normal curated term is read.
+    expect(enforceableOverrides(readOverrides('tr'))).toMatchObject({
+      'Queue Prompt': 'İstemi Kuyruğa Al',
+      'Contact Sheet': 'Kontak Baskı',
+      Lineart: 'Çizgi Sanatı',
+    });
+  });
+
+  it('leaves every other locale asserting nothing', () => {
+    for (const locale of ['zh', 'zh-TW', 'ja', 'ko', 'fr', 'ru', 'ar', 'pt-BR']) {
+      expect(readOverrides(locale)).toEqual({});
+    }
+  });
+});

--- a/site/tests/unit/i18n-es-video-retraction.test.ts
+++ b/site/tests/unit/i18n-es-video-retraction.test.ts
@@ -32,12 +32,12 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { selectGlossary } from '../../scripts/i18n/sync-glossary';
 import {
   applyOverrides,
   enforceableOverrides,
-  selectGlossary,
   type GlossaryOverrides,
-} from '../../scripts/i18n/sync-glossary';
+} from '../../scripts/i18n/glossary-overrides.cjs';
 import { collectViolations } from '../../scripts/i18n/validate-translations';
 import type { WorkflowContent } from '../../src/lib/i18n/schema';
 

--- a/site/tests/unit/i18n-glossary.test.ts
+++ b/site/tests/unit/i18n-glossary.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-  applyOverrides,
   buildMirror,
-  enforceableOverrides,
   flattenStrings,
   PRESERVE_TERMS,
   selectGlossary,
 } from '../../scripts/i18n/sync-glossary';
+import { applyOverrides, enforceableOverrides } from '../../scripts/i18n/glossary-overrides.cjs';
 
 describe('flattenStrings', () => {
   it('flattens nested dictionaries to dot paths, keeping only strings', () => {

--- a/site/tests/unit/i18n-glossary.test.ts
+++ b/site/tests/unit/i18n-glossary.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyOverrides,
   buildMirror,
+  enforceableOverrides,
   flattenStrings,
   PRESERVE_TERMS,
   selectGlossary,
@@ -102,6 +104,38 @@ describe('selectGlossary', () => {
     expect(selected.Workflow).toBe('Рабочий процесс');
   });
 
+  it('lets a null override RETRACT a harvested pair', () => {
+    // The escape hatch for a pair the app's own UI contradicts. The mirror is
+    // regenerated from the app locales every run, so retraction is the only way
+    // to drop one: a hand-edit to the mirror would not survive the next sync.
+    const selected = selectGlossary(
+      { Workflow: 'Рабочий процесс', Video: 'Видео' },
+      { Video: null },
+      corpus
+    );
+
+    expect(selected).toEqual({ Workflow: 'Рабочий процесс' });
+  });
+
+  it('applies a retraction after the cap, so nothing is promoted in its place', () => {
+    // Pins the design decision. Filtering the mirror before ranking would free a
+    // slot and pull the next-ranked term into the enforced glossary, which is how
+    // retracting one bad pair could start enforcing a term nobody vetted.
+    const mirror = { Workflow: 'Рабочий процесс', video: 'Видео', Seed: 'Сид' };
+
+    const retracted = selectGlossary(mirror, { Workflow: null }, corpus, 2);
+
+    expect('Seed' in retracted).toBe(false);
+    expect(Object.keys(retracted)).toEqual(['video']);
+  });
+
+  it('still ignores a blank override rather than treating it as a retraction', () => {
+    // Blank stays an accident; only an explicit null is a deliberate retraction.
+    const selected = selectGlossary({ Workflow: 'Рабочий процесс' }, { Workflow: '  ' }, corpus);
+
+    expect(selected.Workflow).toBe('Рабочий процесс');
+  });
+
   it('counts whole terms only, so a short term cannot ride inside a longer word', () => {
     const selected = selectGlossary(
       { AI: 'ИИ', Workflow: 'Рабочий процесс' },
@@ -141,5 +175,36 @@ describe('selectGlossary', () => {
     );
 
     expect(Object.keys(selected)).toEqual(['Sampler']);
+  });
+});
+
+describe('applyOverrides', () => {
+  it('replaces on a string and deletes on a null', () => {
+    expect(applyOverrides({ a: '1', b: '2' }, { a: 'one', b: null })).toEqual({ a: 'one' });
+  });
+
+  it('ignores a retraction for a term that was never harvested', () => {
+    expect(applyOverrides({ a: '1' }, { zzz: null })).toEqual({ a: '1' });
+  });
+
+  it('does not mutate its input', () => {
+    const base = { a: '1' };
+    applyOverrides(base, { a: null });
+
+    expect(base).toEqual({ a: '1' });
+  });
+});
+
+describe('enforceableOverrides', () => {
+  it('keeps curated terms and drops retractions', () => {
+    // Everything that checks content against the override layer reads it through
+    // here. `collectViolations` treats an override as a hard requirement with no
+    // model in the loop, so a null reaching it would demand fields render as the
+    // literal null.
+    expect(enforceableOverrides({ Queue: 'Cola', Video: null })).toEqual({ Queue: 'Cola' });
+  });
+
+  it('drops a blank the same way it always did', () => {
+    expect(enforceableOverrides({ Queue: '   ' })).toEqual({});
   });
 });


### PR DESCRIPTION
Unblocks the nightly hub translation run, which has failed every night since 08-21.

## What is happening

A **different locale** fails each night, so this is not a Spanish problem:

| Night | Locale | Pruned |
| --- | --- | --- |
| 08-21 [32439836712](https://github.com/Comfy-Org/workflow_templates/actions/runs/32439836712) | ru | 20.6% |
| 08-22 [32546012047](https://github.com/Comfy-Org/workflow_templates/actions/runs/32546012047) | zh | 25.4% |
| 08-23 [32612864319](https://github.com/Comfy-Org/workflow_templates/actions/runs/32612864319) | ko | 44.3% |
| 08-24 [32683050864](https://github.com/Comfy-Org/workflow_templates/actions/runs/32683050864) | es | 19.2% |

```
[i18n] enforce: pruning is systemic, not a tail — failing the run
  es: 19.2% of translated fields failed (> 15% threshold)
```

#1173 changed the glossary, which correctly invalidated every stored verdict. With a 2000-entry
review ceiling and 616 entries per locale, roughly one locale reaches its first re-review per
night, trips the guard once, and settles after: zh 25.4 → 10.7 → 4.1, ko 44.3 → 12.7. The guard is
right. It just cannot tell a first re-review from a broken config.

## Spanish is the one case where the glossary itself is wrong

`buildMirror` skips identity pairs, so wherever the app's Spanish UI leaves a term untranslated the
pair is dropped as uninformative and only a divergent outlier survives:

```
'Video'             -> 'Vídeo'            <- harvested, rank 5 of 200
'VIDEO'             -> 'VÍDEO'            <- harvested, rank 6 of 200
'Download video'    -> 'Descargar video'
'Upload a video'    -> 'Subir un video'
'Generating video…' -> 'Generando video…'
... 12 of 14 video phrases in the same file are unaccented
```

The reviewer was handed those two pairs as required terminology. Of 888 major/critical findings for
es, 797 are `terminology`, and **401 are this one accent**. `enforce` then prunes correct Spanish
back to English.

Measured against the recorded review data (reproduces the run's 827 / 19.2% exactly):

| | Pruned | Rate |
| --- | --- | --- |
| today | 827 / 4312 | 19.2% |
| **without the two video pairs** | **381 / 4312** | **8.8%** |

**Read that 8.8% as a floor, not a forecast.** It assumes every video finding disappears. 65 of the
467 also allege the page contradicts itself (`the title uses vídeo but the description uses video`),
which is a fair complaint independent of this rule and may re-appear as `context` on the next
review. Adding those 63 distinct fields back puts the realistic landing zone at **roughly 9-11%**.
Under the threshold either way, but the margin is thinner than the single number suggests, which is
why the es-only dispatch below matters before trusting the nightly.

`Workflow -> Flujo de trabajo` (254 findings) is a legitimate term and stays. That one is fixed by
retranslation, not by removal.

## The change

Overrides could only add or replace, so there was no way to drop a bad harvested pair, and the
mirror is regenerated every run so a hand-edit would not survive. **A `null` now retracts.**

Three decisions worth reviewing:

1. **Retraction, not an override to the unaccented form.** An override is enforced
   deterministically by `collectViolations` with no model in the loop, so asserting
   `Video -> video` would prune every field that used the accent. `vídeo` (Spain) and `video`
   (Latin America) are both correct Spanish and no native reviewer has ruled, so this enforces
   neither. When a reviewer does rule, it becomes a normal curated override.
2. **Applied AFTER the cap.** Filtering the mirror before ranking frees slots and pulls unvetted
   terms in. Measured on the real es mirror, retracting early would have promoted `Top -> Arriba`
   and `Number of Frames -> Número de fotogramas`, and `Top` is an ordinary word in this corpus.
   After the cap it is purely subtractive. Pinned by a test.
3. **One `applyOverrides` for all five readers.** Retraction has to mean delete in the capped
   selection AND in the raw-mirror fallback. Merging the object over the mirror
   (`{...mirror, ...overrides}`) silently gets that wrong: the key survives as an explicit `null`
   and the prompt renders `- Video → null`. The three deterministic consumers
   (`validate`, `enforce`, and the reviewer fallback) read through `enforceableOverrides`, which
   drops retractions, so a `null` can never become a requirement.

All five readers load one module, `site/scripts/i18n/glossary-overrides.cjs`. It is CommonJS
because node `require`s `.i18nrc.cjs` directly and that config cannot load a TypeScript module;
the four TypeScript scripts import the same file through tsx. JSDoc types keep the TS side fully
typed (`allowJs` is on), so `GlossaryOverrides` and both signatures still typecheck rather than
degrading to `any`. There is no second copy of the rules to drift.

## Verification

Built the glossary against the real ComfyUI_frontend locales and the committed English corpus:

```
overrides {}                -> 2003 effective pairs   (matches the failing run's own log line)
overrides with retractions  -> 2001 effective pairs

es 200 -> 198,  no video pair left,  `Top` NOT promoted
every other locale byte-identical (md5), so only es re-reviews
```

That last line is the safety property: the review cache is keyed per locale off that locale's
glossary, so the other nine keep their verdicts.

`.i18nrc.cjs` was additionally required from plain node CJS the way lobe-i18n loads it, with
`effective/` moved aside so the raw-mirror fallback runs: 2804 pairs, `Video` and `VIDEO`
retracted, no `- Video → null` rendered, `Workflow` retained.

Gate: **692 vitest passing** (6 of the new ones fail without this change, checked by reverting it;
breaking the retraction branch in the shared module fails both suites), eslint clean, prettier
clean, `astro check` 0 errors, `i18n:validate` no violations.

## What this does not fix

fr, tr, ar and pt-BR have not had their first re-review yet and will each spike once. Extra manual
dispatches shorten that wave. **Raising `I18N_REVIEW_MAX_ENTRIES` would not be safe**: the job sets
no `timeout-minutes`, and the 08-21 run took 5h50m against GitHub's 6h default.

## Two unrelated things found on the way, not touched here

- `site/i18n/glossary/preserve-terms.json` on main is missing the five lowercase task acronyms
  (`t2i`, `i2v`, `t2v`, `v2v`, `flf2v`) that `PRESERVE_TERMS` has carried since #1168. The nightly
  regenerates the file so CI never sees it, but `pnpm i18n:glossary` dirties a tracked file locally.
  Left alone because committing it would newly flag shipped zh content and turn this PR's validator
  red.
- zh translations contain spaces jammed inside words (`描述 性`), flagged repeatedly as
  `fluency/major`. Looks like a real glossary-insertion artefact in CJK.

## After merge

Re-dispatch Spanish alone to confirm the live number before trusting the nightly:

```
gh workflow run i18n-update-hub.yml -f locale=es
```

Expect `[i18n] enforce: [es] pruned ~381/4312 field(s) (~8.8%)`. Spanish re-reviews once, because
its own glossary fingerprint changes.


