### PR TITLE
Add duplicate thumbnail validation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -51,11 +51,16 @@ Validates model specifications in workflow templates.
 
 Validates template JSON structure, thumbnails, and checks for third-party nodes.
 
-### 4. Publish (`publish.yml`)
+### 4. Duplicate Thumbnails (`check-duplicate-thumbnails.yml`)
+
+Checks image thumbnails changed by a pull request for byte-identical or visually equivalent images
+owned by another template. Existing legacy duplicate groups do not fail unrelated pull requests.
+
+### 5. Publish (`publish.yml`)
 
 Publishes approved templates to the registry.
 
-### 5. ComfyUI Node Compatibility Report (`report-comfyui-node-compat.yml`)
+### 6. ComfyUI Node Compatibility Report (`report-comfyui-node-compat.yml`)
 
 Informational check — **never blocks PR merges**. Compares changed `templates/*.json` against ComfyUI `master` via static source scan (no torch, no running server).
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -51,16 +51,11 @@ Validates model specifications in workflow templates.
 
 Validates template JSON structure, thumbnails, and checks for third-party nodes.
 
-### 4. Duplicate Thumbnails (`check-duplicate-thumbnails.yml`)
-
-Checks image thumbnails changed by a pull request for byte-identical or visually equivalent images
-owned by another template. Existing legacy duplicate groups do not fail unrelated pull requests.
-
-### 5. Publish (`publish.yml`)
+### 4. Publish (`publish.yml`)
 
 Publishes approved templates to the registry.
 
-### 6. ComfyUI Node Compatibility Report (`report-comfyui-node-compat.yml`)
+### 5. ComfyUI Node Compatibility Report (`report-comfyui-node-compat.yml`)
 
 Informational check — **never blocks PR merges**. Compares changed `templates/*.json` against ComfyUI `master` via static source scan (no torch, no running server).
 

--- a/.github/workflows/check-duplicate-thumbnails.yml
+++ b/.github/workflows/check-duplicate-thumbnails.yml
@@ -1,0 +1,55 @@
+name: Check Duplicate Thumbnails
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - 'templates/index.json'
+      - 'templates/*.webp'
+      - 'templates/**/*.webp'
+      - 'templates/*.png'
+      - 'templates/**/*.png'
+      - 'templates/*.jpg'
+      - 'templates/**/*.jpg'
+      - 'templates/*.jpeg'
+      - 'templates/**/*.jpeg'
+      - 'templates/*.avif'
+      - 'templates/**/*.avif'
+      - 'scripts/validate/check_duplicate_thumbnails.py'
+      - 'packages/core/tests/test_duplicate_thumbnails.py'
+      - '.github/workflows/check-duplicate-thumbnails.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  duplicate-thumbnails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # PR checkouts are merge commits. Depth 2 includes the base parent,
+          # avoiding a costly full-history fetch in this media-heavy repository.
+          fetch-depth: 2
+          sparse-checkout: |
+            templates/
+            scripts/lib/paths.py
+            scripts/validate/check_duplicate_thumbnails.py
+            packages/core/tests/test_duplicate_thumbnails.py
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install lightweight image-check dependencies
+        run: python -m pip install Pillow pytest
+
+      - name: Test duplicate thumbnail checker
+        run: python -m pytest -q packages/core/tests/test_duplicate_thumbnails.py
+
+      - name: Reject changed cross-template duplicates
+        run: python scripts/validate/check_duplicate_thumbnails.py --base-ref HEAD^1

--- a/.github/workflows/check-duplicate-thumbnails.yml
+++ b/.github/workflows/check-duplicate-thumbnails.yml
@@ -6,15 +6,10 @@ on:
     branches: [main]
     paths:
       - 'templates/index.json'
-      - 'templates/*.webp'
       - 'templates/**/*.webp'
-      - 'templates/*.png'
       - 'templates/**/*.png'
-      - 'templates/*.jpg'
       - 'templates/**/*.jpg'
-      - 'templates/*.jpeg'
       - 'templates/**/*.jpeg'
-      - 'templates/*.avif'
       - 'templates/**/*.avif'
       - 'scripts/validate/check_duplicate_thumbnails.py'
       - 'packages/core/tests/test_duplicate_thumbnails.py'
@@ -30,8 +25,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # PR checkouts are merge commits. Depth 2 includes the base parent,
-          # avoiding a costly full-history fetch in this media-heavy repository.
           fetch-depth: 2
           sparse-checkout: |
             templates/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
 - `python scripts/sync/sync_bundles.py` — Same as `npm run sync:bundles`
 - `python scripts/sync/sync_is_app.py` — Write `isApp` into `index.json` from each workflow's `extra.linearMode` (`--dry-run` to report, `--check` for the CI gate)
 - `python scripts/validate/validate_templates.py` — Same as `npm run validate:templates`
+- `python scripts/validate/check_duplicate_thumbnails.py --audit` — Report all byte-identical and visually equivalent cross-template thumbnails (requires Pillow)
+- `python scripts/validate/check_duplicate_thumbnails.py --base-ref origin/main` — Fail only for duplicate groups involving thumbnail changes since the branch base
 - `python scripts/comfyui_node_compat/check.py --static-scan --clone-comfyui --no-fail` — CI-style static compat scan
 - `python scripts/sync/sync_frozen_inventory.py` — Regenerate frozen bundle template inventory from `bundles.json`
 - `python scripts/ci/check_frozen_policy.py --base-ref origin/main` — Dry-run frozen-bundle PR reminder locally
@@ -128,6 +130,7 @@ For full site-specific instructions, see `site/AGENTS.md`.
 ## Code Style
 - **Python**: Ruff linter, line-length 100, target py312. Select rules: E, F
 - **Templates**: JSON workflow files with embedded model metadata. Thumbnails named `{template}-1.webp`
+- **Thumbnail changes**: Whenever adding or changing an implicit `{template}-N.webp` thumbnail or an image path in `templates/index.json`'s `thumbnail` field, run `python scripts/validate/check_duplicate_thumbnails.py --base-ref origin/main`. Install Pillow first if needed (`python -m pip install Pillow`). Use `--audit` to inspect all legacy duplicates.
 - **Naming**: snake_case for Python/templates
 - Bump root `pyproject.toml` version only when intentionally releasing to PyPI (`release` label). Template-only / archive PRs usually leave the root version unchanged.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - `python scripts/sync/sync_is_app.py` — Write `isApp` into `index.json` from each workflow's `extra.linearMode` (`--dry-run` to report, `--check` for the CI gate)
 - `python scripts/validate/validate_templates.py` — Same as `npm run validate:templates`
 - `python scripts/validate/check_duplicate_thumbnails.py --audit` — Report all byte-identical and visually equivalent cross-template thumbnails (requires Pillow)
-- `python scripts/validate/check_duplicate_thumbnails.py --base-ref origin/main` — Fail only for duplicate groups involving thumbnail changes since the branch base
+- `python scripts/validate/check_duplicate_thumbnails.py --base-ref origin/main` — Fail only for duplicate pairs involving thumbnail changes since the branch base
 - `python scripts/comfyui_node_compat/check.py --static-scan --clone-comfyui --no-fail` — CI-style static compat scan
 - `python scripts/sync/sync_frozen_inventory.py` — Regenerate frozen bundle template inventory from `bundles.json`
 - `python scripts/ci/check_frozen_policy.py --base-ref origin/main` — Dry-run frozen-bundle PR reminder locally

