### PR TITLE
perf(ci): sparse-checkout the PyPI publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0  # Full history needed for tags and version comparison
+          fetch-depth: 2  # HEAD and HEAD~1 for version comparison
           sparse-checkout: |
             pyproject.toml
             packages/*/pyproject.toml
@@ -211,16 +211,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0  # Full history needed for tags
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install Node dependencies
-        run: npm ci
+          # HEAD~1 is enough for changed-file detection. Full history plus
+          # input/, output/, site/, archived/, and thumbnail/ is ~3.3GB and
+          # is not used by the PyPI build.
+          fetch-depth: 2
+          sparse-checkout: |
+            templates
+            packages
+            scripts
+          # Cone mode always keeps root files (pyproject.toml, bundles.json,
+          # README.md, LICENSE, MANIFEST.in, setup.py).
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- `publish` was doing a full-history clone of the whole repo (~4GB). Checkout alone can sit for 10+ minutes.
- The wheel build only needs `templates/` (JSON + webp that get copied into packages), `packages/`, and `scripts/`. Root files like `pyproject.toml` / `bundles.json` / `README.md` stay via cone-mode.
- Skipped dirs: `input/` (~1.9GB), `output/` (~0.96GB), `thumbnail/` (~0.37GB), `docs/`, `site/`, `archived/` (~3.3GB together).
- `fetch-depth` is 2 (`HEAD` + `HEAD~1`) instead of full history. GitHub Release notes still come from the API.
- Dropped unused `npm ci` from this job (publish is Python `build` + `twine`).

## Test plan
- [ ] Confirm workflow YAML parses (this PR should not trigger Publish to PyPI; that only runs on `pyproject.toml` changes on main or `workflow_dispatch`).
- [ ] After merge, next `workflow_dispatch` of Publish to PyPI: Checkout should finish in ~1–2 minutes, not 10+.
- [ ] Confirm wheels still include template JSON/webp (sync_bundles copies from `templates/` into `packages/`).