--- a/packages/core/tests/test_duplicate_thumbnails.py
+++ b/packages/core/tests/test_duplicate_thumbnails.py
@@ -1,0 +1,162 @@
+"""Focused tests for the cross-template thumbnail duplicate checker."""
+
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_spec = importlib.util.spec_from_file_location(
+    "check_duplicate_thumbnails",
+    REPO_ROOT / "scripts" / "validate" / "check_duplicate_thumbnails.py",
+)
+duplicate_thumbnails = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = duplicate_thumbnails
+_spec.loader.exec_module(duplicate_thumbnails)
+
+
+def _patterned_image(size: int) -> Image.Image:
+    image = Image.new("RGB", (size, size))
+    pixels = image.load()
+    for y in range(size):
+        for x in range(size):
+            pixels[x, y] = (
+                (x * 2 + y) % 256,
+                (x + y * 2) % 256,
+                (x + y) % 256,
+            )
+    ImageDraw.Draw(image).ellipse(
+        (size // 4, size // 4, 3 * size // 4, 3 * size // 4),
+        fill=(220, 90, 40),
+    )
+    return image
+
+
+def _asset(template_id: str, path: Path) -> duplicate_thumbnails.ThumbnailAsset:
+    return duplicate_thumbnails.ThumbnailAsset(template_id, path.resolve())
+
+
+def test_discovers_explicit_images_and_exact_implicit_numeric_variants(tmp_path):
+    explicit_dir = tmp_path / "thumbnail"
+    explicit_dir.mkdir()
+    (explicit_dir / "custom.png").touch()
+    (tmp_path / "alpha-1.webp").touch()
+    (tmp_path / "alpha-2.webp").touch()
+    (tmp_path / "alpha_extra-1.webp").touch()
+
+    entries = [
+        {"name": "alpha", "thumbnail": ["thumbnail/custom.png", "output/movie.mp4"]},
+        {"name": "alpha_extra"},
+    ]
+
+    assets = duplicate_thumbnails.discover_thumbnail_assets(tmp_path, entries)
+    resolved = {(asset.template_id, asset.path.name) for asset in assets}
+
+    assert resolved == {
+        ("alpha", "custom.png"),
+        ("alpha", "alpha-1.webp"),
+        ("alpha", "alpha-2.webp"),
+        ("alpha_extra", "alpha_extra-1.webp"),
+    }
+
+
+def test_finds_byte_identical_images_across_templates(tmp_path):
+    first = tmp_path / "alpha-1.webp"
+    second = tmp_path / "beta-1.webp"
+    _patterned_image(80).save(first, "WEBP", lossless=True)
+    shutil.copyfile(first, second)
+
+    groups = duplicate_thumbnails.find_duplicate_groups(
+        [_asset("alpha", first), _asset("beta", second)]
+    )
+
+    assert len(groups) == 1
+    assert groups[0].kinds == ("byte-identical",)
+
+
+def test_finds_same_visual_reencoded_at_a_different_size(tmp_path):
+    large = tmp_path / "alpha-1.webp"
+    small = tmp_path / "beta-1.webp"
+    image = _patterned_image(128)
+    image.save(large, "WEBP", lossless=True)
+    image.resize((64, 64), Image.Resampling.LANCZOS).save(small, "WEBP", lossless=True, method=6)
+
+    assert large.read_bytes() != small.read_bytes()
+    groups = duplicate_thumbnails.find_duplicate_groups(
+        [_asset("alpha", large), _asset("beta", small)]
+    )
+
+    assert len(groups) == 1
+    assert groups[0].kinds == ("visually equivalent",)
+
+
+def test_does_not_flag_multiple_assets_owned_by_one_template(tmp_path):
+    first = tmp_path / "alpha-1.webp"
+    second = tmp_path / "alpha-2.webp"
+    _patterned_image(80).save(first, "WEBP", lossless=True)
+    shutil.copyfile(first, second)
+
+    groups = duplicate_thumbnails.find_duplicate_groups(
+        [_asset("alpha", first), _asset("alpha", second)]
+    )
+
+    assert groups == []
+
+
+def test_does_not_flag_a_localized_visible_difference(tmp_path):
+    first = tmp_path / "alpha-1.webp"
+    second = tmp_path / "beta-1.webp"
+    left = Image.new("RGB", (350, 350), "black")
+    right = left.copy()
+    ImageDraw.Draw(right).rectangle((145, 260, 205, 275), fill="white")
+    left.save(first, "WEBP", lossless=True)
+    right.save(second, "WEBP", lossless=True)
+
+    groups = duplicate_thumbnails.find_duplicate_groups(
+        [_asset("alpha", first), _asset("beta", second)]
+    )
+
+    assert groups == []
+
+
+def test_only_thumbnail_mapping_changes_mark_an_existing_template_changed():
+    base = [
+        {"name": "same", "description": "old", "thumbnail": ["thumbnail/a.png"]},
+        {"name": "remapped", "thumbnail": ["thumbnail/old.png"]},
+    ]
+    current = [
+        {"name": "same", "description": "new", "thumbnail": ["thumbnail/a.png"]},
+        {"name": "remapped", "thumbnail": ["thumbnail/new.png"]},
+        {"name": "added"},
+    ]
+
+    changed = duplicate_thumbnails.changed_thumbnail_templates(base, current)
+
+    assert changed == {"remapped", "added"}
+
+
+def test_changed_file_filter_ignores_unrelated_legacy_groups(tmp_path):
+    legacy_left = _asset("legacy_a", tmp_path / "legacy_a-1.webp")
+    legacy_right = _asset("legacy_b", tmp_path / "legacy_b-1.webp")
+    group = duplicate_thumbnails.DuplicateGroup(
+        assets=(legacy_left, legacy_right),
+        matches=(
+            duplicate_thumbnails.DuplicateMatch(legacy_left, legacy_right, "byte-identical", 0.0),
+        ),
+    )
+
+    assert not duplicate_thumbnails.group_touches_changes(
+        group,
+        tmp_path,
+        {"templates/unrelated-1.webp"},
+        set(),
+    )
+    assert duplicate_thumbnails.group_touches_changes(
+        group,
+        tmp_path,
+        {"legacy_a-1.webp"},
+        set(),
+    )

--- a/packages/core/tests/test_duplicate_thumbnails.py
+++ b/packages/core/tests/test_duplicate_thumbnails.py
@@ -1,4 +1,4 @@
-"""Focused tests for the cross-template thumbnail duplicate checker."""
+"""Tests for the cross-template thumbnail duplicate checker."""
 
 import importlib.util
 import shutil
@@ -8,54 +8,44 @@ from pathlib import Path
 from PIL import Image, ImageDraw
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-
 _spec = importlib.util.spec_from_file_location(
     "check_duplicate_thumbnails",
     REPO_ROOT / "scripts" / "validate" / "check_duplicate_thumbnails.py",
 )
-duplicate_thumbnails = importlib.util.module_from_spec(_spec)
-sys.modules[_spec.name] = duplicate_thumbnails
-_spec.loader.exec_module(duplicate_thumbnails)
+checker = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = checker
+_spec.loader.exec_module(checker)
 
 
-def _patterned_image(size: int) -> Image.Image:
-    image = Image.new("RGB", (size, size))
-    pixels = image.load()
-    for y in range(size):
-        for x in range(size):
-            pixels[x, y] = (
-                (x * 2 + y) % 256,
-                (x + y * 2) % 256,
-                (x + y) % 256,
-            )
+def patterned_image(size: int) -> Image.Image:
+    image = Image.linear_gradient("L").resize((size, size)).convert("RGB")
     ImageDraw.Draw(image).ellipse(
-        (size // 4, size // 4, 3 * size // 4, 3 * size // 4),
-        fill=(220, 90, 40),
+        (size // 4, size // 4, 3 * size // 4, 3 * size // 4), fill=(220, 90, 40)
     )
     return image
 
 
-def _asset(template_id: str, path: Path) -> duplicate_thumbnails.ThumbnailAsset:
-    return duplicate_thumbnails.ThumbnailAsset(template_id, path.resolve())
+def asset(template_id: str, path: Path):
+    return template_id, path.resolve()
 
 
-def test_discovers_explicit_images_and_exact_implicit_numeric_variants(tmp_path):
-    explicit_dir = tmp_path / "thumbnail"
-    explicit_dir.mkdir()
-    (explicit_dir / "custom.png").touch()
+def test_finds_explicit_images_and_exact_implicit_names(tmp_path):
+    thumbnail_dir = tmp_path / "thumbnail"
+    thumbnail_dir.mkdir()
+    (thumbnail_dir / "custom.png").touch()
     (tmp_path / "alpha-1.webp").touch()
     (tmp_path / "alpha-2.webp").touch()
     (tmp_path / "alpha_extra-1.webp").touch()
-
     entries = [
         {"name": "alpha", "thumbnail": ["thumbnail/custom.png", "output/movie.mp4"]},
         {"name": "alpha_extra"},
     ]
 
-    assets = duplicate_thumbnails.discover_thumbnail_assets(tmp_path, entries)
-    resolved = {(asset.template_id, asset.path.name) for asset in assets}
+    found = {
+        (template_id, path.name) for template_id, path in checker.find_assets(tmp_path, entries)
+    }
 
-    assert resolved == {
+    assert found == {
         ("alpha", "custom.png"),
         ("alpha", "alpha-1.webp"),
         ("alpha", "alpha-2.webp"),
@@ -64,99 +54,59 @@ def test_discovers_explicit_images_and_exact_implicit_numeric_variants(tmp_path)
 
 
 def test_finds_byte_identical_images_across_templates(tmp_path):
-    first = tmp_path / "alpha-1.webp"
-    second = tmp_path / "beta-1.webp"
-    _patterned_image(80).save(first, "WEBP", lossless=True)
+    first = tmp_path / "alpha.webp"
+    second = tmp_path / "beta.webp"
+    patterned_image(80).save(first, "WEBP", lossless=True)
     shutil.copyfile(first, second)
 
-    groups = duplicate_thumbnails.find_duplicate_groups(
-        [_asset("alpha", first), _asset("beta", second)]
-    )
+    duplicates = checker.find_duplicates([asset("alpha", first), asset("beta", second)])
 
-    assert len(groups) == 1
-    assert groups[0].kinds == ("byte-identical",)
+    assert [duplicate[2] for duplicate in duplicates] == ["byte-identical"]
 
 
 def test_finds_same_visual_reencoded_at_a_different_size(tmp_path):
-    large = tmp_path / "alpha-1.webp"
-    small = tmp_path / "beta-1.webp"
-    image = _patterned_image(128)
+    large = tmp_path / "alpha.webp"
+    small = tmp_path / "beta.webp"
+    image = patterned_image(128)
     image.save(large, "WEBP", lossless=True)
-    image.resize((64, 64), Image.Resampling.LANCZOS).save(small, "WEBP", lossless=True, method=6)
+    image.resize((64, 64), Image.Resampling.LANCZOS).save(small, "WEBP", lossless=True)
 
     assert large.read_bytes() != small.read_bytes()
-    groups = duplicate_thumbnails.find_duplicate_groups(
-        [_asset("alpha", large), _asset("beta", small)]
+    duplicates = checker.find_duplicates([asset("alpha", large), asset("beta", small)])
+
+    assert [duplicate[2] for duplicate in duplicates] == ["visually equivalent"]
+
+
+def test_ignores_same_template_and_visible_differences(tmp_path):
+    first = tmp_path / "first.webp"
+    same = tmp_path / "same.webp"
+    different = tmp_path / "different.webp"
+    image = Image.new("RGB", (350, 350), "black")
+    image.save(first, "WEBP", lossless=True)
+    shutil.copyfile(first, same)
+    ImageDraw.Draw(image).rectangle((145, 260, 205, 275), fill="white")
+    image.save(different, "WEBP", lossless=True)
+
+    assert checker.find_duplicates([asset("alpha", first), asset("alpha", same)]) == []
+    assert checker.find_duplicates([asset("alpha", first), asset("beta", different)]) == []
+
+
+def test_explicit_image_config_ignores_unrelated_metadata():
+    base = {"name": "demo", "description": "old", "thumbnail": ["thumbnail/a.png"]}
+    same_mapping = {"name": "demo", "description": "new", "thumbnail": ["thumbnail/a.png"]}
+    changed_mapping = {"name": "demo", "thumbnail": ["thumbnail/b.png"]}
+
+    assert checker.explicit_images(base) == checker.explicit_images(same_mapping)
+    assert checker.explicit_images(base) != checker.explicit_images(changed_mapping)
+
+
+def test_only_related_changes_block_a_duplicate_pair():
+    duplicate = (
+        ("alpha", REPO_ROOT / "templates/alpha-1.webp"),
+        ("beta", REPO_ROOT / "templates/beta-1.webp"),
+        "byte-identical",
     )
 
-    assert len(groups) == 1
-    assert groups[0].kinds == ("visually equivalent",)
-
-
-def test_does_not_flag_multiple_assets_owned_by_one_template(tmp_path):
-    first = tmp_path / "alpha-1.webp"
-    second = tmp_path / "alpha-2.webp"
-    _patterned_image(80).save(first, "WEBP", lossless=True)
-    shutil.copyfile(first, second)
-
-    groups = duplicate_thumbnails.find_duplicate_groups(
-        [_asset("alpha", first), _asset("alpha", second)]
-    )
-
-    assert groups == []
-
-
-def test_does_not_flag_a_localized_visible_difference(tmp_path):
-    first = tmp_path / "alpha-1.webp"
-    second = tmp_path / "beta-1.webp"
-    left = Image.new("RGB", (350, 350), "black")
-    right = left.copy()
-    ImageDraw.Draw(right).rectangle((145, 260, 205, 275), fill="white")
-    left.save(first, "WEBP", lossless=True)
-    right.save(second, "WEBP", lossless=True)
-
-    groups = duplicate_thumbnails.find_duplicate_groups(
-        [_asset("alpha", first), _asset("beta", second)]
-    )
-
-    assert groups == []
-
-
-def test_only_thumbnail_mapping_changes_mark_an_existing_template_changed():
-    base = [
-        {"name": "same", "description": "old", "thumbnail": ["thumbnail/a.png"]},
-        {"name": "remapped", "thumbnail": ["thumbnail/old.png"]},
-    ]
-    current = [
-        {"name": "same", "description": "new", "thumbnail": ["thumbnail/a.png"]},
-        {"name": "remapped", "thumbnail": ["thumbnail/new.png"]},
-        {"name": "added"},
-    ]
-
-    changed = duplicate_thumbnails.changed_thumbnail_templates(base, current)
-
-    assert changed == {"remapped", "added"}
-
-
-def test_changed_file_filter_ignores_unrelated_legacy_groups(tmp_path):
-    legacy_left = _asset("legacy_a", tmp_path / "legacy_a-1.webp")
-    legacy_right = _asset("legacy_b", tmp_path / "legacy_b-1.webp")
-    group = duplicate_thumbnails.DuplicateGroup(
-        assets=(legacy_left, legacy_right),
-        matches=(
-            duplicate_thumbnails.DuplicateMatch(legacy_left, legacy_right, "byte-identical", 0.0),
-        ),
-    )
-
-    assert not duplicate_thumbnails.group_touches_changes(
-        group,
-        tmp_path,
-        {"templates/unrelated-1.webp"},
-        set(),
-    )
-    assert duplicate_thumbnails.group_touches_changes(
-        group,
-        tmp_path,
-        {"legacy_a-1.webp"},
-        set(),
-    )
+    assert checker.touches_changes(duplicate, {"templates/alpha-1.webp"}, set())
+    assert checker.touches_changes(duplicate, set(), {"beta"})
+    assert not checker.touches_changes(duplicate, {"templates/unrelated-1.webp"}, set())

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -107,27 +107,22 @@ Generated output goes to `scripts/.output/` (gitignored) or repo root (`model_an
 
 ## Duplicate thumbnail check
 
-Install the single image dependency, then audit every effective image thumbnail:
+Install Pillow, then audit every effective image thumbnail:
 
 ```bash
 python -m pip install Pillow
 python scripts/validate/check_duplicate_thumbnails.py --audit
 ```
 
-The checker includes both image paths declared by `thumbnail` in `templates/index.json` and
-implicit `{template}-N.webp` assets. It reports byte-identical files and strict perceptual matches
-that remain visually equivalent after resizing or re-encoding. Multiple assets owned by the same
-template are never treated as cross-template duplicates.
-
-The repository contains legacy duplicate groups, so audit mode reports without failing. Before
-committing a thumbnail change, use the same changed-files gate as CI:
+The checker covers explicit image paths in `templates/index.json` and implicit
+`{template}-N.webp` assets, while ignoring multiple images owned by one template. Audit mode
+reports legacy duplicates without failing. Before committing a thumbnail change, run the CI gate:
 
 ```bash
 python scripts/validate/check_duplicate_thumbnails.py --base-ref origin/main
 ```
 
-That mode fails only when a duplicate group contains a changed image asset, a new template, or a
-changed explicit image-thumbnail mapping. Unrelated legacy groups are summarized and ignored.
+It fails only for duplicate pairs involving a changed asset or image-thumbnail mapping.
 
 ## ComfyUI node compatibility check
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ Python maintenance scripts for ComfyUI workflow templates (packages, CI, i18n).
 | Sync App Mode flag | `python scripts/sync/sync_is_app.py` (`--dry-run`, `--check`) |
 | Validate templates | `python scripts/validate/validate_templates.py` |
 | Validate manifests | `python scripts/validate/validate_manifests.py` |
+| Audit duplicate thumbnails | `python scripts/validate/check_duplicate_thumbnails.py --audit` |
 | ComfyUI node compatibility | `npm run validate:comfyui-nodes` |
 | Maintainer smoke check | `./scripts/maintenance/check_templates.sh` |
 
@@ -59,6 +60,7 @@ Also runs workflow I/O extraction via `generate_workflow_io.py` before locale sy
 | Workflow | Scripts |
 |----------|---------|
 | `validate-templates.yml` | `validate/validate_templates.py`, `validate/validate_thumbnails.py`, `lib/locale_index_files.py` |
+| `check-duplicate-thumbnails.yml` | `validate/check_duplicate_thumbnails.py` |
 | `validate-manifests.yml` | `sync/sync_bundles.py`, `sync/sync_blueprints.py`, `validate/validate_manifests.py`, `validate/list_pip_excluded.py` |
 | `validate-blueprints.yml` | `validate/validate_blueprints.py`, `blueprints/import_blueprints.py`, `sync/sync_blueprints.py` |
 | `link-checker.yml` | `validate/check_links.py`, `data/whitelist.json` |
@@ -102,6 +104,30 @@ npm run mcp:models   # AI model registry
 - **`data/krea_registry_aliases.json`**, **`data/krea_*_models.json`** — Temporary Krea snapshots for one-off registry seeding (delete when seeding is complete).
 
 Generated output goes to `scripts/.output/` (gitignored) or repo root (`model_analysis_report.md`, `asset_validation_report.md`, `comfyui-node-compat.log`, `comfyui-node-compat.latest.log`).
+
+## Duplicate thumbnail check
+
+Install the single image dependency, then audit every effective image thumbnail:
+
+```bash
+python -m pip install Pillow
+python scripts/validate/check_duplicate_thumbnails.py --audit
+```
+
+The checker includes both image paths declared by `thumbnail` in `templates/index.json` and
+implicit `{template}-N.webp` assets. It reports byte-identical files and strict perceptual matches
+that remain visually equivalent after resizing or re-encoding. Multiple assets owned by the same
+template are never treated as cross-template duplicates.
+
+The repository contains legacy duplicate groups, so audit mode reports without failing. Before
+committing a thumbnail change, use the same changed-files gate as CI:
+
+```bash
+python scripts/validate/check_duplicate_thumbnails.py --base-ref origin/main
+```
+
+That mode fails only when a duplicate group contains a changed image asset, a new template, or a
+changed explicit image-thumbnail mapping. Unrelated legacy groups are summarized and ignored.
 
 ## ComfyUI node compatibility check
 

--- a/scripts/validate/check_duplicate_thumbnails.py
+++ b/scripts/validate/check_duplicate_thumbnails.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Find byte-identical and visually equivalent thumbnails across templates.
-
-The repository has historical duplicate thumbnails, so CI uses ``--base-ref``
-to fail only when a duplicate group involves a changed asset or thumbnail
-mapping. ``--audit`` reports the entire current corpus without failing.
-"""
+"""Find duplicate-looking image thumbnails owned by different templates."""
 
 from __future__ import annotations
 
@@ -14,14 +9,12 @@ import json
 import math
 import subprocess
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Sequence
 
 try:
-    from PIL import Image, ImageOps, UnidentifiedImageError
-except ModuleNotFoundError as exc:  # pragma: no cover - exercised before module import
-    raise SystemExit("Pillow is required. Install it with `python -m pip install Pillow`.") from exc
+    from PIL import Image, ImageOps
+except ModuleNotFoundError as exc:  # pragma: no cover
+    raise SystemExit("Install Pillow first: `python -m pip install Pillow`.") from exc
 
 _lib_dir = Path(__file__).resolve().parent.parent / "lib"
 if str(_lib_dir) not in sys.path:
@@ -30,316 +23,147 @@ if str(_lib_dir) not in sys.path:
 from paths import REPO_ROOT, TEMPLATES_DIR  # noqa: E402
 
 
-IMAGE_SUFFIXES = frozenset({".avif", ".jpeg", ".jpg", ".png", ".webp"})
-IMPLICIT_THUMBNAIL_SUFFIX = ".webp"
+IMAGE_SUFFIXES = {".avif", ".jpeg", ".jpg", ".png", ".webp"}
 HASH_SIZE = 16
 NORMALIZED_SIZE = 32
+MAX_HASH_DISTANCE = 16
+MAX_PIXEL_DELTA = 16
+MAX_PIXEL_RMS = 3.0
 
-# Perceptual hashes cheaply narrow the pair candidates. Pixel comparison then
-# keeps the definition intentionally strict: equivalent encodings/resolutions,
-# not two thumbnails that merely share a layout or background.
-MAX_DIFFERENCE_HASH_DISTANCE = 16
-MAX_AVERAGE_HASH_DISTANCE = 8
-MAX_CHANNEL_MEAN_DELTA = 4.0
-MAX_NORMALIZED_RMS = 3.0
-MAX_NORMALIZED_CHANNEL_DELTA = 16
+Asset = tuple[str, Path]
+Fingerprint = tuple[str, int, bytes]
+Duplicate = tuple[Asset, Asset, str]
 
 
-@dataclass(frozen=True)
-class ThumbnailAsset:
-    template_id: str
-    path: Path
+def entries_from_json(data: object) -> list[dict]:
+    if not isinstance(data, list):
+        raise ValueError("templates/index.json must contain a list of categories")
+    return [
+        template
+        for category in data
+        if isinstance(category, dict)
+        for template in category.get("templates", [])
+        if isinstance(template, dict) and isinstance(template.get("name"), str)
+    ]
 
 
-@dataclass(frozen=True)
-class ThumbnailFingerprint:
-    asset: ThumbnailAsset
-    byte_digest: str
-    difference_hash: int
-    average_hash: int
-    channel_means: tuple[float, float, float]
-    normalized_pixels: bytes
-
-
-@dataclass(frozen=True)
-class DuplicateMatch:
-    left: ThumbnailAsset
-    right: ThumbnailAsset
-    kind: str
-    normalized_rms: float
-
-
-@dataclass(frozen=True)
-class DuplicateGroup:
-    assets: tuple[ThumbnailAsset, ...]
-    matches: tuple[DuplicateMatch, ...]
-
-    @property
-    def kinds(self) -> tuple[str, ...]:
-        return tuple(sorted({match.kind for match in self.matches}))
-
-
-def load_template_entries(index_path: Path) -> list[dict]:
-    """Return template entries from every category in an index file."""
+def load_entries(index_path: Path) -> list[dict]:
     with index_path.open(encoding="utf-8") as index_file:
-        categories = json.load(index_file)
-
-    if not isinstance(categories, list):
-        raise ValueError(f"{index_path} must contain a list of categories")
-
-    entries = []
-    for category in categories:
-        if not isinstance(category, dict):
-            continue
-        for template in category.get("templates", []):
-            if isinstance(template, dict) and isinstance(template.get("name"), str):
-                entries.append(template)
-    return entries
+        return entries_from_json(json.load(index_file))
 
 
-def _safe_explicit_thumbnail(templates_dir: Path, relative_path: str) -> Path | None:
-    """Resolve an explicit image thumbnail without allowing it outside templates/."""
-    candidate = (templates_dir / relative_path).resolve()
-    try:
-        candidate.relative_to(templates_dir.resolve())
-    except ValueError:
-        return None
-    if candidate.suffix.lower() not in IMAGE_SUFFIXES or not candidate.is_file():
-        return None
-    return candidate
-
-
-def discover_thumbnail_assets(templates_dir: Path, entries: Sequence[dict]) -> list[ThumbnailAsset]:
-    """Resolve explicit image thumbnails and implicit ``{template}-N.webp`` files."""
-    paths_by_template: dict[str, set[Path]] = {}
+def find_assets(templates_dir: Path, entries: list[dict]) -> list[Asset]:
+    """Find explicit image paths and implicit ``{template}-N.webp`` assets."""
+    templates_dir = templates_dir.resolve()
+    paths_by_template = {entry["name"]: set() for entry in entries}
 
     for entry in entries:
-        template_id = entry["name"]
-        template_paths = paths_by_template.setdefault(template_id, set())
-        explicit = entry.get("thumbnail", [])
-        if not isinstance(explicit, list):
+        thumbnail_paths = entry.get("thumbnail", [])
+        if not isinstance(thumbnail_paths, list):
             continue
-        for relative_path in explicit:
+        for relative_path in thumbnail_paths:
             if not isinstance(relative_path, str):
                 continue
-            thumbnail = _safe_explicit_thumbnail(templates_dir, relative_path)
-            if thumbnail is not None:
-                template_paths.add(thumbnail)
+            path = (templates_dir / relative_path).resolve()
+            try:
+                path.relative_to(templates_dir)
+            except ValueError:
+                continue
+            if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES:
+                paths_by_template[entry["name"]].add(path)
 
-    # Match the numeric suffix exactly so template-name prefixes cannot claim
-    # another template's asset (for example ``foo`` must not claim ``foo_bar-1``).
     template_ids = set(paths_by_template)
-    for path in templates_dir.iterdir():
-        if not path.is_file() or path.suffix.lower() != IMPLICIT_THUMBNAIL_SUFFIX:
-            continue
-        owner, separator, number = path.stem.rpartition("-")
-        if separator and number.isdigit() and owner in template_ids:
-            paths_by_template[owner].add(path.resolve())
+    for path in templates_dir.glob("*.webp"):
+        template_id, separator, number = path.stem.rpartition("-")
+        if separator and number.isdigit() and template_id in template_ids:
+            paths_by_template[template_id].add(path.resolve())
 
     return [
-        ThumbnailAsset(template_id, path)
+        (template_id, path)
         for template_id, paths in sorted(paths_by_template.items())
         for path in sorted(paths)
     ]
 
 
-def _bits_from_comparisons(values: Sequence[int], width: int, height: int) -> int:
-    result = 0
-    row_width = width + 1
-    for y in range(height):
-        for x in range(width):
-            if values[y * row_width + x] > values[y * row_width + x + 1]:
-                result |= 1 << (y * width + x)
-    return result
-
-
-def fingerprint_asset(asset: ThumbnailAsset) -> ThumbnailFingerprint:
-    """Build byte and perceptual fingerprints for one image asset."""
-    image_bytes = asset.path.read_bytes()
-    byte_digest = hashlib.sha256(image_bytes).hexdigest()
-
+def fingerprint(path: Path) -> Fingerprint:
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
     try:
-        with Image.open(asset.path) as source:
+        with Image.open(path) as source:
             image = ImageOps.exif_transpose(source).convert("RGB")
-    except (OSError, UnidentifiedImageError) as exc:
-        raise ValueError(f"Cannot decode thumbnail {asset.path}: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"Cannot decode {path}: {exc}") from exc
 
     normalized = image.resize((NORMALIZED_SIZE, NORMALIZED_SIZE), Image.Resampling.LANCZOS)
     normalized_pixels = normalized.tobytes()
-    pixel_count = NORMALIZED_SIZE * NORMALIZED_SIZE
-    channel_means = tuple(sum(normalized_pixels[channel::3]) / pixel_count for channel in range(3))
-
-    difference_image = image.convert("L").resize(
-        (HASH_SIZE + 1, HASH_SIZE), Image.Resampling.LANCZOS
+    grayscale = image.convert("L").resize((HASH_SIZE + 1, HASH_SIZE), Image.Resampling.LANCZOS)
+    values = list(grayscale.getdata())
+    row_width = HASH_SIZE + 1
+    difference_hash = sum(
+        (values[y * row_width + x] > values[y * row_width + x + 1]) << (y * HASH_SIZE + x)
+        for y in range(HASH_SIZE)
+        for x in range(HASH_SIZE)
     )
-    difference_hash = _bits_from_comparisons(list(difference_image.getdata()), HASH_SIZE, HASH_SIZE)
-
-    average_image = image.convert("L").resize((HASH_SIZE, HASH_SIZE), Image.Resampling.LANCZOS)
-    average_pixels = list(average_image.getdata())
-    average = sum(average_pixels) / len(average_pixels)
-    average_hash = sum((pixel > average) << index for index, pixel in enumerate(average_pixels))
-
-    return ThumbnailFingerprint(
-        asset=asset,
-        byte_digest=byte_digest,
-        difference_hash=difference_hash,
-        average_hash=average_hash,
-        channel_means=channel_means,
-        normalized_pixels=normalized_pixels,
-    )
+    return digest, difference_hash, normalized_pixels
 
 
-def _visual_distance(left: ThumbnailFingerprint, right: ThumbnailFingerprint) -> float | None:
-    if (left.difference_hash ^ right.difference_hash).bit_count() > MAX_DIFFERENCE_HASH_DISTANCE:
-        return None
-    if (left.average_hash ^ right.average_hash).bit_count() > MAX_AVERAGE_HASH_DISTANCE:
-        return None
-    if (
-        max(
-            abs(left_mean - right_mean)
-            for left_mean, right_mean in zip(left.channel_means, right.channel_means)
-        )
-        > MAX_CHANNEL_MEAN_DELTA
-    ):
-        return None
+def visually_same(left: Fingerprint, right: Fingerprint) -> bool:
+    if (left[1] ^ right[1]).bit_count() > MAX_HASH_DISTANCE:
+        return False
 
     squared_error = 0
-    for left_pixel, right_pixel in zip(left.normalized_pixels, right.normalized_pixels):
+    for left_pixel, right_pixel in zip(left[2], right[2]):
         delta = abs(left_pixel - right_pixel)
-        if delta > MAX_NORMALIZED_CHANNEL_DELTA:
-            return None
+        if delta > MAX_PIXEL_DELTA:
+            return False
         squared_error += delta * delta
-    normalized_rms = math.sqrt(squared_error / len(left.normalized_pixels))
-    if normalized_rms > MAX_NORMALIZED_RMS:
-        return None
-    return normalized_rms
+    return math.sqrt(squared_error / len(left[2])) <= MAX_PIXEL_RMS
 
 
-def find_duplicate_matches(
-    fingerprints: Sequence[ThumbnailFingerprint],
-) -> list[DuplicateMatch]:
-    """Return duplicate pairs, excluding pairs owned by the same template."""
-    matches = []
-    for left_index, left in enumerate(fingerprints):
-        for right in fingerprints[left_index + 1 :]:
-            if left.asset.template_id == right.asset.template_id:
+def find_duplicates(assets: list[Asset]) -> list[Duplicate]:
+    fingerprints = [(asset, fingerprint(asset[1])) for asset in assets]
+    duplicates = []
+    for index, (left_asset, left_fingerprint) in enumerate(fingerprints):
+        for right_asset, right_fingerprint in fingerprints[index + 1 :]:
+            if left_asset[0] == right_asset[0]:
                 continue
-            if left.byte_digest == right.byte_digest:
-                matches.append(DuplicateMatch(left.asset, right.asset, "byte-identical", 0.0))
-                continue
-            normalized_rms = _visual_distance(left, right)
-            if normalized_rms is not None:
-                matches.append(
-                    DuplicateMatch(
-                        left.asset,
-                        right.asset,
-                        "visually equivalent",
-                        normalized_rms,
-                    )
-                )
-    return matches
+            if left_fingerprint[0] == right_fingerprint[0]:
+                duplicates.append((left_asset, right_asset, "byte-identical"))
+            elif visually_same(left_fingerprint, right_fingerprint):
+                duplicates.append((left_asset, right_asset, "visually equivalent"))
+    return duplicates
 
 
-def group_duplicate_matches(matches: Sequence[DuplicateMatch]) -> list[DuplicateGroup]:
-    """Group connected duplicate pairs for concise, actionable output."""
-    parent: dict[ThumbnailAsset, ThumbnailAsset] = {}
-
-    def find(asset: ThumbnailAsset) -> ThumbnailAsset:
-        parent.setdefault(asset, asset)
-        while parent[asset] != asset:
-            parent[asset] = parent[parent[asset]]
-            asset = parent[asset]
-        return asset
-
-    def union(left: ThumbnailAsset, right: ThumbnailAsset) -> None:
-        left_root = find(left)
-        right_root = find(right)
-        if left_root != right_root:
-            parent[right_root] = left_root
-
-    for match in matches:
-        union(match.left, match.right)
-
-    assets_by_root: dict[ThumbnailAsset, set[ThumbnailAsset]] = {}
-    matches_by_root: dict[ThumbnailAsset, list[DuplicateMatch]] = {}
-    for match in matches:
-        root = find(match.left)
-        assets_by_root.setdefault(root, set()).update((match.left, match.right))
-        matches_by_root.setdefault(root, []).append(match)
-
-    groups = [
-        DuplicateGroup(
-            tuple(sorted(assets, key=lambda asset: (asset.template_id, str(asset.path)))),
-            tuple(matches_by_root[root]),
-        )
-        for root, assets in assets_by_root.items()
-    ]
-    return sorted(
-        groups,
-        key=lambda group: (group.assets[0].template_id, str(group.assets[0].path)),
-    )
-
-
-def find_duplicate_groups(assets: Sequence[ThumbnailAsset]) -> list[DuplicateGroup]:
-    fingerprints = [fingerprint_asset(asset) for asset in assets]
-    return group_duplicate_matches(find_duplicate_matches(fingerprints))
-
-
-def _run_git(repo_root: Path, *arguments: str) -> str:
+def git(repo_root: Path, *arguments: str) -> str:
     result = subprocess.run(
-        ["git", *arguments],
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
+        ["git", *arguments], cwd=repo_root, capture_output=True, text=True, check=False
     )
-    if result.returncode != 0:
-        detail = result.stderr.strip() or result.stdout.strip()
-        raise ValueError(f"git {' '.join(arguments)} failed: {detail}")
+    if result.returncode:
+        raise ValueError(result.stderr.strip() or f"git {' '.join(arguments)} failed")
     return result.stdout
 
 
-def _explicit_image_paths(entry: dict) -> tuple[str, ...]:
-    thumbnail = entry.get("thumbnail", [])
-    if not isinstance(thumbnail, list):
+def explicit_images(entry: dict) -> tuple[str, ...]:
+    paths = entry.get("thumbnail", [])
+    if not isinstance(paths, list):
         return ()
     return tuple(
         sorted(
             path
-            for path in thumbnail
+            for path in paths
             if isinstance(path, str) and Path(path).suffix.lower() in IMAGE_SUFFIXES
         )
     )
 
 
-def _thumbnail_config_by_template(entries: Iterable[dict]) -> dict[str, tuple[str, ...]]:
-    return {entry["name"]: _explicit_image_paths(entry) for entry in entries}
-
-
-def changed_thumbnail_templates(
-    base_entries: Iterable[dict], current_entries: Iterable[dict]
-) -> set[str]:
-    """Return new templates and templates whose explicit image mapping changed."""
-    base_config = _thumbnail_config_by_template(base_entries)
-    current_config = _thumbnail_config_by_template(current_entries)
-    return {
-        template_id
-        for template_id, config in current_config.items()
-        if template_id not in base_config or base_config[template_id] != config
-    }
-
-
 def changes_since_base(
-    repo_root: Path, base_ref: str, current_entries: Sequence[dict]
+    repo_root: Path, base_ref: str, current_entries: list[dict]
 ) -> tuple[set[str], set[str], str]:
-    """Return changed repo paths/template mappings since the merge base."""
-    base_commit = _run_git(repo_root, "merge-base", base_ref, "HEAD").strip()
+    base_commit = git(repo_root, "merge-base", base_ref, "HEAD").strip()
     if not base_commit:
         raise ValueError(f"No merge base found for {base_ref}")
 
-    changed_paths = {
-        path
-        for path in _run_git(
+    changed_paths = set(
+        git(
             repo_root,
             "diff",
             "--name-only",
@@ -348,110 +172,79 @@ def changes_since_base(
             "--",
             "templates",
         ).splitlines()
-        if path
-    }
+    )
     changed_paths.update(
-        path
-        for path in _run_git(
-            repo_root, "ls-files", "--others", "--exclude-standard", "--", "templates"
-        ).splitlines()
-        if path
+        git(repo_root, "ls-files", "--others", "--exclude-standard", "--", "templates").splitlines()
     )
 
-    base_index_text = _run_git(repo_root, "show", f"{base_commit}:templates/index.json")
-    base_categories = json.loads(base_index_text)
-    base_entries = [
-        template
-        for category in base_categories
-        if isinstance(category, dict)
-        for template in category.get("templates", [])
-        if isinstance(template, dict) and isinstance(template.get("name"), str)
-    ]
-    changed_templates = changed_thumbnail_templates(base_entries, current_entries)
+    base_entries = entries_from_json(
+        json.loads(git(repo_root, "show", f"{base_commit}:templates/index.json"))
+    )
+    base_config = {entry["name"]: explicit_images(entry) for entry in base_entries}
+    current_config = {entry["name"]: explicit_images(entry) for entry in current_entries}
+    changed_templates = {
+        template_id
+        for template_id, config in current_config.items()
+        if template_id not in base_config or base_config[template_id] != config
+    }
     return changed_paths, changed_templates, base_commit
 
 
-def group_touches_changes(
-    group: DuplicateGroup,
-    repo_root: Path,
+def touches_changes(
+    duplicate: Duplicate,
     changed_paths: set[str],
     changed_templates: set[str],
 ) -> bool:
     return any(
-        asset.template_id in changed_templates
-        or asset.path.relative_to(repo_root).as_posix() in changed_paths
-        for asset in group.assets
+        template_id in changed_templates or path.relative_to(REPO_ROOT).as_posix() in changed_paths
+        for template_id, path in duplicate[:2]
     )
 
 
-def _format_group(
-    group: DuplicateGroup,
+def print_duplicate(
+    duplicate: Duplicate,
     number: int,
-    repo_root: Path,
     changed_paths: set[str] | None = None,
     changed_templates: set[str] | None = None,
-) -> list[str]:
-    kinds = ", ".join(group.kinds)
-    lines = [f"Duplicate group {number} ({kinds}):"]
+) -> None:
     changed_paths = changed_paths or set()
     changed_templates = changed_templates or set()
-    for asset in group.assets:
-        relative_path = asset.path.relative_to(repo_root).as_posix()
+    print(f"Duplicate {number} ({duplicate[2]}):")
+    for template_id, path in duplicate[:2]:
+        relative_path = path.relative_to(REPO_ROOT).as_posix()
         reasons = []
         if relative_path in changed_paths:
             reasons.append("changed asset")
-        if asset.template_id in changed_templates:
+        if template_id in changed_templates:
             reasons.append("changed thumbnail mapping")
         marker = f" [{', '.join(reasons)}]" if reasons else ""
-        lines.append(f"  - template `{asset.template_id}`: `{relative_path}`{marker}")
-    return lines
+        print(f"  - template `{template_id}`: `{relative_path}`{marker}")
 
 
-def build_parser() -> argparse.ArgumentParser:
+def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     mode = parser.add_mutually_exclusive_group(required=True)
-    mode.add_argument(
-        "--audit",
-        action="store_true",
-        help="report every existing cross-template duplicate and exit successfully",
-    )
-    mode.add_argument(
-        "--base-ref",
-        help="fail only for duplicate groups involving changes since this Git ref",
-    )
-    parser.add_argument(
-        "--templates-dir",
-        type=Path,
-        default=TEMPLATES_DIR,
-        help=argparse.SUPPRESS,
-    )
-    return parser
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
-    templates_dir = args.templates_dir.resolve()
-    index_path = templates_dir / "index.json"
+    mode.add_argument("--audit", action="store_true", help="report all existing duplicates")
+    mode.add_argument("--base-ref", help="fail only for duplicates involving changed thumbnails")
+    args = parser.parse_args()
 
     try:
-        entries = load_template_entries(index_path)
-        assets = discover_thumbnail_assets(templates_dir, entries)
-        groups = find_duplicate_groups(assets)
+        entries = load_entries(TEMPLATES_DIR / "index.json")
+        assets = find_assets(TEMPLATES_DIR, entries)
+        duplicates = find_duplicates(assets)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"Thumbnail duplicate check failed: {exc}", file=sys.stderr)
         return 2
 
-    template_count = len({entry["name"] for entry in entries})
-    print(f"Scanned {len(assets)} effective image thumbnails across {template_count} templates.")
-
+    print(
+        f"Scanned {len(assets)} effective image thumbnails across "
+        f"{len({entry['name'] for entry in entries})} templates."
+    )
     if args.audit:
-        if not groups:
-            print("No cross-template duplicate thumbnails found.")
-            return 0
-        print(f"Found {len(groups)} cross-template duplicate thumbnail group(s).")
-        for number, group in enumerate(groups, start=1):
+        print(f"Found {len(duplicates)} cross-template duplicate pair(s).")
+        for number, duplicate in enumerate(duplicates, 1):
             print()
-            print("\n".join(_format_group(group, number, REPO_ROOT)))
+            print_duplicate(duplicate, number)
         print("\nAudit mode reports existing debt without failing.")
         return 0
 
@@ -463,38 +256,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Thumbnail duplicate check failed: {exc}", file=sys.stderr)
         return 2
 
-    blocking_groups = [
-        group
-        for group in groups
-        if group_touches_changes(group, REPO_ROOT, changed_paths, changed_templates)
+    blocking = [
+        duplicate
+        for duplicate in duplicates
+        if touches_changes(duplicate, changed_paths, changed_templates)
     ]
-    ignored_count = len(groups) - len(blocking_groups)
+    ignored = len(duplicates) - len(blocking)
     print(f"Compared changes with merge base {base_commit[:12]} ({args.base_ref}).")
-    if not blocking_groups:
-        print("No changed thumbnail introduces or modifies a cross-template duplicate.")
-        if ignored_count:
-            print(f"Ignored {ignored_count} pre-existing duplicate group(s).")
+    if not blocking:
+        print("No changed thumbnail duplicates another template thumbnail.")
+        if ignored:
+            print(f"Ignored {ignored} pre-existing duplicate pair(s).")
         return 0
 
-    print(
-        f"Found {len(blocking_groups)} duplicate group(s) involving changed thumbnails; "
-        "replace the repeated image before merging."
-    )
-    for number, group in enumerate(blocking_groups, start=1):
+    print(f"Found {len(blocking)} changed duplicate pair(s); replace the repeated image.")
+    for number, duplicate in enumerate(blocking, 1):
         print()
-        print(
-            "\n".join(
-                _format_group(
-                    group,
-                    number,
-                    REPO_ROOT,
-                    changed_paths,
-                    changed_templates,
-                )
-            )
-        )
-    if ignored_count:
-        print(f"\nIgnored {ignored_count} unrelated pre-existing duplicate group(s).")
+        print_duplicate(duplicate, number, changed_paths, changed_templates)
+    if ignored:
+        print(f"\nIgnored {ignored} unrelated pre-existing duplicate pair(s).")
     return 1
 
 

--- a/scripts/validate/check_duplicate_thumbnails.py
+++ b/scripts/validate/check_duplicate_thumbnails.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Find byte-identical and visually equivalent thumbnails across templates.
+
+The repository has historical duplicate thumbnails, so CI uses ``--base-ref``
+to fail only when a duplicate group involves a changed asset or thumbnail
+mapping. ``--audit`` reports the entire current corpus without failing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:
+    from PIL import Image, ImageOps, UnidentifiedImageError
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised before module import
+    raise SystemExit("Pillow is required. Install it with `python -m pip install Pillow`.") from exc
+
+_lib_dir = Path(__file__).resolve().parent.parent / "lib"
+if str(_lib_dir) not in sys.path:
+    sys.path.insert(0, str(_lib_dir))
+
+from paths import REPO_ROOT, TEMPLATES_DIR  # noqa: E402
+
+
+IMAGE_SUFFIXES = frozenset({".avif", ".jpeg", ".jpg", ".png", ".webp"})
+IMPLICIT_THUMBNAIL_SUFFIX = ".webp"
+HASH_SIZE = 16
+NORMALIZED_SIZE = 32
+
+# Perceptual hashes cheaply narrow the pair candidates. Pixel comparison then
+# keeps the definition intentionally strict: equivalent encodings/resolutions,
+# not two thumbnails that merely share a layout or background.
+MAX_DIFFERENCE_HASH_DISTANCE = 16
+MAX_AVERAGE_HASH_DISTANCE = 8
+MAX_CHANNEL_MEAN_DELTA = 4.0
+MAX_NORMALIZED_RMS = 3.0
+MAX_NORMALIZED_CHANNEL_DELTA = 16
+
+
+@dataclass(frozen=True)
+class ThumbnailAsset:
+    template_id: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class ThumbnailFingerprint:
+    asset: ThumbnailAsset
+    byte_digest: str
+    difference_hash: int
+    average_hash: int
+    channel_means: tuple[float, float, float]
+    normalized_pixels: bytes
+
+
+@dataclass(frozen=True)
+class DuplicateMatch:
+    left: ThumbnailAsset
+    right: ThumbnailAsset
+    kind: str
+    normalized_rms: float
+
+
+@dataclass(frozen=True)
+class DuplicateGroup:
+    assets: tuple[ThumbnailAsset, ...]
+    matches: tuple[DuplicateMatch, ...]
+
+    @property
+    def kinds(self) -> tuple[str, ...]:
+        return tuple(sorted({match.kind for match in self.matches}))
+
+
+def load_template_entries(index_path: Path) -> list[dict]:
+    """Return template entries from every category in an index file."""
+    with index_path.open(encoding="utf-8") as index_file:
+        categories = json.load(index_file)
+
+    if not isinstance(categories, list):
+        raise ValueError(f"{index_path} must contain a list of categories")
+
+    entries = []
+    for category in categories:
+        if not isinstance(category, dict):
+            continue
+        for template in category.get("templates", []):
+            if isinstance(template, dict) and isinstance(template.get("name"), str):
+                entries.append(template)
+    return entries
+
+
+def _safe_explicit_thumbnail(templates_dir: Path, relative_path: str) -> Path | None:
+    """Resolve an explicit image thumbnail without allowing it outside templates/."""
+    candidate = (templates_dir / relative_path).resolve()
+    try:
+        candidate.relative_to(templates_dir.resolve())
+    except ValueError:
+        return None
+    if candidate.suffix.lower() not in IMAGE_SUFFIXES or not candidate.is_file():
+        return None
+    return candidate
+
+
+def discover_thumbnail_assets(templates_dir: Path, entries: Sequence[dict]) -> list[ThumbnailAsset]:
+    """Resolve explicit image thumbnails and implicit ``{template}-N.webp`` files."""
+    paths_by_template: dict[str, set[Path]] = {}
+
+    for entry in entries:
+        template_id = entry["name"]
+        template_paths = paths_by_template.setdefault(template_id, set())
+        explicit = entry.get("thumbnail", [])
+        if not isinstance(explicit, list):
+            continue
+        for relative_path in explicit:
+            if not isinstance(relative_path, str):
+                continue
+            thumbnail = _safe_explicit_thumbnail(templates_dir, relative_path)
+            if thumbnail is not None:
+                template_paths.add(thumbnail)
+
+    # Match the numeric suffix exactly so template-name prefixes cannot claim
+    # another template's asset (for example ``foo`` must not claim ``foo_bar-1``).
+    template_ids = set(paths_by_template)
+    for path in templates_dir.iterdir():
+        if not path.is_file() or path.suffix.lower() != IMPLICIT_THUMBNAIL_SUFFIX:
+            continue
+        owner, separator, number = path.stem.rpartition("-")
+        if separator and number.isdigit() and owner in template_ids:
+            paths_by_template[owner].add(path.resolve())
+
+    return [
+        ThumbnailAsset(template_id, path)
+        for template_id, paths in sorted(paths_by_template.items())
+        for path in sorted(paths)
+    ]
+
+
+def _bits_from_comparisons(values: Sequence[int], width: int, height: int) -> int:
+    result = 0
+    row_width = width + 1
+    for y in range(height):
+        for x in range(width):
+            if values[y * row_width + x] > values[y * row_width + x + 1]:
+                result |= 1 << (y * width + x)
+    return result
+
+
+def fingerprint_asset(asset: ThumbnailAsset) -> ThumbnailFingerprint:
+    """Build byte and perceptual fingerprints for one image asset."""
+    image_bytes = asset.path.read_bytes()
+    byte_digest = hashlib.sha256(image_bytes).hexdigest()
+
+    try:
+        with Image.open(asset.path) as source:
+            image = ImageOps.exif_transpose(source).convert("RGB")
+    except (OSError, UnidentifiedImageError) as exc:
+        raise ValueError(f"Cannot decode thumbnail {asset.path}: {exc}") from exc
+
+    normalized = image.resize((NORMALIZED_SIZE, NORMALIZED_SIZE), Image.Resampling.LANCZOS)
+    normalized_pixels = normalized.tobytes()
+    pixel_count = NORMALIZED_SIZE * NORMALIZED_SIZE
+    channel_means = tuple(sum(normalized_pixels[channel::3]) / pixel_count for channel in range(3))
+
+    difference_image = image.convert("L").resize(
+        (HASH_SIZE + 1, HASH_SIZE), Image.Resampling.LANCZOS
+    )
+    difference_hash = _bits_from_comparisons(list(difference_image.getdata()), HASH_SIZE, HASH_SIZE)
+
+    average_image = image.convert("L").resize((HASH_SIZE, HASH_SIZE), Image.Resampling.LANCZOS)
+    average_pixels = list(average_image.getdata())
+    average = sum(average_pixels) / len(average_pixels)
+    average_hash = sum((pixel > average) << index for index, pixel in enumerate(average_pixels))
+
+    return ThumbnailFingerprint(
+        asset=asset,
+        byte_digest=byte_digest,
+        difference_hash=difference_hash,
+        average_hash=average_hash,
+        channel_means=channel_means,
+        normalized_pixels=normalized_pixels,
+    )
+
+
+def _visual_distance(left: ThumbnailFingerprint, right: ThumbnailFingerprint) -> float | None:
+    if (left.difference_hash ^ right.difference_hash).bit_count() > MAX_DIFFERENCE_HASH_DISTANCE:
+        return None
+    if (left.average_hash ^ right.average_hash).bit_count() > MAX_AVERAGE_HASH_DISTANCE:
+        return None
+    if (
+        max(
+            abs(left_mean - right_mean)
+            for left_mean, right_mean in zip(left.channel_means, right.channel_means)
+        )
+        > MAX_CHANNEL_MEAN_DELTA
+    ):
+        return None
+
+    squared_error = 0
+    for left_pixel, right_pixel in zip(left.normalized_pixels, right.normalized_pixels):
+        delta = abs(left_pixel - right_pixel)
+        if delta > MAX_NORMALIZED_CHANNEL_DELTA:
+            return None
+        squared_error += delta * delta
+    normalized_rms = math.sqrt(squared_error / len(left.normalized_pixels))
+    if normalized_rms > MAX_NORMALIZED_RMS:
+        return None
+    return normalized_rms
+
+
+def find_duplicate_matches(
+    fingerprints: Sequence[ThumbnailFingerprint],
+) -> list[DuplicateMatch]:
+    """Return duplicate pairs, excluding pairs owned by the same template."""
+    matches = []
+    for left_index, left in enumerate(fingerprints):
+        for right in fingerprints[left_index + 1 :]:
+            if left.asset.template_id == right.asset.template_id:
+                continue
+            if left.byte_digest == right.byte_digest:
+                matches.append(DuplicateMatch(left.asset, right.asset, "byte-identical", 0.0))
+                continue
+            normalized_rms = _visual_distance(left, right)
+            if normalized_rms is not None:
+                matches.append(
+                    DuplicateMatch(
+                        left.asset,
+                        right.asset,
+                        "visually equivalent",
+                        normalized_rms,
+                    )
+                )
+    return matches
+
+
+def group_duplicate_matches(matches: Sequence[DuplicateMatch]) -> list[DuplicateGroup]:
+    """Group connected duplicate pairs for concise, actionable output."""
+    parent: dict[ThumbnailAsset, ThumbnailAsset] = {}
+
+    def find(asset: ThumbnailAsset) -> ThumbnailAsset:
+        parent.setdefault(asset, asset)
+        while parent[asset] != asset:
+            parent[asset] = parent[parent[asset]]
+            asset = parent[asset]
+        return asset
+
+    def union(left: ThumbnailAsset, right: ThumbnailAsset) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
+    for match in matches:
+        union(match.left, match.right)
+
+    assets_by_root: dict[ThumbnailAsset, set[ThumbnailAsset]] = {}
+    matches_by_root: dict[ThumbnailAsset, list[DuplicateMatch]] = {}
+    for match in matches:
+        root = find(match.left)
+        assets_by_root.setdefault(root, set()).update((match.left, match.right))
+        matches_by_root.setdefault(root, []).append(match)
+
+    groups = [
+        DuplicateGroup(
+            tuple(sorted(assets, key=lambda asset: (asset.template_id, str(asset.path)))),
+            tuple(matches_by_root[root]),
+        )
+        for root, assets in assets_by_root.items()
+    ]
+    return sorted(
+        groups,
+        key=lambda group: (group.assets[0].template_id, str(group.assets[0].path)),
+    )
+
+
+def find_duplicate_groups(assets: Sequence[ThumbnailAsset]) -> list[DuplicateGroup]:
+    fingerprints = [fingerprint_asset(asset) for asset in assets]
+    return group_duplicate_matches(find_duplicate_matches(fingerprints))
+
+
+def _run_git(repo_root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise ValueError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def _explicit_image_paths(entry: dict) -> tuple[str, ...]:
+    thumbnail = entry.get("thumbnail", [])
+    if not isinstance(thumbnail, list):
+        return ()
+    return tuple(
+        sorted(
+            path
+            for path in thumbnail
+            if isinstance(path, str) and Path(path).suffix.lower() in IMAGE_SUFFIXES
+        )
+    )
+
+
+def _thumbnail_config_by_template(entries: Iterable[dict]) -> dict[str, tuple[str, ...]]:
+    return {entry["name"]: _explicit_image_paths(entry) for entry in entries}
+
+
+def changed_thumbnail_templates(
+    base_entries: Iterable[dict], current_entries: Iterable[dict]
+) -> set[str]:
+    """Return new templates and templates whose explicit image mapping changed."""
+    base_config = _thumbnail_config_by_template(base_entries)
+    current_config = _thumbnail_config_by_template(current_entries)
+    return {
+        template_id
+        for template_id, config in current_config.items()
+        if template_id not in base_config or base_config[template_id] != config
+    }
+
+
+def changes_since_base(
+    repo_root: Path, base_ref: str, current_entries: Sequence[dict]
+) -> tuple[set[str], set[str], str]:
+    """Return changed repo paths/template mappings since the merge base."""
+    base_commit = _run_git(repo_root, "merge-base", base_ref, "HEAD").strip()
+    if not base_commit:
+        raise ValueError(f"No merge base found for {base_ref}")
+
+    changed_paths = {
+        path
+        for path in _run_git(
+            repo_root,
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRT",
+            base_commit,
+            "--",
+            "templates",
+        ).splitlines()
+        if path
+    }
+    changed_paths.update(
+        path
+        for path in _run_git(
+            repo_root, "ls-files", "--others", "--exclude-standard", "--", "templates"
+        ).splitlines()
+        if path
+    )
+
+    base_index_text = _run_git(repo_root, "show", f"{base_commit}:templates/index.json")
+    base_categories = json.loads(base_index_text)
+    base_entries = [
+        template
+        for category in base_categories
+        if isinstance(category, dict)
+        for template in category.get("templates", [])
+        if isinstance(template, dict) and isinstance(template.get("name"), str)
+    ]
+    changed_templates = changed_thumbnail_templates(base_entries, current_entries)
+    return changed_paths, changed_templates, base_commit
+
+
+def group_touches_changes(
+    group: DuplicateGroup,
+    repo_root: Path,
+    changed_paths: set[str],
+    changed_templates: set[str],
+) -> bool:
+    return any(
+        asset.template_id in changed_templates
+        or asset.path.relative_to(repo_root).as_posix() in changed_paths
+        for asset in group.assets
+    )
+
+
+def _format_group(
+    group: DuplicateGroup,
+    number: int,
+    repo_root: Path,
+    changed_paths: set[str] | None = None,
+    changed_templates: set[str] | None = None,
+) -> list[str]:
+    kinds = ", ".join(group.kinds)
+    lines = [f"Duplicate group {number} ({kinds}):"]
+    changed_paths = changed_paths or set()
+    changed_templates = changed_templates or set()
+    for asset in group.assets:
+        relative_path = asset.path.relative_to(repo_root).as_posix()
+        reasons = []
+        if relative_path in changed_paths:
+            reasons.append("changed asset")
+        if asset.template_id in changed_templates:
+            reasons.append("changed thumbnail mapping")
+        marker = f" [{', '.join(reasons)}]" if reasons else ""
+        lines.append(f"  - template `{asset.template_id}`: `{relative_path}`{marker}")
+    return lines
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--audit",
+        action="store_true",
+        help="report every existing cross-template duplicate and exit successfully",
+    )
+    mode.add_argument(
+        "--base-ref",
+        help="fail only for duplicate groups involving changes since this Git ref",
+    )
+    parser.add_argument(
+        "--templates-dir",
+        type=Path,
+        default=TEMPLATES_DIR,
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    templates_dir = args.templates_dir.resolve()
+    index_path = templates_dir / "index.json"
+
+    try:
+        entries = load_template_entries(index_path)
+        assets = discover_thumbnail_assets(templates_dir, entries)
+        groups = find_duplicate_groups(assets)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Thumbnail duplicate check failed: {exc}", file=sys.stderr)
+        return 2
+
+    template_count = len({entry["name"] for entry in entries})
+    print(f"Scanned {len(assets)} effective image thumbnails across {template_count} templates.")
+
+    if args.audit:
+        if not groups:
+            print("No cross-template duplicate thumbnails found.")
+            return 0
+        print(f"Found {len(groups)} cross-template duplicate thumbnail group(s).")
+        for number, group in enumerate(groups, start=1):
+            print()
+            print("\n".join(_format_group(group, number, REPO_ROOT)))
+        print("\nAudit mode reports existing debt without failing.")
+        return 0
+
+    try:
+        changed_paths, changed_templates, base_commit = changes_since_base(
+            REPO_ROOT, args.base_ref, entries
+        )
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"Thumbnail duplicate check failed: {exc}", file=sys.stderr)
+        return 2
+
+    blocking_groups = [
+        group
+        for group in groups
+        if group_touches_changes(group, REPO_ROOT, changed_paths, changed_templates)
+    ]
+    ignored_count = len(groups) - len(blocking_groups)
+    print(f"Compared changes with merge base {base_commit[:12]} ({args.base_ref}).")
+    if not blocking_groups:
+        print("No changed thumbnail introduces or modifies a cross-template duplicate.")
+        if ignored_count:
+            print(f"Ignored {ignored_count} pre-existing duplicate group(s).")
+        return 0
+
+    print(
+        f"Found {len(blocking_groups)} duplicate group(s) involving changed thumbnails; "
+        "replace the repeated image before merging."
+    )
+    for number, group in enumerate(blocking_groups, start=1):
+        print()
+        print(
+            "\n".join(
+                _format_group(
+                    group,
+                    number,
+                    REPO_ROOT,
+                    changed_paths,
+                    changed_templates,
+                )
+            )
+        )
+    if ignored_count:
+        print(f"\nIgnored {ignored_count} unrelated pre-existing duplicate group(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a lightweight pair-based checker for byte-identical and visually equivalent thumbnails across distinct templates
- resolve explicit image thumbnail paths and implicit template-N.webp assets while ignoring multiple assets owned by one template
- add a changed-files/base-ref CI gate so unrelated legacy duplicates do not block PRs
- document the local commands and require the check in AGENTS.md for thumbnail changes

## Measurements

- current corpus: 597 templates and 767 effective image thumbnails
- audit runtime: 2.33 to 2.52 seconds locally, median 2.36 seconds
- existing debt: 3 cross-template pairs, consisting of 1 byte-identical and 2 visually equivalent pairs
- the MiniMax and Nano Banana regressions are both detected despite different byte hashes

## Validation

- 6 focused tests passed
- Ruff lint and format checks passed
- Python compilation passed
- workflow YAML parsed successfully
- audit mode reports all 3 legacy pairs without failing
- base-ref mode ignores unrelated legacy pairs and fails with actionable template IDs and asset paths for a newly affected duplicate