### PR TITLE
feat(i18n): turn on the nine reviewed locales

### DIFF
--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -228,6 +228,13 @@ jobs:
       - name: Refresh sign-off records
         if: always()
         working-directory: site
+        # Every hub locale may be granted its first wave by policy: the native
+        # review gate was dropped deliberately (nav, 2026-08-24) so indexation is
+        # not held behind reviewer capacity. The other half of the predicate is
+        # untouched, so a page whose fields are not genuinely translated, or that
+        # carries an unresolved critical/major finding, is still held back.
+        env:
+          I18N_BOOTSTRAP_LOCALES: zh,zh-TW,ja,ko,es,fr,ru,tr,ar,pt-BR
         run: pnpm i18n:signoff-refresh
 
       # Format only the generated files; whole-tree prettier hits pre-existing

--- a/site/src/i18n/reviews/ar.json
+++ b/site/src/i18n/reviews/ar.json
@@ -1,0 +1,3218 @@
+{
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "2958e8974c70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0136284ecc19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "f21b64f8761c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "017694778c62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "52e999bab131",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "b2c55d24d09b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "602daac2d9e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "0b83356c3852",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "05561ffd8466",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0314e3bcf260": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "46fe50e34613",
+    "reviewedArtifactChecksum": "a274a7bf1821",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "d5ed9dd557f3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "5186c2552860",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "972ae2e4b601",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "c1e7885d0391",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "3d11e0732725",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0553e57852fe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c73130ac13b8",
+    "reviewedArtifactChecksum": "eaa0dcc71c7a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "52b342b9c9b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "5bd4f28f5e8b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "06caca08d30b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "cd22f01ec3ba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "58cfcbaa302a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0801185d2115": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5c7d51b77a",
+    "reviewedArtifactChecksum": "3b62e911a2db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0812b435d117": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "3361316c6c4a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085a4bba12f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "283a752e9005",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "890edd865bf5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "554bed6382ad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0a6672ca248d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "7716f8143e01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "b70fa6a24fdf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b405e2734df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "624d042fa96e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "379425f7b520",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "405cbec5294c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ba871b9578d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "c997cae74bcf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "ac226e0bca69",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "c1a31de507c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "113c9ab2c6d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387ec1f14afa",
+    "reviewedArtifactChecksum": "766957e124d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "11657ed32877": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "63b92d2012c3",
+    "reviewedArtifactChecksum": "f080ed63f405",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "33c6a8810b2c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "12c2481d04b4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9c6ff6175b64",
+    "reviewedArtifactChecksum": "a8897e6d2822",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "52d411ac2770",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "085bea72afa4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15538e51d812": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "935eb3882193",
+    "reviewedArtifactChecksum": "d0ee17f8a2a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "72ee485e38f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "cedef71f809f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "16f123e593db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "e0305510d815",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "171dea657096": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91799cf35e77",
+    "reviewedArtifactChecksum": "a19806dd95d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "4209877edf8b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "65c0aa7fd9fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "182021fcf3dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0eff80aeaad",
+    "reviewedArtifactChecksum": "2292a5bbb247",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1880d7035ea2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "5807d57ac732",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "2a9f1190ee6e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1af3df552a07": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "e449cd62e086",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "fd1b4f4ae567",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "377f1867aa76",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "eea3caa83117",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "a0a849313a13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "e0c27d917d82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "c587280d218e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "29b60e1b0a44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1f594885b9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "aded36ae3085",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "0dd73e263804",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "f369a1cfaa2e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "d91df3a0ca76",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "24708aec5b1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "231992fee1a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "6b2c6dc14606",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "00bbd02e8f53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2652985596d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eddea5c0dbca",
+    "reviewedArtifactChecksum": "0f98252d0ce7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "1ee6fca6e9aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "cd33b1521fb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a95da601676": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f3cd6bdb534d",
+    "reviewedArtifactChecksum": "336d8311bf4f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "271b813fea2a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "8eeda27f7205",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "695d409aa683",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "7e752fe26d75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2f10814fd823": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "9d450c88505b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "d28592d9fd39",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "300efdae24f6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "1107fd692caf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "b3445a55bd29",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "86a474fe986d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "a87bcd577a9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "9f12ebb6345f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "a7cb2f1c0cd2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "fa47c72803c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "67a97730e722",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3515c5083027": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "554e4ef6a5f3",
+    "reviewedArtifactChecksum": "8b120e2b6e4f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "36794f399aa0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "7a5c4612f04c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "7bf835643034",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "5ac86ad638c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "37dbba07d214",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cb47a67b81a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "19d587d12601",
+    "reviewedArtifactChecksum": "ef2dde395cc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "f0d590732ab9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "3b7fd0fd2cec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3eb92c1b2380": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bf7aa20f745d",
+    "reviewedArtifactChecksum": "21b28c177cb2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ef4de40106b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "f3fde50613d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40770c9eb41b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "d57f8edddc61",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40a427168ef7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "9ba41c5c70d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40dea2f852c3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "16a3ad6ae34f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "41f029c74cd4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "00a46ee03e82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "430b718c2c90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "38dd066ff613",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "cda4f6ee86ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "f829d43c419f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "74ffbc4e8e04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4638e59ae7d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a0e59ae686f",
+    "reviewedArtifactChecksum": "aa6a7037edd6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46fc617ad144": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8f8ad09fe7e",
+    "reviewedArtifactChecksum": "63c1575eddf0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "471717404074": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "bfcdd7d61bc7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4724032fa666": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "47dbbf59972c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "d7a071a51353",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47a892d81764": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "376ecaaeccc6",
+    "reviewedArtifactChecksum": "fe801c220e2b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "49a2f3a0811f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "51dc5f124b8f",
+    "reviewedArtifactChecksum": "44035f091dc3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a4da321a45d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04f477efeaa6",
+    "reviewedArtifactChecksum": "9655af17e436",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a6697085e75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad1c8a8ecac9",
+    "reviewedArtifactChecksum": "911a6c400af1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "1f113265ff86",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "970baa94058a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "a83c25603477",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "a69a2a7698b1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ca799182440": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a16c03fe7032",
+    "reviewedArtifactChecksum": "d43e4e0c67ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "9cb4aa4773c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4dfdaf8f07d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a50bbbf99764",
+    "reviewedArtifactChecksum": "16ed93434392",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e57a7fe516e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83e635a7828c",
+    "reviewedArtifactChecksum": "41f318147fab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "1e43aca97040",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "69ce417b405a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "7c33c5b6281a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "b42bd7aa8371",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "50199f76fe74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c1fb24a9e72",
+    "reviewedArtifactChecksum": "9da5583d0f17",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "b296cbafbca0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "dba93a8fd59f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "c18743a42d65",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "536dc32faee1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a12ade6eb6f",
+    "reviewedArtifactChecksum": "e2829d5adcb4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558cc012978d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9a40936909",
+    "reviewedArtifactChecksum": "a55388c7a6d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558dc01ae546": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c5045c9c5f05",
+    "reviewedArtifactChecksum": "84336c386dac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "560738f98e65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "49a608dbdeb3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5697ddf9182f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "c7daa700f777",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "f0f5281bca71",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "598da2637dc8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "51e12e31c353",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "72be5c5ae4be",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "c9edd8010612",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "b47d46be0479",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "4a0b931411df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fa9b44388cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75268e0ea37",
+    "reviewedArtifactChecksum": "3811dd3eb1af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fd7dc1f9db5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70417a1c18f0",
+    "reviewedArtifactChecksum": "dae49de047b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "603b2d01feb0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bab688e65c3f",
+    "reviewedArtifactChecksum": "5ed5619c81f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6645006a0cb7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "e64c221ece3b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67981edb9ad4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa37a7c8d562",
+    "reviewedArtifactChecksum": "b2402e548eb7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67a816af8a73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee604150adb4",
+    "reviewedArtifactChecksum": "770855b97da5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67b461209d58": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e95ee7304036",
+    "reviewedArtifactChecksum": "6cb43fb691a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68c39b4c6a6f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5106ec4eb948",
+    "reviewedArtifactChecksum": "01f1f6b10ca1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68dcfc02a679": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5dbfcd37a1ff",
+    "reviewedArtifactChecksum": "a855a4fe07a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68f726502f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "3787b1f4e63e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "2c0ca8e73f6a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6991493996fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "0125d8200240",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69a3789c4840": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "79a4cab80516",
+    "reviewedArtifactChecksum": "cd8c9c779e08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a2b37d44146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ebbffb505567",
+    "reviewedArtifactChecksum": "db9589f75da2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "81bf03811633",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6afbca6e9d22": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb05dda45844",
+    "reviewedArtifactChecksum": "7b3c179656af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "2fe50018cdbc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b3078795300": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "c1f6e89387c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "67da7c52b8e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "6213bf6ab151",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c3fa01b5d73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce44981723ba",
+    "reviewedArtifactChecksum": "40aa72c59bdd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "215a47e0c1f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e099b1a7822": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85c8585ef6ce",
+    "reviewedArtifactChecksum": "de59457ce35d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "5d8141d07fe4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "f926f2c8e5fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "6b039bcb2924",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "bb303753c4a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fec31e40f4a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc934cbc82b8",
+    "reviewedArtifactChecksum": "0ecb9d8b9a12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7016f027bcf1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "300e97084480",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70dea50257fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "b54330bf0dff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "c3678f0327bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71355ee91724": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f168dc59d8b",
+    "reviewedArtifactChecksum": "4ce842acb606",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71a0edbac544": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "177e8ad6342f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "390838a9fa95",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "153208e65d4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "730d964da0cc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "02c64ba307fd",
+    "reviewedArtifactChecksum": "b8cb6a90ba35",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7330608df8b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "5711a84f4112",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "9b2977dcb674",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "da2f744185d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "8be4599d8d63",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "768526487e8d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f1c03a7a813",
+    "reviewedArtifactChecksum": "d9646dfadad4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "ab327b0ae97c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "770640dfddef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "1234e430f034",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "288ef8969b61",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "787cfd599758": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "a7b1b7a6c053",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79227f845a2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "bfb5213ba82d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "c6ddafaafe14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7a6ab8b6e694": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bac15fa24b1e",
+    "reviewedArtifactChecksum": "005c275f6661",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b973ace62af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "11f26939ebdd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7c0c712700e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9bf2dbbc9f",
+    "reviewedArtifactChecksum": "1065004e3953",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "3a1d142971af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cfb99272578": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "f3b9fad4d6a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7dca0438edf4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a20647f365c",
+    "reviewedArtifactChecksum": "a1223e7864c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "a3a9135bd2e8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "2d79f38ed8d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "75dee5d71984",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "18d28f7e7fbb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "30692d603a7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "825e6fb23c2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f9084ed9312",
+    "reviewedArtifactChecksum": "1aaa028ad2ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "834ab8919949": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ddbe0761021",
+    "reviewedArtifactChecksum": "6d4e99c565ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "857e50707831": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "f93353c8c9a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "1cc163c4fa7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "86efedaffa3e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "6a470b838490",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "21b310897837",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "87f3b4c32e4f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "405b0711392d",
+    "reviewedArtifactChecksum": "e30d04996122",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "cfbabd7d29f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88f014a33e2a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "42a4bae0bf1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "895960b69952": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "b254a1926cd9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "ae22d5947741",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a90e1694881": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "3629a4bb2bdc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8bd8b493eb7a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a017392574e5",
+    "reviewedArtifactChecksum": "e4709c1a56b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c553cc7c664": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "499792e4d375",
+    "reviewedArtifactChecksum": "0b86451ef26b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7390cc52c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6713a12925e8",
+    "reviewedArtifactChecksum": "0563ed73fbeb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "b5ad97f209ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "520dcec5bd1b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "257f9775879e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "b12ab3d033fb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "d92fd49b59ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "cdbdb28dd882",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f90aec3d12c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b3ffacce720",
+    "reviewedArtifactChecksum": "bf9d491ff11f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8fe7ed30c4ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a9cc5890cb7",
+    "reviewedArtifactChecksum": "3a6e74f668b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "bc39991acf2e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "e023e524b8c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "718796165a01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9173ef378024": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "fd7db39b722c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "8a3ad66b4776",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93c182d3aefb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "0851f6b16248",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "947be2b6d997": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "889f802e4873",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9654558acd06": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a12731a191",
+    "reviewedArtifactChecksum": "ac5ba7a912fb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "35919b191257",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96f9694b12c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "22e7e26d2476",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9717b437111c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "38ea646d9690",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977bc7f55865": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16b8504f3ddc",
+    "reviewedArtifactChecksum": "dfa3f8a709d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "6402a227476b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "587339bccdb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "dcff8426ff6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9851c174a194": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd55d897b05c",
+    "reviewedArtifactChecksum": "49b923bc5337",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9974666c3acb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71d3d1fa5eeb",
+    "reviewedArtifactChecksum": "69a82cbb49e8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "af292f77ba80",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "d9f8d6b3b8cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "9782d08b8d06",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "e6bcf8a5963b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9be3d7110c75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "b6965c4ee6b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "e5f87fa1ca85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cc2917611e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "eecc20ab75bd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cca5e2b3dde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "478c9fb1fb03",
+    "reviewedArtifactChecksum": "740bcaa5230d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9d588c37e728": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "52bf0fb36d94",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "dba8ae0ffe34",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e910f3b95c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "222b5e4fda0b",
+    "reviewedArtifactChecksum": "fc34cbab1aef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "ad9b9c752ed1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f1bb8c2f14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd521aa22072",
+    "reviewedArtifactChecksum": "41ae825cfe8e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f9f595534d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47ebf99edfc0",
+    "reviewedArtifactChecksum": "f4905585ccc4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "e98ab3eb4db1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "ad392310fdc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a09d65985659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "05dfceafb99c",
+    "reviewedArtifactChecksum": "91a61a4de802",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "2b909956c4fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "500201ea9d4d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "eb95d43e1b29",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a335e0968d76": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a271486f288",
+    "reviewedArtifactChecksum": "8372aa8fba75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a3e50e79cb89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fbf819fbfc3",
+    "reviewedArtifactChecksum": "9671a094d47c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "a9ac501a1fdf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "0c79ce56359c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a781503cf508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "31da9097d9d9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a84541c0018a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "2f58d0bf86de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "b6df71d2dc1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d874e28508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "766b2299106f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "c4091b2e0323",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "003f22899e54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9241caf70ac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "25699da31ab8",
+    "reviewedArtifactChecksum": "625c4ca6f732",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "e4e688222512",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "9a3711e6bb85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "c13f145fd8df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aac8b0d80e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c55f22e29a79",
+    "reviewedArtifactChecksum": "bf6d7e33e325",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "f1b322cfa1f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "7fd74bdf3a7a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "ef33240fd1e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "adca306765ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "4d7c7dd99474",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ae12a241076c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "9b62d9e3fd3f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "8dd79ceadf47",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "f956f9e16996",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "4e4558f32adf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afa2656c1d4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9062cb86b8e5",
+    "reviewedArtifactChecksum": "615247c4ebd0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "cd10c06a5e14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "d2fecc91e900",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "1791c5bfee5e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3437893d89d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "f83c00b43f54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "b8a263a17fa3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b37902cee452": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e60d5dfd84a3",
+    "reviewedArtifactChecksum": "12b2a5ff5b2b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "74fa7c033fc9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "4629e65f0c84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "72912349beab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "612bcdfb4a2a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b594a01df1d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "94660f232c6a",
+    "reviewedArtifactChecksum": "59e39639905a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b5e0c3c14836": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e5859746672",
+    "reviewedArtifactChecksum": "42f3fbef6416",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "09ce40a45a7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "a7a29d4af952",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b893149a8671": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c53aa635287a",
+    "reviewedArtifactChecksum": "8404cfd14624",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b89d812e25e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "d06353fc3dfe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b8c030205d86": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "457f3312e60d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "006553274b33",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b95499a55c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16809786d5b3",
+    "reviewedArtifactChecksum": "822f69f44e33",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "baa06a413558": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb0421c78c54",
+    "reviewedArtifactChecksum": "50f7c1353d95",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "38d790e153c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bb33cc433026": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "043eb18f4f7d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "ec032683c0e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "69c433d19336",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "2358b448d13a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "0d27e360611a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bed989744195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a326351226e",
+    "reviewedArtifactChecksum": "cc84b00f7be5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "2419b42dba30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bfba92751be8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "346d47321248",
+    "reviewedArtifactChecksum": "daf1563a443c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0198b907108": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "31b32e7ba02d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "56782320fa3d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "4845d35573ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1959fdc5642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "314621ba0722",
+    "reviewedArtifactChecksum": "efd0098d8bd8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "76c58f7ab155",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "31206b3b3a60",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "8dde07dce982",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "947a41d4cdf0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c365c23d9a69": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "b22799f9c5c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "4f7e4e612d4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "07b0e6b91430",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c5cbee07611f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "16baa5bca2f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c666b9b4014e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "95bb7f754047",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "e420a42296d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "629fff4412bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c70904777c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "080834c1e71d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "2cca65c663c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "db7670210286",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c98e5c457e1e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8bc16ce3029",
+    "reviewedArtifactChecksum": "db7aea99b826",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "2790bdb01424",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "bec2b96a7d69",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc053bb55df6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b9c62043d7a5",
+    "reviewedArtifactChecksum": "4243244414c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc078724f871": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "801dd18e4e4a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc23c187984a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3b18a4f3d32",
+    "reviewedArtifactChecksum": "abe8c9529877",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "98aeb747b088",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccc43113008f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "737cfc94ecba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccf567b604be": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "35178767cfb8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "78750014bd42",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "dd3055c93061",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "7bc656e6e28a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "6506f53f9f6c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "b9c0e1091186",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "59f4c632106b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "46d44a028c52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cff9f70a9137": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0888293ad9f",
+    "reviewedArtifactChecksum": "fdde2e813d0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d124e24eca67": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c2a79ee0629",
+    "reviewedArtifactChecksum": "e56b62feaf31",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "1f20d1930eee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d23f62e48d10": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "8c6fcf19a16d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "11911e3b41b1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "d977916a5573",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "8bbad9678cac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "b311ad816bc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6109704c9d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "b7090bdcd997",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d636956bdddc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "71f401199eb9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "9fa3b33ad953",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6e252fb4880": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "824117ef4c78",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "6e24a292a85d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "9fdb13a4acbd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "f91961886ba9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "5548b1efba15",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "1eac0cdfd94b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "0746929fe146",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "45b553d90436",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "ad2eb055dc8e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "751553800e6c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "8734ef864ac6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dff780783fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "6ae5e26dae6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "51c0652cbe17",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0df9e9c7683": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07c0da77ff02",
+    "reviewedArtifactChecksum": "07c874adbae8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0f1fb8115ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2208cdd14461",
+    "reviewedArtifactChecksum": "ce5a0f96749f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e41b80eb587d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "b568e57ae602",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "ee6dfbb2e7da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "fc171035feba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "81bd21a5df69",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "289777bdaa42",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6f74ca84e32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e68fb1567b85",
+    "reviewedArtifactChecksum": "3654b16c89c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8099b642c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab48a85786be",
+    "reviewedArtifactChecksum": "4c78f3bb8331",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "abbf73fc6c08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "90f768e2c271",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "a17b6770f465",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "bc7eace41880",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "a28cf40bea84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "5cae9bdd2de4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "845c3076465b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "181fa3dec0b8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef8586090398": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "51f3005f72a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f052abfce10e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "5c0d5f6c3793",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3096e2ffb64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20e28569e2d2",
+    "reviewedArtifactChecksum": "006190fa28c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "97a2976e8d75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e29143100c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18726770189",
+    "reviewedArtifactChecksum": "1b030fe178bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "6c00997d09e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f56329f28659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "4b866fe9f1a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "775ddc481394",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "29b3be3a9bba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "b5646c715c84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "33b4dcfd905d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f889bba5102a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "0288eb80f0ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "e131c4ddb689",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "8185e0f24a0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa1f01a51d17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "33418f4fe697",
+    "reviewedArtifactChecksum": "389a52a1f5b3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "05566abcc490",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fdab9848b160": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bc70dfe515b2",
+    "reviewedArtifactChecksum": "3ee230897c12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "ba17da28ee18",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe773d7d7377": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "7be6962d3c17",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "3a9023e709ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ff88e6723334": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "d15f219b79c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "19e01e2ccd08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/es.json
+++ b/site/src/i18n/reviews/es.json
@@ -1,0 +1,2594 @@
+{
+  "017694778c62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "ce5f26f0d6bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "7b25fda1f0ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "b7b6a79b8720",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "e45a939bf466",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "be2fdeb38193",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "74781334d678",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "4040790924f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "3e8d6003bafe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "8e47b4552806",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0812b435d117": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "a5ffc1699cad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085a4bba12f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "8b2ad1da9375",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085ff06f65f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "70722feb9a86",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "9e079edcc76d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "d3d704ba2b4a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "732579d7854d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "ee6fb00612d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ba871b9578d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "1d538029bae7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "224b7ee71a02",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "47c0ffd7f424",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1043317e75c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "1e174b4ae133",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "da74d554d4a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "dfa1ee675f72",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "c5894c2d70ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "b051e8324dab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "69124175f30e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "5f6de5347510",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "171dea657096": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91799cf35e77",
+    "reviewedArtifactChecksum": "c681d7786f7d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "64941de5e05e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "50cfb39550bd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1880d7035ea2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "56c4d097f3cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18da3456241d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6f5a6f71f9d9",
+    "reviewedArtifactChecksum": "dedaefc93ad4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18f288d70060": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "c8d47e576fc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "af6960b31b65",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "0318218fbbf0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "82e097edc7a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "2fa323416eac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "58bc1f41abcb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1cbba0417673": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "dbd365f4efb8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d16e17134e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "ee1994b89e4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "7c5622b823ba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "a62f1a742b28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1f594885b9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "7e1526f18b09",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "d43955dd0d23",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "f161101d6981",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "cac457924f01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "79aa25aeb5ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "4c6f16690912",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "231992fee1a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "8530623a067a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "27bacca060cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "81664c530a0a",
+    "reviewedArtifactChecksum": "1c2067f74f50",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "500d0ba434c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "d66ff11f895a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "e6f8b286ecb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "299685fcb8dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "7047b32ec8e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29be9776c3b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "f55e0b36b399",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "c24ce5ecec12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "aa4772f06d7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2c4b652466d9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ccc760fcbc2",
+    "reviewedArtifactChecksum": "ef5564b1665e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "8de8e7f383bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da9ee24ad74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4186cea3bf4d",
+    "reviewedArtifactChecksum": "c52811f902c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "300efdae24f6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "dc2c9bf4d4b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "ad163f059aaa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "8c129a0e42e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "34331bc6c523",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "2256804f112c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "8adc73cfd5ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "96cca14aeabc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "6bd5cf5520b6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "364e72458b36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5605da08c0e6",
+    "reviewedArtifactChecksum": "c9a92f046eee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3755b3465820": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "788a5febdf8a",
+    "reviewedArtifactChecksum": "9f0a008c266d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3858678780f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b9a6690fdf4",
+    "reviewedArtifactChecksum": "63e38f73b4a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "06cfb32b3deb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "802235b77266",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "7f5ff23b2339",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cf3c6a082ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23fa60e1ebba",
+    "reviewedArtifactChecksum": "644ef36a5a05",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "badb8f5f0917",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "595fef3c6465",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ef4de40106b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "3ec1e62fa059",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "b632bb4e9a6b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "430b718c2c90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "1c867f535472",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4540c3f34805": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "6ccce44f3f43",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45638e198c1d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "7d3ad22585ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "5285b99e9fa5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a80518c9c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55cd4863a54d",
+    "reviewedArtifactChecksum": "8a965c73123c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "b6cb7171f2b6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "3f0b5a24e0bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "51ba1066ea6e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "3fd82166118f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ca799182440": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a16c03fe7032",
+    "reviewedArtifactChecksum": "5c43c8a041ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "8c4a24b1bf53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "89b0703adc52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d989a34d147": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "5373407a4f54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "8c39f8b54573",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e430639b9b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "a776daa747d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "8c132e8434fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "fb380a3c92ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52dd3f09bb59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce2975c65c9c",
+    "reviewedArtifactChecksum": "f1c18a2c2f44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5427ef92c853": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "dd008d75adad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5615df5d2e0d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "baf17938711f",
+    "reviewedArtifactChecksum": "58f1ec99b7a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "563f9b5f6ce3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "092def4efba1",
+    "reviewedArtifactChecksum": "ef2a254ab429",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5652fbe7f479": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ec4de54fd666",
+    "reviewedArtifactChecksum": "96c35783c025",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "585c7006af9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "2cfa329ec1db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "d39a806b2a13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "6888dd99e9ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "a22127e21336",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "c832bc588db7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "9eb96f0665b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "fd985b99532e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68c39b4c6a6f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5106ec4eb948",
+    "reviewedArtifactChecksum": "1127e7198a9e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68f726502f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "d6a31e622810",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "e96def739663",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "25e012079059",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "ed689e1f9ca8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "d49d1b3254a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "9309fa388253",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "82db3b2d540b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c3fa01b5d73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce44981723ba",
+    "reviewedArtifactChecksum": "e4613e80cbef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6d0042d2f554": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07611af3f621",
+    "reviewedArtifactChecksum": "075b9d704731",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "257b05826a19",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70dea50257fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "d04a552cfaa4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "d49be8757c13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "6001a2e94d8e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7330608df8b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "84f950ac49b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "6aaefeaf15af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "736ab92b893a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ca13f304ebba",
+    "reviewedArtifactChecksum": "663a231eb5f0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "489d821c6dc9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "46aeac11ae1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "75fb83052003": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2997faf42514",
+    "reviewedArtifactChecksum": "a2ef31bf5c6b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "45bb13a1d2df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "0e7d714a5f0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "1516ca225c5e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79bdba6f2250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "35caddcbe4d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7a6ab8b6e694": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bac15fa24b1e",
+    "reviewedArtifactChecksum": "b70ca892a7a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b25a77c44de": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "c04e41b212b3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "f9c56ebe5b2a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "9a826d5f4574",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "c87940e928e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "72061c5fdeca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "83ff3768d42b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c3e7617c972",
+    "reviewedArtifactChecksum": "40ab4491d073",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "840b6e4c3983": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "575ac8693ee3",
+    "reviewedArtifactChecksum": "5a3941395d75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "680ad369378f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "874c251ff2f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "3e0bbc18ac0c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "25613bfbe713",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "d474f6c872fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "894c44a995a2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8eec53904a2",
+    "reviewedArtifactChecksum": "d4e8486d0c04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a1f5f5998cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2d71fda9dbb3",
+    "reviewedArtifactChecksum": "b0dbfea60054",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8bd8b493eb7a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a017392574e5",
+    "reviewedArtifactChecksum": "a6bab3c3610c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c90417df6d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a607c0fb4184",
+    "reviewedArtifactChecksum": "926d7c1e70fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "72d6bb1a2f28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "a15f8b5cb9a4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "d1ead8b615af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f90aec3d12c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b3ffacce720",
+    "reviewedArtifactChecksum": "ad1dd4a2d995",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "8e33ec9bba55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "7ac4d2a6addb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90d086fef9e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7ef0f5883edf",
+    "reviewedArtifactChecksum": "a4df05139959",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "a869c229063b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91ec966e3abb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "26094c3b1ded",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "920c6926e747": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "850f8a55b20a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "cc7d75f68aaa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "7d2fa1b471fb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9394f9968da3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3dcee651464",
+    "reviewedArtifactChecksum": "f187e7a58f0d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93f286fbc2c8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "37ff0c409aa4",
+    "reviewedArtifactChecksum": "f770215639d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "947be2b6d997": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "47cdcdc5b1c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96f9694b12c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "a6cc34a39270",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9717b437111c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "e2441905358c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "44034d4fc9d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "9cdd141c0e03",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "fe74d62a4ee9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9851c174a194": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd55d897b05c",
+    "reviewedArtifactChecksum": "ebaa3cb8c7e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "a5faa0689a08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "9b192f278011",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99ac5a75449c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "e55ea59cb321",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9a2d779f8ddb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22a817436ead",
+    "reviewedArtifactChecksum": "d0b8d35b87d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "2856eadd540b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "e2fb735a656d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9be3d7110c75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "720c2d466f57",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c0e04762e99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "409e8afd3ba2",
+    "reviewedArtifactChecksum": "04cced33906e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "94cb9867de46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cc2917611e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "0eac771805ee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9d588c37e728": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "6bcae7b12f6a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "f98ed5894c57",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "7a28a516b9ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "2913a65053ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a084de008c94": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "e5cfd61d46f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a09d65985659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "05dfceafb99c",
+    "reviewedArtifactChecksum": "9c89b7445771",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "a8334026e8ee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "f5f4caad9323",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "843d209e035e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a335e0968d76": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a271486f288",
+    "reviewedArtifactChecksum": "ad25497a167b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a39b591d8c3b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a234de78d008",
+    "reviewedArtifactChecksum": "f05a64b24e6a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a47d77950ec1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "b7b1a8820d39",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "abc6f31328bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a50ab9e1df59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e09f98cd488d",
+    "reviewedArtifactChecksum": "0de7e4813036",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "b65c876d6cd5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a58c512532df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "3e688e7374eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "49b137536f5f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "8b50ea443fa8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a84541c0018a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "e9bb5167c6e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "3b123ea014d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "cd0630002cc1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "ada2b643d73f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aac8b0d80e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c55f22e29a79",
+    "reviewedArtifactChecksum": "add579b23db4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "d39b74e45149",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "9e33b2433bff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "aa62af340ed1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ad8614720882": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d4fc106119f",
+    "reviewedArtifactChecksum": "bbb975a284cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "adca306765ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "98e537c704ae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "0780136edd84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "8af21b08e382",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afd30ccf8238": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8baf7e5024e1",
+    "reviewedArtifactChecksum": "b017b7e5e686",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "6cade935116c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "bcdc5ba9183a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "e4122c59b602",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "bc8d78a26ca6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "35ef2c8d4853",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "2c9a8ff2318c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "1e561c8ceff4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b5e0c3c14836": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e5859746672",
+    "reviewedArtifactChecksum": "7cadc3188ca5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6e55869de51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "84911d16a480",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "970176b798eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b993c1885a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "afba28767dc8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ba62b8d37772": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c238c0c4184",
+    "reviewedArtifactChecksum": "8c0fd03e2b1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "510b632882d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "074d00554cfc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "257e44fe533b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "367e6c821e16",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "3a858ae55d60",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0198b907108": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "821c79472d6b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a547f8fee6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9d006aaa7074",
+    "reviewedArtifactChecksum": "f6136e83f054",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "4cbbfe65ac52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1956ef24421": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a70fceb5d9f7",
+    "reviewedArtifactChecksum": "e44b27a70823",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1959fdc5642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "314621ba0722",
+    "reviewedArtifactChecksum": "faed7762e4cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "d4509641202a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "45743e9d455c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "9d950576b770",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "fed85a966ba0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2aae816fe63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c5a8fc3c87b",
+    "reviewedArtifactChecksum": "21f50392e916",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "5cc9ea00182f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c365c23d9a69": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "597c54e56f16",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c384585f8b2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "ef4e35f770b6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "66e87945df93",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "7851d1963a07",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c5cbee07611f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "e23bebea2443",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c666b9b4014e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "95e6e14fb699",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "74774da29bca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "0d27893387c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "600dc766a850",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "6e4e3aae2b70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "6f29813de327",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "3274fae45877",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc078724f871": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "abb2a8c1efc2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc23c187984a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3b18a4f3d32",
+    "reviewedArtifactChecksum": "b9e583c9f0e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "880d2f862c93",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "cd4122b1b0f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "6a4ff2707240",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "42b078a74c1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "865e764a86cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "ad5f0bc769b8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "34d025f75134",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "1eddabb97eb3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "2585db3e8529",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d23f62e48d10": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "46bd9fc0ef69",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "7b46b3d9e386",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d2cee11e428d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "23b2344f4c82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "2a2569351cb7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "81f7a58929fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "b957069c3649",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "bb199801d448",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "22a668e05022",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "1e8add39ce70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d768fd20d606": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "77242b0b0b21",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "632524b94316",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "d36d17afc604",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "dd315090ab70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "44c3d162a0e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dba8340fd0f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2f5928f73e0",
+    "reviewedArtifactChecksum": "a293921ac746",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "fc0110840bf4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "eb5d6a48bac8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc62b97bc1fc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "607d1c185682",
+    "reviewedArtifactChecksum": "c49117ce0954",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "fd5f4415f7a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc73712c1842": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b483aac476e6",
+    "reviewedArtifactChecksum": "e9b20a5161f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc7727f63c0c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb408a2280dd",
+    "reviewedArtifactChecksum": "3e7c64e31182",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "044ac61965dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "2d1ded27c7a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "fc404bacc306",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e173ace9bf90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "ab0676865fd8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "c80765cf1bbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "610dc13375a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "42c891c1dc96",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "7b32676c7a68",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5f83394283d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "f97be959ba87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "48e27fad8c26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "085154a96483",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e78f02853c98": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7a2357bf6d3",
+    "reviewedArtifactChecksum": "0d72f863018d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "57c3aedbed0a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e81f8eb0ee5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fee8d86b0c31",
+    "reviewedArtifactChecksum": "64ac3a48d850",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "4e3445266170",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9543e32164b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "0d978b176a77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "b3736ae22251",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "90e2372c6f03",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "74962f64fc97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "e29ea5baa274",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "f40eb4b34c97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef10fc1fe4d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f61d2cc731a",
+    "reviewedArtifactChecksum": "a3164fc3f250",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "be909489e1c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "aa34ee30717a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "d456d716ec9b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f052abfce10e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "aa544c21bf5e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "45baee3b27f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5199b5121f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "f35eddd25b84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "dc3a53f000f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "2eed990e57f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "0fa7a1251edc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "6712855faed1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "b3c56c30443b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f889bba5102a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "7ddcc8475c5d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "e4c1e395e45c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "ca71b6edad15",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "53831064c810",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd76422c14ea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "8f2accbbb1e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "f43731a86270",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "c08ccde16cf9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ff88e6723334": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "60750c3621df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ffbc62a77b85": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cbb7a2feaeb",
+    "reviewedArtifactChecksum": "690233ada398",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "f0de3fa20ddb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/fr.json
+++ b/site/src/i18n/reviews/fr.json
@@ -1,0 +1,4714 @@
+{
+  "00d3d57a5195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "18d757c3e105",
+    "reviewedArtifactChecksum": "1139f242f0ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "2d541b639360",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0136284ecc19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "ed84e93981c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "017694778c62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "23f59205b45c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "33f940cd7198",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "8030ab0164cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02b3722db38c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44edc2331fb8",
+    "reviewedArtifactChecksum": "74850f1474f3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "3c82592dd25d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "3f50bc661ebb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "2a5589c909e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0314e3bcf260": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "46fe50e34613",
+    "reviewedArtifactChecksum": "36c89e4a9910",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "a82401c6e8b8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "22f6a4e0bb9e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "454464bf4755",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "703be21f5adc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "f260310138c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0553e57852fe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c73130ac13b8",
+    "reviewedArtifactChecksum": "1dd49988f8c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "f6388ba148e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "8e45108d963e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "06caca08d30b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "68a16881c124",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "f73fd76cde15",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0801185d2115": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5c7d51b77a",
+    "reviewedArtifactChecksum": "6a8f428579f9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0812b435d117": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "a2dad01bac85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085a4bba12f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "5835f800e081",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085ff06f65f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "e18a309f5ada",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "63aa6a407525",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "1016b9580473",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0a6672ca248d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "921ac45569bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "d0fac30845fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b405e2734df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "28fc4018f09d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "9361bfbe7ea6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "90a44f1b67b6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ba871b9578d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "75c2d00c37fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "2cae6a991b97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "6d0e8bb6cea0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "071936a82abe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1043317e75c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "77d3d5eac6e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "105559626c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e095741cc033",
+    "reviewedArtifactChecksum": "292519f0e5b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "113c9ab2c6d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387ec1f14afa",
+    "reviewedArtifactChecksum": "4a03e8661465",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "11657ed32877": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "63b92d2012c3",
+    "reviewedArtifactChecksum": "3533e2ded7ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "aa3de581a7b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "12c2481d04b4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9c6ff6175b64",
+    "reviewedArtifactChecksum": "73a717acf8c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "b3201bb68458",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "13ba3af78782": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f35ddb881ae7",
+    "reviewedArtifactChecksum": "0416505aa5fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "92247f24a585",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "14597b195403": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c17e54fbe09a",
+    "reviewedArtifactChecksum": "e0d81c9a1212",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15538e51d812": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "935eb3882193",
+    "reviewedArtifactChecksum": "4f40604d07c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "4823762e50d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "56f1162f1e61",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "ac7d25dfd544",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "16f123e593db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "aee601a8b3a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "5512bc8c7661",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "5fcc331963ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "a32397dfc658",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "182021fcf3dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0eff80aeaad",
+    "reviewedArtifactChecksum": "13981876165e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1880d7035ea2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "44ed9b40ee79",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18f288d70060": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "aaf573771cb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "a1b5d73dd74e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1af3df552a07": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "312654aa6ae7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "4af79cf5bdc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "d4268dc4fb24",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "4c4211bdffb8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "e7f607f21b30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1cbba0417673": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "d46898256695",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d16e17134e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "b405b3b7c76c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "10bdf161699e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "32d393a881fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "a2d631d694c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1f594885b9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "ea28d9fddaad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1fb07c3b4b99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d2ce08d29a8",
+    "reviewedArtifactChecksum": "3c758c1a7fe2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "c957ecdbbecf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "392a5cfa6fc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "5e332edc63ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "fc8f4a74ba23",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "65fe960fc789",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "231992fee1a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "e80de8338428",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "23226868cf80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "267006baa10b",
+    "reviewedArtifactChecksum": "0035f1eea7b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "0e302c3f0897",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "260ed6c2147f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73a812d2aaf7",
+    "reviewedArtifactChecksum": "bdbd64c322d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2620e5135442": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "898d2af58acc",
+    "reviewedArtifactChecksum": "b510aa579670",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2639a76cf00e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "688d48d48dda",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2652985596d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eddea5c0dbca",
+    "reviewedArtifactChecksum": "9077f7375439",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "268307c5793e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e73f6dbefda5",
+    "reviewedArtifactChecksum": "2f6839582ce8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "26e1f4eddd7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44093fc53faa",
+    "reviewedArtifactChecksum": "958b226b1a0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "27bacca060cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "81664c530a0a",
+    "reviewedArtifactChecksum": "84a64d5bb676",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "68d12bb2026d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "28bef9a984ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b5c9754c6f0e",
+    "reviewedArtifactChecksum": "f1632a88be54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "430429a980de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "230bfdb3db3b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "299685fcb8dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "c95aeaedf69e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29be9776c3b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "95644423f390",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "61717626aaa5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "d5fff79fe526",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2c4b652466d9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ccc760fcbc2",
+    "reviewedArtifactChecksum": "fc7476f1af26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "ff431ea34de2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "e4e9008bf8af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da9ee24ad74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4186cea3bf4d",
+    "reviewedArtifactChecksum": "f2f000abeace",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "792f27c0833f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2f10814fd823": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "978c9ade4d59",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "e6cf909bc716",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "f4522381cd34",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "143fdd8c0b8e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "e0248848c9df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "9b04bf3343d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "193c0c6a1a66",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "cd0326588301",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "b8e6de17490c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "a11dee32aef9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "bbbd01f90815",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "2086ea29959e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "364e72458b36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5605da08c0e6",
+    "reviewedArtifactChecksum": "50cdb9ae57fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "36794f399aa0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "7eae24da3039",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3755b3465820": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "788a5febdf8a",
+    "reviewedArtifactChecksum": "c10dee7cf449",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3858678780f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b9a6690fdf4",
+    "reviewedArtifactChecksum": "420405ba269f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "f80442bb8182",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "e5650a5a0234",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39d6048bf91e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3a2c2fbc8ec",
+    "reviewedArtifactChecksum": "491a8f55a556",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39f7098079f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e2c27847ee1",
+    "reviewedArtifactChecksum": "f33b14945698",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3b9e9f29c1dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69a67afce7c6",
+    "reviewedArtifactChecksum": "095eb85a9d65",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "bd8d4f33175b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cb47a67b81a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "19d587d12601",
+    "reviewedArtifactChecksum": "8d90397e77b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cf3c6a082ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23fa60e1ebba",
+    "reviewedArtifactChecksum": "36a0beebaf5d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "b2ce26ecee0c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "bb13e39cab67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3eb92c1b2380": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bf7aa20f745d",
+    "reviewedArtifactChecksum": "2f1503b8abc9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ef4de40106b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "cc60fc1f0186",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3efed399a12d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ef55610485f",
+    "reviewedArtifactChecksum": "96164b6565f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "404250f61d0a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6f1fe977608",
+    "reviewedArtifactChecksum": "49611b887dc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40770c9eb41b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "e3dd5b4c2bb3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40a427168ef7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "0ff771cbc96f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40dea2f852c3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "fb5210c2d71e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "d28b5d351247",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4176b98e2b7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "810032a8dcaa",
+    "reviewedArtifactChecksum": "5459a05ec354",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "417d8dfe78c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "583467999376",
+    "reviewedArtifactChecksum": "ff3a43b257fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "41f029c74cd4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "fdcb2181b351",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "430b718c2c90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "ad1238feb941",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "58151101ad6a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "44d156cf2723": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e049f067e24",
+    "reviewedArtifactChecksum": "863e29a8994d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "452e68e4a484": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "9e2097279cb4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4540c3f34805": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "a5f1d51ce16e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45638e198c1d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "0a687cc390a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "94161aaeda79",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45c0ce6bcf2e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "152763825cc8",
+    "reviewedArtifactChecksum": "bd2511ce1042",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "a7b79ed40cef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "460daa6b205d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb1e02435d8e",
+    "reviewedArtifactChecksum": "7ccd7bb5d738",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a303cbccf9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ff3f48dc5ef",
+    "reviewedArtifactChecksum": "234f7caa1c79",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a80518c9c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55cd4863a54d",
+    "reviewedArtifactChecksum": "776cf81e904d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46fc617ad144": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8f8ad09fe7e",
+    "reviewedArtifactChecksum": "f5bd157a29de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "471717404074": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "cbdfa1b203dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4724032fa666": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "9ce7c7502985",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "e43a6276c1cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47a892d81764": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "376ecaaeccc6",
+    "reviewedArtifactChecksum": "96af9b2ec313",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47d245c34a7d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "1c6267e3f593",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a4da321a45d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04f477efeaa6",
+    "reviewedArtifactChecksum": "ede18c51a18f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a6697085e75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad1c8a8ecac9",
+    "reviewedArtifactChecksum": "b010c238a65f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "9bfb060dc488",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b042b6638a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27c46c50ab30",
+    "reviewedArtifactChecksum": "1cc79b690eb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "2d490941f701",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "290cc0fa8872",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "9016087d8f1a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ca799182440": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a16c03fe7032",
+    "reviewedArtifactChecksum": "8a4c4b93cc19",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "08a56865cba0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "6b0273ec7be1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d989a34d147": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "a90d12269950",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "097bf72f1e73",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e430639b9b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "fd740c34273c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e57a7fe516e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83e635a7828c",
+    "reviewedArtifactChecksum": "18b0e486ea3b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "230728ac7118",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "597dbb6b4698",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "f4c070994997",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4f8b62bfd681": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d64266bfd70",
+    "reviewedArtifactChecksum": "12c709971bf2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "45e336a55bca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "50199f76fe74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c1fb24a9e72",
+    "reviewedArtifactChecksum": "0326400a833e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "ed3351417c07",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "57888852728b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "5fb8f0c88590",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52dd3f09bb59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce2975c65c9c",
+    "reviewedArtifactChecksum": "35f54a7bf205",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "536dc32faee1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a12ade6eb6f",
+    "reviewedArtifactChecksum": "8b96e3ee5096",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "537cf7f1f745": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb039818c192",
+    "reviewedArtifactChecksum": "69356547dd1e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5427ef92c853": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "d0d451aea1fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5489b3cf2ac1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62d873360da1",
+    "reviewedArtifactChecksum": "701cf4907b16",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558cc012978d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9a40936909",
+    "reviewedArtifactChecksum": "559d5630cde8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558dc01ae546": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c5045c9c5f05",
+    "reviewedArtifactChecksum": "96487a8e340f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "560738f98e65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "73f35f34fb0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5615df5d2e0d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "baf17938711f",
+    "reviewedArtifactChecksum": "ec6269924662",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "563f9b5f6ce3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "092def4efba1",
+    "reviewedArtifactChecksum": "f7852c4dafae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5652fbe7f479": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ec4de54fd666",
+    "reviewedArtifactChecksum": "efba4cf52678",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5697ddf9182f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "06066e655767",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "56e17946ef8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9233fda5148f",
+    "reviewedArtifactChecksum": "afb0692916f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "57eb4f2ddb92": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2271b8120f36",
+    "reviewedArtifactChecksum": "555f44fa64b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "585c7006af9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "56a0946bb772",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "476fbfa179ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5931e9bdf9db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "916bf36e3b22",
+    "reviewedArtifactChecksum": "68351a04a189",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "598da2637dc8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "f803fddf8221",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "5b800fc7e0d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ad4348c8417": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8e5f70f83529",
+    "reviewedArtifactChecksum": "f5cf3e4004a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ae006b13a36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa7092ff2f81",
+    "reviewedArtifactChecksum": "d18fca4b9998",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "1ab261bcf6ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "dc3be7d6110f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "ba07a989b6d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cef286d4c51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fab982dd28db",
+    "reviewedArtifactChecksum": "386f88ba3f64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d0cbc370579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "698aba7e4fe0",
+    "reviewedArtifactChecksum": "7b34fd69dd7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "701a70b6954a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f1e9e754358": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "5ddfad4d6765",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8b74d92e62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23954b90525f",
+    "reviewedArtifactChecksum": "fce0d727c4fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "15aa7fa9fbad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fd7dc1f9db5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70417a1c18f0",
+    "reviewedArtifactChecksum": "0e7ff43d8825",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "603b2d01feb0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bab688e65c3f",
+    "reviewedArtifactChecksum": "a080a1d39716",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "60e1839cbb34": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23ded424e7e5",
+    "reviewedArtifactChecksum": "fa657df5b174",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "615266189e02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a7cb54de4c8",
+    "reviewedArtifactChecksum": "e04cc57d1786",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "62cb2b168265": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9dc4ceaa4e05",
+    "reviewedArtifactChecksum": "9f376efb5c8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6332ca621968": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c422eaca74c",
+    "reviewedArtifactChecksum": "e0fb930a81cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "53aea2f13f4a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "07ac3329e491",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "64f4db9e3e33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "223cf2121461",
+    "reviewedArtifactChecksum": "9f9287636913",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "655893ad7990": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "904aabfd86ab",
+    "reviewedArtifactChecksum": "fa89a0f5ebfa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "65758201b8ae": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c1dcc0da6d2e",
+    "reviewedArtifactChecksum": "b1506a978649",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6645006a0cb7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "e5ddf2402627",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67981edb9ad4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa37a7c8d562",
+    "reviewedArtifactChecksum": "06de78606fdd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67a816af8a73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee604150adb4",
+    "reviewedArtifactChecksum": "2d1dcafbf3fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67b461209d58": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e95ee7304036",
+    "reviewedArtifactChecksum": "6abc4616e5dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68c39b4c6a6f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5106ec4eb948",
+    "reviewedArtifactChecksum": "ef7416dba79b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68dcfc02a679": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5dbfcd37a1ff",
+    "reviewedArtifactChecksum": "aea3402526c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68f726502f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "f4fe72c8a53f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "21a92415c1d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6991493996fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "68435d9b8d1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69a3789c4840": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "79a4cab80516",
+    "reviewedArtifactChecksum": "db67c2c8e0ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "26501171ce27",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "449c81c506b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6afbca6e9d22": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb05dda45844",
+    "reviewedArtifactChecksum": "f92d8ae3e3d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "5d48e5ac6973",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b3078795300": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "69ec632cd6a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "be740a69b43d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "1108df465bb1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "2035fffa3150",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6d0042d2f554": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07611af3f621",
+    "reviewedArtifactChecksum": "a13f5e685eb6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e099b1a7822": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85c8585ef6ce",
+    "reviewedArtifactChecksum": "a6f006ccaec0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "98a3a044182d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "80de9f008022",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "4063a886f8f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "d2259130535d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fcaf95e52b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b98247d4d4a3",
+    "reviewedArtifactChecksum": "81b3195ad3b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fec31e40f4a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc934cbc82b8",
+    "reviewedArtifactChecksum": "8a7d4a8fe542",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7016f027bcf1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "575fadcbc19b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70dea50257fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "8f2e296a4f73",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70e6b211c5ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bfd219d920b4",
+    "reviewedArtifactChecksum": "7b2294b5129a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "b81a0cdc0a8f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71355ee91724": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f168dc59d8b",
+    "reviewedArtifactChecksum": "a502aab58fb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71a0edbac544": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "3c896d537562",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "995c7d20a196",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "92c1d09cda89",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "730d964da0cc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "02c64ba307fd",
+    "reviewedArtifactChecksum": "e2d4d229d0b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7330608df8b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "a263897b59f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "7215695b3ce7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "736ab92b893a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ca13f304ebba",
+    "reviewedArtifactChecksum": "05108a34a2e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "73a6511dc29e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "728cfd09e417",
+    "reviewedArtifactChecksum": "421490ed6fff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "16b031fa2d9b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "098c4911bc3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "75fb83052003": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2997faf42514",
+    "reviewedArtifactChecksum": "3f6a760108d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "768526487e8d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f1c03a7a813",
+    "reviewedArtifactChecksum": "e07808519738",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "cea1e983aac0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "770640dfddef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "fff3ae7e312c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "46e4df4e9348",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "787cfd599758": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "1e6bbd9cf709",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7905fe6d550c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "0c313ac26bd3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79227f845a2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "e73e53fb466a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "339db09ca47a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79bdba6f2250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "7b554c1fcae3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7a6ab8b6e694": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bac15fa24b1e",
+    "reviewedArtifactChecksum": "b2f2779ac63f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b25a77c44de": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "471239af5689",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b973ace62af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "e03d1b5ce8bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7c0c712700e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9bf2dbbc9f",
+    "reviewedArtifactChecksum": "add34e8b4812",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "d8221fe320e1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cecbe192fc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "195d7bfcd500",
+    "reviewedArtifactChecksum": "7000a27ffe30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cfb99272578": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "3eeee3f7a235",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7dca0438edf4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a20647f365c",
+    "reviewedArtifactChecksum": "aefade08f710",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "597d65481b26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "8406ce3f9763",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "3876e34efedb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "60c4d77d68a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "0f95553f5b7a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "f4fcc98f063f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "825e6fb23c2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f9084ed9312",
+    "reviewedArtifactChecksum": "1d55abeb1f50",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "834ab8919949": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ddbe0761021",
+    "reviewedArtifactChecksum": "e5186b6b758d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8357db8ead93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "846d1964fbdf",
+    "reviewedArtifactChecksum": "12b29cf0527d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "83ff3768d42b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c3e7617c972",
+    "reviewedArtifactChecksum": "36fa9ca37d2b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "840b6e4c3983": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "575ac8693ee3",
+    "reviewedArtifactChecksum": "d9c02a128b06",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "847f17f3f95c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba380c49e96f",
+    "reviewedArtifactChecksum": "bd0d19eb6e52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "857e50707831": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "66e933457ceb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "254221267658",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "86efedaffa3e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "d4b93e34eab4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "874c251ff2f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "f0e44983466c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "fccb609be3e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "87f3b4c32e4f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "405b0711392d",
+    "reviewedArtifactChecksum": "f5d8ca1c7405",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88f014a33e2a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "9c00925bc30d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "894c44a995a2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8eec53904a2",
+    "reviewedArtifactChecksum": "b60b7ae76b5c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "895960b69952": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "722c1e63778e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a1f5f5998cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2d71fda9dbb3",
+    "reviewedArtifactChecksum": "208ef92d7bc2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "2b7067105e1a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a90e1694881": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "fe5f2135fd07",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8bd8b493eb7a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a017392574e5",
+    "reviewedArtifactChecksum": "66cad849825a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c553cc7c664": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "499792e4d375",
+    "reviewedArtifactChecksum": "37b168930196",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7390cc52c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6713a12925e8",
+    "reviewedArtifactChecksum": "d4623211d1c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "335e5e9be16e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c90417df6d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a607c0fb4184",
+    "reviewedArtifactChecksum": "ce8c901d6e9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "9d32ea24814c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "11a83f385c3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "ff3c8954f2af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "cb3a82e336c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "6a5d790b98aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f90aec3d12c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b3ffacce720",
+    "reviewedArtifactChecksum": "d47372ae7b7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8fe7ed30c4ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a9cc5890cb7",
+    "reviewedArtifactChecksum": "3be77ca82b99",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "7946d531f3dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "fce27d038154",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90d086fef9e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7ef0f5883edf",
+    "reviewedArtifactChecksum": "6b7c5fea744b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "911c19a4391b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8d806844167e",
+    "reviewedArtifactChecksum": "d00cba3f2fce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "881a9df7f5b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9173ef378024": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "b5f0594de290",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91a17d5206d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f80b0c183e1",
+    "reviewedArtifactChecksum": "dda3e44cc077",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91ec966e3abb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "331bded1a7e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "920c6926e747": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "14b6f5711d33",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "40b20cbaedd4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "dec46bd6a900",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "1d0a5920aa6f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93c182d3aefb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "48839bf9e5d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93f286fbc2c8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "37ff0c409aa4",
+    "reviewedArtifactChecksum": "b15e9b562f13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "947be2b6d997": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "3a69aee5ba04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "94ed41b87579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "adb1da920293",
+    "reviewedArtifactChecksum": "58cab3d9770f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9654558acd06": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a12731a191",
+    "reviewedArtifactChecksum": "ca160c2baf95",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "4fc54a276e97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96f9694b12c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "cd59a70e1273",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9717b437111c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "dfa520088298",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977bc7f55865": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16b8504f3ddc",
+    "reviewedArtifactChecksum": "44aeed366429",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977fefa2b934": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78dc929ff375",
+    "reviewedArtifactChecksum": "85da477f6bdb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "f935b8be91de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "6584dad644f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "8b0566a47303",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9851c174a194": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd55d897b05c",
+    "reviewedArtifactChecksum": "747dec160f44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9974666c3acb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71d3d1fa5eeb",
+    "reviewedArtifactChecksum": "bd18b21635d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "7d45142202c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "56d8a3b83d2a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99ac5a75449c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "88a4125fe242",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99aec65eea89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "08ee59c22c25",
+    "reviewedArtifactChecksum": "b948232d9740",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9a2d779f8ddb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22a817436ead",
+    "reviewedArtifactChecksum": "a5e589838135",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "4ed35b009b39",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "e4f9b41cbc3f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9be3d7110c75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "36425ba72384",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c0e04762e99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "409e8afd3ba2",
+    "reviewedArtifactChecksum": "332a94f88e5e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "83d703616de1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cc2917611e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "b3cf58225f92",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cca5e2b3dde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "478c9fb1fb03",
+    "reviewedArtifactChecksum": "88001de6083e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9d588c37e728": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "d8deb827c294",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9dac2dae8bfc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aef58f46958a",
+    "reviewedArtifactChecksum": "e98a0992f161",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "8a13340d295f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e910f3b95c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "222b5e4fda0b",
+    "reviewedArtifactChecksum": "fd3f97f6d18c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ed4f6b88b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c3118fbc5ef5",
+    "reviewedArtifactChecksum": "dbf981ccbc92",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "9df803f583e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f1bb8c2f14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd521aa22072",
+    "reviewedArtifactChecksum": "9d47c83147a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f9f595534d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47ebf99edfc0",
+    "reviewedArtifactChecksum": "ef7ada46284e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "c22e90ef8a60",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a013e57e6d51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3676bc6af0c3",
+    "reviewedArtifactChecksum": "0f52ba5b1cfa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a084de008c94": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "4aa4f2b8a624",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a09d65985659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "05dfceafb99c",
+    "reviewedArtifactChecksum": "e8151ea4cea3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "6f1a54e56f04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "fd15241bd269",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "6b00f36f78fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a20d3822a38f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "15e223da937d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "f5f861d73c67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "a954b7a331c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a3e50e79cb89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fbf819fbfc3",
+    "reviewedArtifactChecksum": "ef5ac02e4b7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a47d77950ec1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "b47a204214a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "973a10f13074",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a50ab9e1df59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e09f98cd488d",
+    "reviewedArtifactChecksum": "0775c38036c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "878c78c50446",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a58c512532df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "2aaae9147a4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "8d89b5eb5cc5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "28f81d10b979",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a781503cf508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "60d43bf3159b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a84541c0018a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "d8df947e0dd3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "196e7743d6dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d139dba458": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6189bdf610c",
+    "reviewedArtifactChecksum": "3436d5a39ed0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d874e28508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "89528effe70a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "e58c071846ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "b1ad927a9180",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9241caf70ac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "25699da31ab8",
+    "reviewedArtifactChecksum": "b45de80e941d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "84eabf4029d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "6c8d25344b56",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "a1cb7614de12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aac8b0d80e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c55f22e29a79",
+    "reviewedArtifactChecksum": "3e6be8c225cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "79e3a2ae147b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "d4d10c871a67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "1f2ede8d0883",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ad8614720882": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d4fc106119f",
+    "reviewedArtifactChecksum": "90b9a298e47a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "adca306765ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "7f57654d9a5f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ae12a241076c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "b41103bb7329",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "282da1397b97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "e396f6d40a62",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "d7433ac631df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afa2656c1d4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9062cb86b8e5",
+    "reviewedArtifactChecksum": "7cf78d40bc3f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afd30ccf8238": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8baf7e5024e1",
+    "reviewedArtifactChecksum": "7633d6b2e367",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "0e81d5b50b4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "23e0a844ec58",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "1957a344287e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3437893d89d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "0bf26d0d9a23",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "20ae3f8f830f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b35c9fa7658c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52f2757246e6",
+    "reviewedArtifactChecksum": "4acc5d8d4d32",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b37902cee452": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e60d5dfd84a3",
+    "reviewedArtifactChecksum": "7945d55241f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "19c7b51a53e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "b3f8d430273f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "2f1cbf869aa0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "dcfcee0bebd1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "487442119497",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b594a01df1d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "94660f232c6a",
+    "reviewedArtifactChecksum": "0c5b79accd6c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b5e0c3c14836": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e5859746672",
+    "reviewedArtifactChecksum": "f0f1a5d9f4f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "12edb3ed196c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "328ca9a193b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6e55869de51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "4f65cb469f62",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b74ad340c930": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "0a2070f5c81d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b893149a8671": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c53aa635287a",
+    "reviewedArtifactChecksum": "6701f61416fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b89d812e25e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "bbe9de729aa2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b8c030205d86": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "68acaf7bad68",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "883eacdd2756",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b95499a55c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16809786d5b3",
+    "reviewedArtifactChecksum": "a494d97c4af8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b993c1885a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "6cef1b39f5c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ba62b8d37772": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c238c0c4184",
+    "reviewedArtifactChecksum": "b720228ded13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "baa06a413558": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb0421c78c54",
+    "reviewedArtifactChecksum": "03e53567532c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "f202a8439fa5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bb33cc433026": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "8d33e202e326",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bd874c5e02d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b205dfd4c7b0",
+    "reviewedArtifactChecksum": "6b97b36147c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "db2afd1d52fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "20468c239d38",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "d301b633ea87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "b4c2eba6dcc3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "ee14709dacb0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0198b907108": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "d681edd73b26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c01a333cfbd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9026217dfd87",
+    "reviewedArtifactChecksum": "7f4d81ece310",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "d4bc0b30be6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "0922f1bcbbaa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a547f8fee6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9d006aaa7074",
+    "reviewedArtifactChecksum": "114a7e76daef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "3447f016e4b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1956ef24421": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a70fceb5d9f7",
+    "reviewedArtifactChecksum": "374148d4affb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1959fdc5642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "314621ba0722",
+    "reviewedArtifactChecksum": "76f6bd6cbd67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "7b460abad33a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "7f9b6dc49681",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "54773830938f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "1f182d2c7a2c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "19874f8617f9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c365c23d9a69": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "1373266175b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c384585f8b2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "cd6760def284",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "25688c7abb34",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "f764c4c3a717",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c5cbee07611f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "ea4ccc7907a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c666b9b4014e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "dccd3b0f0554",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "29dbd72d8ec1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "e4e4d029f40f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c70904777c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "071b867ec2e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "646fc63c08fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "921a84d7fe40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "d248a933f5be",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c98e5c457e1e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8bc16ce3029",
+    "reviewedArtifactChecksum": "38787175a2aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "ae83c876eaf4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "40e236421495",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc053bb55df6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b9c62043d7a5",
+    "reviewedArtifactChecksum": "a3e8ba280872",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc078724f871": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "0e9e3a763ef2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "3aeb11bf626f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccc43113008f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "63dfb2731107",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccf567b604be": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "1fb1f9d63150",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "ee2e6322ecc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "9c15ff0e2d40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "20e96b800359",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "53d281c68f85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "96a99ed057f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "5de5efd0bad9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "710f7892f776",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cff9f70a9137": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0888293ad9f",
+    "reviewedArtifactChecksum": "89d4e34be79c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d124e24eca67": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c2a79ee0629",
+    "reviewedArtifactChecksum": "d43befec1376",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "07e3855b1f38",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "098e9aa1742e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d23f62e48d10": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "adbe1c356a74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "ae4109f93ee8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d2cee11e428d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "4ae4c31121b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "6955d0f0ce75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d4b951896b54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "74603b189b71",
+    "reviewedArtifactChecksum": "759cbf75d8ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "535f2bb0af8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "63748863a563",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6109704c9d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "e82460a252dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d636956bdddc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "347270630198",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "2f740ee39422",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6bda294b8ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "347186231e5f",
+    "reviewedArtifactChecksum": "bc54646ef846",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6e252fb4880": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "aac2ed4eaa91",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "9b703a677464",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "f6da46836727",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d768fd20d606": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "4e21adb63f54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d78377cf53f4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62ce15566253",
+    "reviewedArtifactChecksum": "fd6163fdd49f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d82f4527c76a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6517985e895c",
+    "reviewedArtifactChecksum": "2351dbbaded7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d833dc5abe59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ff8e0fc1088",
+    "reviewedArtifactChecksum": "f1b565f80966",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "7fe32b71bebc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8bd574de179": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ed010eb61ee",
+    "reviewedArtifactChecksum": "b524f2778dd9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d99717df8788": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "746e2830ce5d",
+    "reviewedArtifactChecksum": "d38f7bb5fa36",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "a18d6c618782",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "0986f5c7ef84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "92fa33dce3bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "b6ffd31687d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dba8340fd0f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2f5928f73e0",
+    "reviewedArtifactChecksum": "48afbb8ffa1a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "9a2066a860bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "8691dedad14e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc4b3f6dab6e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bbbc8180df94",
+    "reviewedArtifactChecksum": "ff8ed3cbfefe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc62b97bc1fc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "607d1c185682",
+    "reviewedArtifactChecksum": "5f7012a330db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "4e1385655faf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc73712c1842": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b483aac476e6",
+    "reviewedArtifactChecksum": "8df6962c6cf0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc7727f63c0c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb408a2280dd",
+    "reviewedArtifactChecksum": "45af8593f30e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "1626aa9cceeb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dcf21d867c91": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7b380339f8c1",
+    "reviewedArtifactChecksum": "f4f58acd2dd2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "7204152426bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dff780783fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "bce52ed92572",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "118aed9c13f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0df9e9c7683": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07c0da77ff02",
+    "reviewedArtifactChecksum": "fedd74aef887",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0f1fb8115ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2208cdd14461",
+    "reviewedArtifactChecksum": "c78c61a8ffaa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e173ace9bf90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "43018fa69cf2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2716c39cb46": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88d2297a2338",
+    "reviewedArtifactChecksum": "9ba2d647c58f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2df0992de37": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f18a7f8283b5",
+    "reviewedArtifactChecksum": "e60f0ceb2c53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "614de812e620",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e41b80eb587d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "13e96cff6054",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "80d1c4372d93",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4d64e14c5e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a8b9fb83ba3b",
+    "reviewedArtifactChecksum": "29e51fe87047",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "c5d91998a576",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "6cb2cf919e81",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5f83394283d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "ea8ab6b49f6f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "36f083043f68",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6aa60b3fa90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "157edbd2a5dd",
+    "reviewedArtifactChecksum": "f7498e3a3939",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "3773abdb88d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6f74ca84e32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e68fb1567b85",
+    "reviewedArtifactChecksum": "454f49eff3aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6fd8da0c247": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aefaba1e21a5",
+    "reviewedArtifactChecksum": "3ae40f928ce9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e78f02853c98": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7a2357bf6d3",
+    "reviewedArtifactChecksum": "a78421622ecc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8099b642c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab48a85786be",
+    "reviewedArtifactChecksum": "7f0fdf3dd0ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "ace3069004a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e81f8eb0ee5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fee8d86b0c31",
+    "reviewedArtifactChecksum": "d071ab544aa8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "d2541df8166b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9543e32164b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "c385c075db5f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "856edaa43b20",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9f70b059f43": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f2449f49b504",
+    "reviewedArtifactChecksum": "448fbe43859e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea4911d91143": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a921f371596f",
+    "reviewedArtifactChecksum": "bf0efe0208a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea6154c3447d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "49ab4b5c4f32",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb53769b541b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "882c4917c540",
+    "reviewedArtifactChecksum": "61a86b48d4eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "40786dfc6173",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "d015f61d4e52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "05b3ad9f0fdb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "855163ca0538",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "50f60149c4c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "f092d815f07a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef10fc1fe4d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f61d2cc731a",
+    "reviewedArtifactChecksum": "165a240ac3dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "c9028e87f67d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "7054a342c558",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef543bd4a773": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7debec13329",
+    "reviewedArtifactChecksum": "0aa6dbf7bbae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "408292247e91",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef8586090398": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "c67dc803c2ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "5da64c8c5983",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f1dc525f26dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0240a925b535",
+    "reviewedArtifactChecksum": "5f4211e9e360",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3096e2ffb64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20e28569e2d2",
+    "reviewedArtifactChecksum": "c3e2ae28e120",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "779af6939a24",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f49b24114ea9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e89780c7120",
+    "reviewedArtifactChecksum": "06e80f2d6bca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "4995f233aa9e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "b2d0afd49357",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5199b5121f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "bb905245dc09",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f56329f28659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "a06601a0d190",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "27a559a17b51",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6be37ba0bde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a4060336a6",
+    "reviewedArtifactChecksum": "4ef1c505b078",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "c07eff1aa11b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "b4a7b1c888c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f83ee3caa04e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a47e936b4941",
+    "reviewedArtifactChecksum": "3454623214d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "c3d5dbe8be84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "4a38e79fbde0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "0ef29ddad334",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93775fd8ce0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41bb23f3a44e",
+    "reviewedArtifactChecksum": "32dbfba13c7d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "9b94aedd8249",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f9cffe716495": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "beaa27cce795",
+    "reviewedArtifactChecksum": "ffdb0f653d67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa1f01a51d17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "33418f4fe697",
+    "reviewedArtifactChecksum": "ee78bb67eb12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "af7dee827bb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "4d8c8df0b6b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb63409aebf0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f40a7e7b42da",
+    "reviewedArtifactChecksum": "e57a897a4711",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "cebdc2f9b064",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd76422c14ea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "1113d209fe6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fdab9848b160": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bc70dfe515b2",
+    "reviewedArtifactChecksum": "226816e82d57",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "b4514a6f3a1e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe773d7d7377": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "f922f54559f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "1ebcf3b7492c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ff88e6723334": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "7fa4ed358b08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ffbc62a77b85": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cbb7a2feaeb",
+    "reviewedArtifactChecksum": "f611620558c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "427dcca61bfe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/ja.json
+++ b/site/src/i18n/reviews/ja.json
@@ -1,0 +1,4842 @@
+{
+  "00d3d57a5195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "18d757c3e105",
+    "reviewedArtifactChecksum": "069c04b8f0a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "5d479cece346",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0136284ecc19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "bc60b7c7c6a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "017694778c62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "383770cbfd18",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "ff6a6b8554f3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "20e78dce6fff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02b3722db38c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44edc2331fb8",
+    "reviewedArtifactChecksum": "ae185e26f99e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "68b1b84e0068",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "89bb8243b397",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "cc9136841f0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0314e3bcf260": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "46fe50e34613",
+    "reviewedArtifactChecksum": "fd1fb9e63ed7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "107d69fe4353",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "820a019bbb8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "e44feaab0bc3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "65ca59eaf525",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "6a2c3d1c924c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0553e57852fe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c73130ac13b8",
+    "reviewedArtifactChecksum": "2693cc6d9f64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "6794fdb34355",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "c2cb0e34933c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "06caca08d30b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "48c3e52b6c38",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "ae740fbc375c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0801185d2115": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5c7d51b77a",
+    "reviewedArtifactChecksum": "3f3af0f44a53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0812b435d117": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "ad836510b005",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085a4bba12f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "33ab475fd81d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085ff06f65f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "58a5b46f7ffa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "b5223c5571c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "bd3c330397f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0a6672ca248d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "812983debe3f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "46ce6c79bfc3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "90368b801b30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "c2f71caa542d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ba871b9578d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "88f27533a064",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "846086638627",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "9062715e050c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "eaf0f6e0b416",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1043317e75c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "b6fb1a7fce64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "105559626c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e095741cc033",
+    "reviewedArtifactChecksum": "84d7abb7525d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "113c9ab2c6d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387ec1f14afa",
+    "reviewedArtifactChecksum": "ced2a5670695",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "11657ed32877": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "63b92d2012c3",
+    "reviewedArtifactChecksum": "d10af726cc3d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "b15eada7d0cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "12c2481d04b4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9c6ff6175b64",
+    "reviewedArtifactChecksum": "c9616f22d1f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "cb9f9682080a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "13ba3af78782": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f35ddb881ae7",
+    "reviewedArtifactChecksum": "1a6e0473e030",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "0216900a16fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "14597b195403": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c17e54fbe09a",
+    "reviewedArtifactChecksum": "06284a83e69e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15538e51d812": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "935eb3882193",
+    "reviewedArtifactChecksum": "36acf4a1b16b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "0bb654767fab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "11fb2f32dd5d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "11d00ece68b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "16f123e593db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "7824eb67c756",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "171dea657096": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91799cf35e77",
+    "reviewedArtifactChecksum": "35c9ff1422cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "fd8a7893502d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "5ce415c65cba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "826af6de2db8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "182021fcf3dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0eff80aeaad",
+    "reviewedArtifactChecksum": "1a61ed7fd58a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1880d7035ea2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "6ecfb87ac0e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18da3456241d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6f5a6f71f9d9",
+    "reviewedArtifactChecksum": "3e7e8005abf8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18f288d70060": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "f7df939da284",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "0a19ebb2afa6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1af3df552a07": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "3efbe6458261",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "ab1af64c817d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "63752467baf0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "8d92df73ad82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "79591c7d3667",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1cbba0417673": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "65c510dce4b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d16e17134e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "f72975cb7b46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "949770d7c466",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "903ebf66cd81",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "86d33ede6f04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1f594885b9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "59f6950e47a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1fb07c3b4b99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d2ce08d29a8",
+    "reviewedArtifactChecksum": "d4c18dccfbdb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "ce6dbc9a677c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "47121be19047",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "508bda6313c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "89531b3302ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "b8215e256d98",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "231992fee1a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "95e843cc7999",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "23226868cf80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "267006baa10b",
+    "reviewedArtifactChecksum": "6b82316ca35b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "f52c1ba98318",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "260ed6c2147f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73a812d2aaf7",
+    "reviewedArtifactChecksum": "3bfb06b4c7bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2620e5135442": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "898d2af58acc",
+    "reviewedArtifactChecksum": "07ee7651108f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2639a76cf00e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "aa2cc4e52d33",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2652985596d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eddea5c0dbca",
+    "reviewedArtifactChecksum": "9bdc9d074511",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "268307c5793e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e73f6dbefda5",
+    "reviewedArtifactChecksum": "a593552e2d3c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "26e1f4eddd7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44093fc53faa",
+    "reviewedArtifactChecksum": "dc82166c8421",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "27bacca060cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "81664c530a0a",
+    "reviewedArtifactChecksum": "148020f4d6de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "94f3f0d031cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "28bef9a984ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b5c9754c6f0e",
+    "reviewedArtifactChecksum": "6b449ef5dd81",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "f60cef3a5d9d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "6111f15fe060",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "299685fcb8dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "e41e768465ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29be9776c3b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "fb69940e9794",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a95da601676": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f3cd6bdb534d",
+    "reviewedArtifactChecksum": "f22c5da217d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "9ebc97c0b97f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "1de826b7a7f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2c4b652466d9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ccc760fcbc2",
+    "reviewedArtifactChecksum": "ad4372341af8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "ab730eedef70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "7120d54439ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da9ee24ad74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4186cea3bf4d",
+    "reviewedArtifactChecksum": "cb0a3f241459",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "492eed613d4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2f10814fd823": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "d6b5e24edf43",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "8092fd748b04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "300efdae24f6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "a9827f92a337",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "689a9ec40d95",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "41fe64825791",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "abb221d3b736",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "8dbb9a285909",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "d071f43f3896",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "6c6cfbbb9a49",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "3053446c2610",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "e357ba04b121",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "f6a441b319e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3515c5083027": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "554e4ef6a5f3",
+    "reviewedArtifactChecksum": "38ccc05f7a77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "351e79d06ae1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "358d6127c306",
+    "reviewedArtifactChecksum": "128c02f8c829",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "7e92e5b73632",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "364e72458b36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5605da08c0e6",
+    "reviewedArtifactChecksum": "f62afcfb9782",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "36794f399aa0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "7d9c675b3d10",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3755b3465820": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "788a5febdf8a",
+    "reviewedArtifactChecksum": "6388dbd136fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3858678780f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b9a6690fdf4",
+    "reviewedArtifactChecksum": "b30bbf5670b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "a2bbf02ef992",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "4ba3799c7ce9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39d6048bf91e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3a2c2fbc8ec",
+    "reviewedArtifactChecksum": "c3bca0723526",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39f7098079f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e2c27847ee1",
+    "reviewedArtifactChecksum": "d4dbaf5bd562",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3b9e9f29c1dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69a67afce7c6",
+    "reviewedArtifactChecksum": "888eb36ab879",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "40764ab9b3e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cb47a67b81a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "19d587d12601",
+    "reviewedArtifactChecksum": "ab32d21c785d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cf3c6a082ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23fa60e1ebba",
+    "reviewedArtifactChecksum": "fbaecf75b378",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "0bf775f1d0d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "e8efaf0e063e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ef4de40106b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "62d6c7d96e14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3efed399a12d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ef55610485f",
+    "reviewedArtifactChecksum": "45a0bc58876e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "404250f61d0a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6f1fe977608",
+    "reviewedArtifactChecksum": "14a904226e94",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40770c9eb41b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "34c1294ea152",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40a427168ef7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "c263326289ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40dea2f852c3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "213cc4e15f94",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "7f0193b3548a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4176b98e2b7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "810032a8dcaa",
+    "reviewedArtifactChecksum": "02691c0ad494",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "417d8dfe78c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "583467999376",
+    "reviewedArtifactChecksum": "7ef9a1d5fa52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "41f029c74cd4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "06040d6e46ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "430b718c2c90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "3341eb12152f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "dc2e7d7ba321",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "44d156cf2723": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e049f067e24",
+    "reviewedArtifactChecksum": "ad43b3efab28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "452e68e4a484": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "ac7b507280b8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4540c3f34805": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "fc48154c1f7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45638e198c1d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "a158611d81e8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "6b7787f58ac0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45a8be9c1124": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "189dbae0eb4a",
+    "reviewedArtifactChecksum": "fcf4f60c978f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45c0ce6bcf2e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "152763825cc8",
+    "reviewedArtifactChecksum": "e0c398d131e8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "9f0578ef82a4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "460daa6b205d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb1e02435d8e",
+    "reviewedArtifactChecksum": "586800d20e3e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4638e59ae7d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a0e59ae686f",
+    "reviewedArtifactChecksum": "67e79601b622",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a303cbccf9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ff3f48dc5ef",
+    "reviewedArtifactChecksum": "6c20920383dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a80518c9c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55cd4863a54d",
+    "reviewedArtifactChecksum": "5f9a946898c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46fc617ad144": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8f8ad09fe7e",
+    "reviewedArtifactChecksum": "75176defae81",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "471717404074": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "4e6fc571ab35",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4724032fa666": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "7d24a9324939",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "21881c3bb742",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47a892d81764": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "376ecaaeccc6",
+    "reviewedArtifactChecksum": "ad5b9e10ec30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47d245c34a7d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "f6f7e8117734",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "49a2f3a0811f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "51dc5f124b8f",
+    "reviewedArtifactChecksum": "ef14fe0513cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a4da321a45d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04f477efeaa6",
+    "reviewedArtifactChecksum": "1eac26e7f97e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a6697085e75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad1c8a8ecac9",
+    "reviewedArtifactChecksum": "ee160de34705",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "72e176215a41",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b042b6638a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27c46c50ab30",
+    "reviewedArtifactChecksum": "80b35e95e719",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "83f8c3cb03c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "875a0e07f1ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "7b6257844fc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "e138b73a9979",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d989a34d147": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "504f4dd9390c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "b190ded8eb99",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4dfdaf8f07d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a50bbbf99764",
+    "reviewedArtifactChecksum": "9548c7ae41b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e430639b9b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "79a6490eb077",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e57a7fe516e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83e635a7828c",
+    "reviewedArtifactChecksum": "44f89b487189",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "4268d3bdd30c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "0acbc131b476",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "967b91eaf718",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4f8b62bfd681": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d64266bfd70",
+    "reviewedArtifactChecksum": "761eab742e48",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "e2af4690101d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "50199f76fe74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c1fb24a9e72",
+    "reviewedArtifactChecksum": "4d97136c70a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "9f3dff4057a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "14fa163480ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "59ac25f63d87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52dd3f09bb59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce2975c65c9c",
+    "reviewedArtifactChecksum": "f7d03f1be24f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "536dc32faee1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a12ade6eb6f",
+    "reviewedArtifactChecksum": "25734d0b093f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "537cf7f1f745": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb039818c192",
+    "reviewedArtifactChecksum": "76a05d5115ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5427ef92c853": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "1770b63f48e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5489b3cf2ac1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62d873360da1",
+    "reviewedArtifactChecksum": "426ffd230c44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558cc012978d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9a40936909",
+    "reviewedArtifactChecksum": "ddeb9ebe0aee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558dc01ae546": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c5045c9c5f05",
+    "reviewedArtifactChecksum": "c14170ec6662",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "560738f98e65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "a6fa958f9a29",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5615df5d2e0d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "baf17938711f",
+    "reviewedArtifactChecksum": "b4842db0fa1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "563f9b5f6ce3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "092def4efba1",
+    "reviewedArtifactChecksum": "a1e17263baff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5652fbe7f479": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ec4de54fd666",
+    "reviewedArtifactChecksum": "8aa9378a1230",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5697ddf9182f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "1181e1f4d47c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "56e17946ef8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9233fda5148f",
+    "reviewedArtifactChecksum": "fdb69a49312a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "57eb4f2ddb92": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2271b8120f36",
+    "reviewedArtifactChecksum": "b12be14b0a3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "585c7006af9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "b0c035206f84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "e39cb4167688",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5931e9bdf9db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "916bf36e3b22",
+    "reviewedArtifactChecksum": "d1e3bae0ef8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "598da2637dc8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "b695e4f48ac9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "37e5515130fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ad4348c8417": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8e5f70f83529",
+    "reviewedArtifactChecksum": "0f2b93b6321c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ae006b13a36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa7092ff2f81",
+    "reviewedArtifactChecksum": "d0bce753f604",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "12cb40c9e403",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "1e02bd1d8644",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "a182327de2bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cef286d4c51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fab982dd28db",
+    "reviewedArtifactChecksum": "edb97f32ca45",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d0cbc370579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "698aba7e4fe0",
+    "reviewedArtifactChecksum": "9b56315855c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "f770250eacbc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f1e9e754358": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "a0f5a7e8a7a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8b74d92e62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23954b90525f",
+    "reviewedArtifactChecksum": "bd5bddc8bc85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "1d97ebf0be53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fa9b44388cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75268e0ea37",
+    "reviewedArtifactChecksum": "4a49e35d4c9f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fd7dc1f9db5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70417a1c18f0",
+    "reviewedArtifactChecksum": "96356f550399",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "603b2d01feb0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bab688e65c3f",
+    "reviewedArtifactChecksum": "654e5a9f0f3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "60e1839cbb34": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23ded424e7e5",
+    "reviewedArtifactChecksum": "775b564b4ee0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "615266189e02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a7cb54de4c8",
+    "reviewedArtifactChecksum": "0ea11a09707d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "62cb2b168265": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9dc4ceaa4e05",
+    "reviewedArtifactChecksum": "30f2fd66c945",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6332ca621968": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c422eaca74c",
+    "reviewedArtifactChecksum": "25cbb23b654d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "f2c4807133d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "ecc7b785ff9a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "64f4db9e3e33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "223cf2121461",
+    "reviewedArtifactChecksum": "f71c665e294e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "655893ad7990": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "904aabfd86ab",
+    "reviewedArtifactChecksum": "f22056f6e746",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "65758201b8ae": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c1dcc0da6d2e",
+    "reviewedArtifactChecksum": "d4d84c701541",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6645006a0cb7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "4412aaf35474",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67981edb9ad4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa37a7c8d562",
+    "reviewedArtifactChecksum": "13f24dbf6476",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67a816af8a73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee604150adb4",
+    "reviewedArtifactChecksum": "f73f1d73832e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67b461209d58": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e95ee7304036",
+    "reviewedArtifactChecksum": "cb640b94a44f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68c39b4c6a6f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5106ec4eb948",
+    "reviewedArtifactChecksum": "5d67e00d34c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68f726502f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "583363e407d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "1e83abefa4ba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6991493996fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "890dbbac0d14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69a3789c4840": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "79a4cab80516",
+    "reviewedArtifactChecksum": "354634faea00",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "6fe3c9fa78ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a2b37d44146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ebbffb505567",
+    "reviewedArtifactChecksum": "fbb5e39f635c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "86fee6faa969",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6afbca6e9d22": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb05dda45844",
+    "reviewedArtifactChecksum": "f10ed8fe3595",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "a4caaabce786",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b3078795300": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "15521d40acca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "233ec9fccdc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "d9f5f12cc649",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c3fa01b5d73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce44981723ba",
+    "reviewedArtifactChecksum": "6dd3f64dcf1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "b26ac37b3e06",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6d0042d2f554": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07611af3f621",
+    "reviewedArtifactChecksum": "58b2f91e8145",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e099b1a7822": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85c8585ef6ce",
+    "reviewedArtifactChecksum": "7cf233d237ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "dd2f44cc2075",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "424be27fc14d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "da18c5d63202",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "363607f19bb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fcaf95e52b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b98247d4d4a3",
+    "reviewedArtifactChecksum": "67fddd40f75d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fec31e40f4a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc934cbc82b8",
+    "reviewedArtifactChecksum": "6f614bd7aa7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7016f027bcf1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "9ef9aa3edea3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70dea50257fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "cd259cabd1b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70e6b211c5ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bfd219d920b4",
+    "reviewedArtifactChecksum": "0c50ab612f40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "f807ba3eeaf7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71355ee91724": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f168dc59d8b",
+    "reviewedArtifactChecksum": "27907a832078",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71a0edbac544": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "1159605820a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "f97d904d5e98",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "30220268e0d9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7330608df8b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "bfe3863feb44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "19ad323d5d4d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "736ab92b893a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ca13f304ebba",
+    "reviewedArtifactChecksum": "196a313f432e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "73a6511dc29e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "728cfd09e417",
+    "reviewedArtifactChecksum": "775379e81bea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "bd49745afe8d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "a58287ca8e19",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "75fb83052003": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2997faf42514",
+    "reviewedArtifactChecksum": "880b1af46822",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "20d5d1c9ede2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "770640dfddef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "b5d4906066ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "002b95232f0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "787cfd599758": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "f2cb36597c4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7905fe6d550c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "7c48159fd08a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79227f845a2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "efaeea711439",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "944dc13f3d1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79bdba6f2250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "2f4d0c2dcd05",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7a6ab8b6e694": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bac15fa24b1e",
+    "reviewedArtifactChecksum": "4dbd226d602a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b25a77c44de": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "d2e00d47ac11",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b973ace62af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "330733f9955e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7c0c712700e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9bf2dbbc9f",
+    "reviewedArtifactChecksum": "5ff8b14f2274",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "f0f885f5f23b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cecbe192fc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "195d7bfcd500",
+    "reviewedArtifactChecksum": "f95074c97a6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cfb99272578": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "38bf6cb3b6ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7dca0438edf4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a20647f365c",
+    "reviewedArtifactChecksum": "8ed671e8dfd2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "89ac036f6d7d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "3bc91cbf7da8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "44a51247fdb0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "81982d3e05b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "b34ccbf06eec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "a0a790f256c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "825e6fb23c2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f9084ed9312",
+    "reviewedArtifactChecksum": "84c744e0599c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "834ab8919949": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ddbe0761021",
+    "reviewedArtifactChecksum": "2cb33d70e598",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8357db8ead93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "846d1964fbdf",
+    "reviewedArtifactChecksum": "0204c379a40d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "83ff3768d42b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c3e7617c972",
+    "reviewedArtifactChecksum": "986f2fa88724",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "840b6e4c3983": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "575ac8693ee3",
+    "reviewedArtifactChecksum": "91ced0d37988",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "847f17f3f95c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba380c49e96f",
+    "reviewedArtifactChecksum": "4e081fee58d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "857e50707831": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "98a0d1fb4779",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "f439afcef28b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "86efedaffa3e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "7f5825baa78b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "874c251ff2f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "8ac5014a0142",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "1a0bab836311",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "87f3b4c32e4f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "405b0711392d",
+    "reviewedArtifactChecksum": "306f4ffba0fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "1ff3d47887eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88f014a33e2a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "d655fb0a009c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "894c44a995a2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8eec53904a2",
+    "reviewedArtifactChecksum": "3f42d59aef68",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "895960b69952": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "094b83078435",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a1f5f5998cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2d71fda9dbb3",
+    "reviewedArtifactChecksum": "08b85a9c83dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "1f5a73cdc6ca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a90e1694881": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "052ca91ea2f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c553cc7c664": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "499792e4d375",
+    "reviewedArtifactChecksum": "12293f513dec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7390cc52c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6713a12925e8",
+    "reviewedArtifactChecksum": "55f3fcfe807c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "16ba5078b654",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c90417df6d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a607c0fb4184",
+    "reviewedArtifactChecksum": "f33dfcd84cd0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "98f75adbf61a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "5ef89ffe7042",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "cbe374992b8f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8e090ccf5a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47f76e5028f9",
+    "reviewedArtifactChecksum": "45e564fd78c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "e2248f73f005",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "5fd8b5c8f86f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f90aec3d12c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b3ffacce720",
+    "reviewedArtifactChecksum": "909468707b05",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8fe7ed30c4ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a9cc5890cb7",
+    "reviewedArtifactChecksum": "25bc499a36fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "91d7e499bd53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "61b676e59e51",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90d086fef9e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7ef0f5883edf",
+    "reviewedArtifactChecksum": "6197a676bef9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "911c19a4391b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8d806844167e",
+    "reviewedArtifactChecksum": "4a6a9fa702a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "239744a2632c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9173ef378024": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "9dad748dd455",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91a17d5206d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f80b0c183e1",
+    "reviewedArtifactChecksum": "aad3643b659a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91ec966e3abb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "923975b4bfac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "920c6926e747": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "986aa5dcf983",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "fb0abb319a97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "9c3ea4010f5c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "7ad13c175851",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9394f9968da3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3dcee651464",
+    "reviewedArtifactChecksum": "8377cba9ac14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93c182d3aefb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "09f29d307389",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93f286fbc2c8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "37ff0c409aa4",
+    "reviewedArtifactChecksum": "551c0014e580",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "947be2b6d997": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "6873f275f6b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "94ed41b87579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "adb1da920293",
+    "reviewedArtifactChecksum": "154545569ef6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9654558acd06": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a12731a191",
+    "reviewedArtifactChecksum": "d5753ffea1d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "82df6fb752e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96f9694b12c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "081c5f898586",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9717b437111c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "3a02e3ca96f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977bc7f55865": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16b8504f3ddc",
+    "reviewedArtifactChecksum": "79dd0602846d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977fefa2b934": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78dc929ff375",
+    "reviewedArtifactChecksum": "3010216d8538",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "4e0524f34d06",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "b6351c8c7959",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "2cd642f7cb26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9851c174a194": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd55d897b05c",
+    "reviewedArtifactChecksum": "185c1cec66dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9974666c3acb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71d3d1fa5eeb",
+    "reviewedArtifactChecksum": "c693805814fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "786ad15b1b83",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "158990d4383e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99ac5a75449c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "eff3364f6021",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99aec65eea89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "08ee59c22c25",
+    "reviewedArtifactChecksum": "8a5280f024c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9a2d779f8ddb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22a817436ead",
+    "reviewedArtifactChecksum": "f7b6505b564d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "fe2c18b4099b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "e46029aaa3ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9be3d7110c75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "cbd3996f21a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c0e04762e99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "409e8afd3ba2",
+    "reviewedArtifactChecksum": "91d75129d8c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "1706de0070ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cc2917611e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "4336967c55e1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cca5e2b3dde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "478c9fb1fb03",
+    "reviewedArtifactChecksum": "eccc0e245784",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9d588c37e728": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "073dd2a75493",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9dac2dae8bfc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aef58f46958a",
+    "reviewedArtifactChecksum": "b8e798da71af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "4da768495248",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e910f3b95c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "222b5e4fda0b",
+    "reviewedArtifactChecksum": "f4bc7567a8d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ed4f6b88b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c3118fbc5ef5",
+    "reviewedArtifactChecksum": "7cb755f1101e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "2ee28a8c9789",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f1bb8c2f14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd521aa22072",
+    "reviewedArtifactChecksum": "8e0ed187ef3f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f9f595534d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47ebf99edfc0",
+    "reviewedArtifactChecksum": "d15fa935b717",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "3e70d5dd5d4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "b9f4f11b57b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a013e57e6d51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3676bc6af0c3",
+    "reviewedArtifactChecksum": "0def537c7ebb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a084de008c94": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "9931b8f10a55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a09d65985659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "05dfceafb99c",
+    "reviewedArtifactChecksum": "5dbb512520f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "6f10df90f8b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "c0e38019b562",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "fcae6558bef5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a20d3822a38f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "01760e8922e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "e09ca4e6e57d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "38236eccb667",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a335e0968d76": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a271486f288",
+    "reviewedArtifactChecksum": "34db3928ccad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a39b591d8c3b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a234de78d008",
+    "reviewedArtifactChecksum": "d2205be26cc5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a3e50e79cb89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fbf819fbfc3",
+    "reviewedArtifactChecksum": "fcc6de711c0d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a47d77950ec1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "4ec6969ce9fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "e5402535a5ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a50ab9e1df59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e09f98cd488d",
+    "reviewedArtifactChecksum": "47024be28f82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "f6496d10061e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a58c512532df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "5d58a859eda2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "af735dbebeed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "083098bf031f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a781503cf508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "4bb011b1fb0b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a84541c0018a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "77813ceb7ca4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "43bc0aea338a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d139dba458": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6189bdf610c",
+    "reviewedArtifactChecksum": "128bf919975d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d874e28508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "a36d24a54a0b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "003758056e32",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "df834c2e33e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9241caf70ac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "25699da31ab8",
+    "reviewedArtifactChecksum": "2441a022329a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "c8af3d95804b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "829c58fc55e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "c34389d4bd05",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aac8b0d80e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c55f22e29a79",
+    "reviewedArtifactChecksum": "b534982f566b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "fec1c0c4bd40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "9feb82b77503",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "2ca3139e031a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ad8614720882": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d4fc106119f",
+    "reviewedArtifactChecksum": "cd19f2c4371d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "adca306765ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "2e2125105d9f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ae12a241076c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "9d3edb8df3df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "e9f7eef01208",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "d520528e8f52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "28834851c4c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afa2656c1d4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9062cb86b8e5",
+    "reviewedArtifactChecksum": "d848b9794b11",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afd30ccf8238": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8baf7e5024e1",
+    "reviewedArtifactChecksum": "d176bab7e699",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "87e9c2e7b75f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "7d52360efdcd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "d2702a9887d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3437893d89d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "29ee53a08798",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "5392daf4d689",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b35c9fa7658c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52f2757246e6",
+    "reviewedArtifactChecksum": "9abeb974c789",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b37902cee452": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e60d5dfd84a3",
+    "reviewedArtifactChecksum": "af2a4d81254f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "b3597650241f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "2a64771ab745",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "8c594ec38949",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "3cb99438dbb3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b594a01df1d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "94660f232c6a",
+    "reviewedArtifactChecksum": "b51a3462a391",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b5e0c3c14836": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e5859746672",
+    "reviewedArtifactChecksum": "e35aad408e26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "f952281e7255",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "89929ae2ea7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6e55869de51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "affdd5d1ce04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b74ad340c930": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "3dc375b753d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b893149a8671": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c53aa635287a",
+    "reviewedArtifactChecksum": "bf264a6edce3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b89d812e25e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "e5166f7292a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b8c030205d86": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "f695b65ef426",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "4c3311c3512f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b95499a55c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16809786d5b3",
+    "reviewedArtifactChecksum": "2856dbb73f1b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b993c1885a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "df344190bc56",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ba62b8d37772": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c238c0c4184",
+    "reviewedArtifactChecksum": "a5faf5a76021",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "baa06a413558": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb0421c78c54",
+    "reviewedArtifactChecksum": "34848f211506",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "d8f01417214b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bb33cc433026": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "2d49ee88187b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bd874c5e02d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b205dfd4c7b0",
+    "reviewedArtifactChecksum": "80d99fe35224",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "c6aa2a5dc9db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "72d3654b39da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "f480ee4dbae2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "be8194d8b7ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bed989744195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a326351226e",
+    "reviewedArtifactChecksum": "54c7d92ce683",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "66d8dd9d3941",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bfba92751be8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "346d47321248",
+    "reviewedArtifactChecksum": "d4536093a5e8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0198b907108": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "d4c61974f35c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c01a333cfbd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9026217dfd87",
+    "reviewedArtifactChecksum": "a88aaf09e0fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "59997daf43ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "42c862af7e44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a547f8fee6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9d006aaa7074",
+    "reviewedArtifactChecksum": "eca16da0e3f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "80326936f851",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1956ef24421": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a70fceb5d9f7",
+    "reviewedArtifactChecksum": "b6960b62c2b3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1959fdc5642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "314621ba0722",
+    "reviewedArtifactChecksum": "dbadde5d54c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "996051df7534",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "1344bce6a326",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "d727d85be000",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "6a32404efc37",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2aae816fe63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c5a8fc3c87b",
+    "reviewedArtifactChecksum": "945fbe643e1a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "79b396622ee2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c365c23d9a69": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "951a2800c3fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c384585f8b2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "24875fd1a9e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "aaf85dec21d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "f6b09f7a4578",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c5cbee07611f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "50cb0336273b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c666b9b4014e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "4de79e2120a4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "ecb5d3ee0e72",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "1ceedff61ee9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c70904777c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "67c3304af3c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "7215355eeaaf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "75ed8a054aeb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "0880baeb90cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c98e5c457e1e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8bc16ce3029",
+    "reviewedArtifactChecksum": "4dc160826f27",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "8e164c99e7da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "23cff6614466",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc053bb55df6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b9c62043d7a5",
+    "reviewedArtifactChecksum": "9bdad1e4edfa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc078724f871": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "4f53af0d04ee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc23c187984a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3b18a4f3d32",
+    "reviewedArtifactChecksum": "54b277225571",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "811e2f017cfb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccc43113008f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "83dda0b0d699",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccf567b604be": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "424dc383ee1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "e4ea7d33f619",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "30f88d90d507",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "baac88dbf79d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "16699b6e0534",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "d426f86fd1e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "7ee34dce4721",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "a8d7b8af773a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d124e24eca67": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c2a79ee0629",
+    "reviewedArtifactChecksum": "8d0554eea203",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "d054d736b299",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "6d1c87c9fa9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d23f62e48d10": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "65498a811c45",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "f3fe7d137860",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d2cee11e428d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "f6d2cfdf6bc1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "ba82e0ba88ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "96f9de2e03d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d4b951896b54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "74603b189b71",
+    "reviewedArtifactChecksum": "8266a33d72d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "dc3615203eda",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "f0813d44c1f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6109704c9d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "bf806ac4e52e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d636956bdddc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "811fdf84b62a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "20904ae79db1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6bda294b8ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "347186231e5f",
+    "reviewedArtifactChecksum": "b6a44cf93f6f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6e252fb4880": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "c4946f901a48",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "f4720f65acdb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "ffc01fb8d8cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d768fd20d606": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "cb5be5ee1571",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d78377cf53f4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62ce15566253",
+    "reviewedArtifactChecksum": "aad09b55f6d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d82f4527c76a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6517985e895c",
+    "reviewedArtifactChecksum": "f688fc28db78",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d833dc5abe59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ff8e0fc1088",
+    "reviewedArtifactChecksum": "0770e2039a81",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "70850060bd7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8bd574de179": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ed010eb61ee",
+    "reviewedArtifactChecksum": "7950d852d2b6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d99717df8788": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "746e2830ce5d",
+    "reviewedArtifactChecksum": "5552b194a698",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "04765d79a6d9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "7422eb6717be",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "1a3753b1f640",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "799937836f17",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dba8340fd0f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2f5928f73e0",
+    "reviewedArtifactChecksum": "dfba4a4e0ae1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "dfe5076d32e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "9fabd22f2844",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc4b3f6dab6e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bbbc8180df94",
+    "reviewedArtifactChecksum": "480904e5a152",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc62b97bc1fc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "607d1c185682",
+    "reviewedArtifactChecksum": "f8402ac60c71",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "f59900fbc930",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc73712c1842": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b483aac476e6",
+    "reviewedArtifactChecksum": "185130d2019c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc7727f63c0c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb408a2280dd",
+    "reviewedArtifactChecksum": "b6dbf0dff435",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "5fc02041b283",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dcf21d867c91": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7b380339f8c1",
+    "reviewedArtifactChecksum": "62aa474579bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "2552775cc0bd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dff780783fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "ebc15864c419",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "c08c6b47e71b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0df9e9c7683": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07c0da77ff02",
+    "reviewedArtifactChecksum": "4ba707eec92c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0f1fb8115ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2208cdd14461",
+    "reviewedArtifactChecksum": "fc121e50165c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e173ace9bf90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "921d18d5c285",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e1e03cafda18": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "11cc7048ff73",
+    "reviewedArtifactChecksum": "07f3ee758025",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2716c39cb46": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88d2297a2338",
+    "reviewedArtifactChecksum": "cf70ce19b70e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2df0992de37": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f18a7f8283b5",
+    "reviewedArtifactChecksum": "b43679d48528",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "97be8e8458ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e41b80eb587d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "ed9410258ddb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "c4f7b86c892d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4ab88456b9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a28a6937d8b",
+    "reviewedArtifactChecksum": "4eb43e190f0d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4d64e14c5e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a8b9fb83ba3b",
+    "reviewedArtifactChecksum": "f2f91297d21a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "e2ac43c5c269",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "e0ef56af07a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5f83394283d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "981b0ccd388e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "65ee28b6c89d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6aa60b3fa90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "157edbd2a5dd",
+    "reviewedArtifactChecksum": "d1ce540988ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "f197425dc1a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6f74ca84e32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e68fb1567b85",
+    "reviewedArtifactChecksum": "2e42ba0c04b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6fd8da0c247": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aefaba1e21a5",
+    "reviewedArtifactChecksum": "412bdee75993",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8099b642c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab48a85786be",
+    "reviewedArtifactChecksum": "042840ba4233",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "c449be4de192",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e81f8eb0ee5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fee8d86b0c31",
+    "reviewedArtifactChecksum": "73ecd9d8d47c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "81312ee0b3b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9543e32164b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "d95bfb80ceca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "add30a40d659",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9f70b059f43": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f2449f49b504",
+    "reviewedArtifactChecksum": "f13768d60cff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea4911d91143": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a921f371596f",
+    "reviewedArtifactChecksum": "8010b2d6886a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea6154c3447d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "a800f7e2fbfd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb53769b541b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "882c4917c540",
+    "reviewedArtifactChecksum": "cac2f8415e49",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "88b20a2b98e1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "4791fa866242",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "9c12b91c9327",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "e91121ff5e32",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "c781304c9321",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "57e5a295086f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef10fc1fe4d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f61d2cc731a",
+    "reviewedArtifactChecksum": "2c7c9bfb651c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "3088bdc9b34a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "d90fa44a1ee5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef543bd4a773": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7debec13329",
+    "reviewedArtifactChecksum": "3435762c856a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "b3cf9aa1b178",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef8586090398": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "2be7c5e31c03",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "2bfdb56e3182",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f052abfce10e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "6f3844a34114",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f1dc525f26dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0240a925b535",
+    "reviewedArtifactChecksum": "5cf2fe71b8e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3096e2ffb64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20e28569e2d2",
+    "reviewedArtifactChecksum": "da6a43877461",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "770fd3dfb460",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f49b24114ea9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e89780c7120",
+    "reviewedArtifactChecksum": "8cb0b06393f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "18b49d4b4cb0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "35b1fd4ad07d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5199b5121f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "c99800d4935b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f56329f28659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "c2910794d805",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "668ee12ea5c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6be37ba0bde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a4060336a6",
+    "reviewedArtifactChecksum": "94b9f310ec18",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "2c9088bc89fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "2cdc3a90cdf4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "4163b0879146",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "6d266bb3a174",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f889bba5102a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "8f6f643bf1b3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "1d6ceee774b6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "563aa220b7d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93775fd8ce0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41bb23f3a44e",
+    "reviewedArtifactChecksum": "662ac761f765",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "c99de7367974",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f9cffe716495": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "beaa27cce795",
+    "reviewedArtifactChecksum": "7754a720df28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "4e82ea7036a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa9731c2000f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da9922d1bc7d",
+    "reviewedArtifactChecksum": "49db64be89ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "b9bbc6e6f215",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb63409aebf0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f40a7e7b42da",
+    "reviewedArtifactChecksum": "5230825c6d96",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "ce0dc18b3fb4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd76422c14ea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "fe0d8afe991d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "e75cd825ab20",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe773d7d7377": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "d15dc778f042",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "018bd2fc5ccd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ff88e6723334": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "8953ef2c8409",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ffbc62a77b85": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cbb7a2feaeb",
+    "reviewedArtifactChecksum": "440be6de257d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "058080732057",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/ko.json
+++ b/site/src/i18n/reviews/ko.json
@@ -1,0 +1,3946 @@
+{
+  "00d3d57a5195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "18d757c3e105",
+    "reviewedArtifactChecksum": "234beb27218b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "a06e836fba3c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0136284ecc19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "47b3b461942b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "017694778c62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "3ebed477e1e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "908d3f8c453b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "c6993f58593e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02b3722db38c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44edc2331fb8",
+    "reviewedArtifactChecksum": "86aec0cb5caf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "0362bcb89ca8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "0e3bf8d009de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "2abc5bc167c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0314e3bcf260": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "46fe50e34613",
+    "reviewedArtifactChecksum": "7090ee2602cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "6b869bc539d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "4d98769346ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "84b44794e33c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "f4b78d7fe941",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0553e57852fe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c73130ac13b8",
+    "reviewedArtifactChecksum": "eb8a06501bd1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "0c4060d9a36e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "eb5e9f1e7c2a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "06caca08d30b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "d391fa51df45",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "7dae5eefa651",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0812b435d117": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "fdf3af8a1986",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085ff06f65f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "f6c1feaa9c58",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "f30b396b8fd8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "f92a5656fb14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0a6672ca248d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "b078081412f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "6263e8dfeb06",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b405e2734df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "7c2578de6514",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "c76f36075f0d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "a9a9bb216126",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "25ee8cd27f77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "60773dcfaf86",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "f2c08694c519",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1043317e75c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "860aed2a4a54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "105559626c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e095741cc033",
+    "reviewedArtifactChecksum": "58c7d8bc79b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "11657ed32877": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "63b92d2012c3",
+    "reviewedArtifactChecksum": "3652465fc7c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "bfb609bc48e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "3f8e1642ef5a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "13ba3af78782": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f35ddb881ae7",
+    "reviewedArtifactChecksum": "d4d85ce2ffc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "eea0929dbca8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "27f2e910a78c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "dc98c3b50ccb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "aaa4550ea2a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "16f123e593db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "25aa339b0fde",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "171dea657096": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91799cf35e77",
+    "reviewedArtifactChecksum": "87dbc62ab851",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "40cefffd70cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "22e86fe1fd96",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "e1a1e6f09131",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "182021fcf3dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0eff80aeaad",
+    "reviewedArtifactChecksum": "0690e1a0a710",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18da3456241d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6f5a6f71f9d9",
+    "reviewedArtifactChecksum": "f1cfce63e2ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18f288d70060": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "2f9397980dad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "7e0660d8eabd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "e18c46e1daca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "5a4579197ba9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1cbba0417673": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "1755328c02ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "7d34e398c324",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "37fd1e57d162",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "c3e2ef4fc79b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1f594885b9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "9afe0cc40c4f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1fb07c3b4b99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d2ce08d29a8",
+    "reviewedArtifactChecksum": "69765da8f105",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "4165d5b400a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "1944b58810f9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "a482194c6204",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "58ceda99b27f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "985d9d4ca74d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "23226868cf80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "267006baa10b",
+    "reviewedArtifactChecksum": "dd4ae4a79731",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "849d0ca4166e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "260ed6c2147f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73a812d2aaf7",
+    "reviewedArtifactChecksum": "fffbb2e8db35",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2639a76cf00e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "fe35a72fd2b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2652985596d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eddea5c0dbca",
+    "reviewedArtifactChecksum": "8204c2372e14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "268307c5793e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e73f6dbefda5",
+    "reviewedArtifactChecksum": "dccdce7f8280",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "26e1f4eddd7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44093fc53faa",
+    "reviewedArtifactChecksum": "a07e8debdf03",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "27bacca060cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "81664c530a0a",
+    "reviewedArtifactChecksum": "3cd92ff8491a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "28bef9a984ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b5c9754c6f0e",
+    "reviewedArtifactChecksum": "ce59fe1116a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "ef53c62dc1e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "c070a705edc3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "299685fcb8dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "f2b1e3706a51",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29be9776c3b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "7b9405822876",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a95da601676": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f3cd6bdb534d",
+    "reviewedArtifactChecksum": "dd2f680db7a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "744ec59d49ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "48d3a9070c9d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2c4b652466d9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ccc760fcbc2",
+    "reviewedArtifactChecksum": "8c4d3f60c58d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "9a60e7451a28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "fcf57c10d177",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "bd888e8c667f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2f10814fd823": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "1598698e7e4e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "456102def7b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "300efdae24f6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "7e6738735b27",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "1316f8da5a52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "6df20576e751",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "8c7c2c7d6ee7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "3dfcd542b557",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "1a4546a066f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "a8077aa507e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "09be73c87048",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "20f1e2193a05",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "351e79d06ae1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "358d6127c306",
+    "reviewedArtifactChecksum": "0f57b8e8a97d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "46c58177a118",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "364e72458b36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5605da08c0e6",
+    "reviewedArtifactChecksum": "7acf71e5da13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "36794f399aa0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "15de0d391f0a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3858678780f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b9a6690fdf4",
+    "reviewedArtifactChecksum": "2fd59533a929",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "4e3b74151fba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "d2c60e1bbcc9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "8991be72f49c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "5242aa62069a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "44afdc592be6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3eb92c1b2380": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bf7aa20f745d",
+    "reviewedArtifactChecksum": "6e5b680c845a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "404250f61d0a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6f1fe977608",
+    "reviewedArtifactChecksum": "b0f7cbb8a941",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40a427168ef7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "95a118ac7622",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40dea2f852c3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "e9e1c538ab41",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "501ee291c047",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4176b98e2b7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "810032a8dcaa",
+    "reviewedArtifactChecksum": "5d14cd195b80",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "41f029c74cd4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "c56762d10534",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "101aee802cf8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "44d156cf2723": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e049f067e24",
+    "reviewedArtifactChecksum": "6e2cf9b55e9a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "452e68e4a484": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "47e6c86880dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4540c3f34805": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "6da96cd1b83a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "b26a9cd01dac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45a8be9c1124": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "189dbae0eb4a",
+    "reviewedArtifactChecksum": "7b550d33d37f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45c0ce6bcf2e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "152763825cc8",
+    "reviewedArtifactChecksum": "378bee48108d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "92c3c998ebf3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4638e59ae7d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a0e59ae686f",
+    "reviewedArtifactChecksum": "c8e72b41a624",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a303cbccf9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ff3f48dc5ef",
+    "reviewedArtifactChecksum": "b8870136b80d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46fc617ad144": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8f8ad09fe7e",
+    "reviewedArtifactChecksum": "86f59c6b994d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4724032fa666": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "93ad5273d0fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47d245c34a7d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "6a39e8f9e22e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "8b737be4453d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b042b6638a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27c46c50ab30",
+    "reviewedArtifactChecksum": "1bee95da9203",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "d1244ad446a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "5f734a0e828b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "7b5e9c19b33c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ca799182440": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a16c03fe7032",
+    "reviewedArtifactChecksum": "cd0888f6c3bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "387877707230",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "f988c964e4d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d989a34d147": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "4c75042b9136",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "e8e324d582d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e430639b9b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "7928ee6b7eb4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e57a7fe516e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83e635a7828c",
+    "reviewedArtifactChecksum": "212734a5c81f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "279e48b4485d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "f40b9e3c81c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4f8b62bfd681": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d64266bfd70",
+    "reviewedArtifactChecksum": "182a075af358",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "50199f76fe74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c1fb24a9e72",
+    "reviewedArtifactChecksum": "abf74ed0e141",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "766ffbe438c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "d7ac383966c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "5538b166007d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "537cf7f1f745": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb039818c192",
+    "reviewedArtifactChecksum": "2cc90332c8f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5427ef92c853": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "4280beb20490",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5489b3cf2ac1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62d873360da1",
+    "reviewedArtifactChecksum": "8326235eee30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558cc012978d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9a40936909",
+    "reviewedArtifactChecksum": "f9d2ee13d854",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558dc01ae546": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c5045c9c5f05",
+    "reviewedArtifactChecksum": "30b679de3cd3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5652fbe7f479": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ec4de54fd666",
+    "reviewedArtifactChecksum": "db62ff743e98",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5697ddf9182f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "b553d3bf330c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "56e17946ef8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9233fda5148f",
+    "reviewedArtifactChecksum": "ad47badaf2dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "57eb4f2ddb92": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2271b8120f36",
+    "reviewedArtifactChecksum": "6ed674e4d5bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "585c7006af9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "6c28d601fa03",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "1b3f389a2ca8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5931e9bdf9db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "916bf36e3b22",
+    "reviewedArtifactChecksum": "fb0e7e1798f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "598da2637dc8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "4249be85a8e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "7ae5c98206e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ad4348c8417": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8e5f70f83529",
+    "reviewedArtifactChecksum": "28f37ff60454",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ae006b13a36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa7092ff2f81",
+    "reviewedArtifactChecksum": "2a89f74d8515",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "2d197b1413f0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "a94d17d53b7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "c2d3a72e0706",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cef286d4c51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fab982dd28db",
+    "reviewedArtifactChecksum": "fc22ff3e1f49",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "1b6265b3a23e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f1e9e754358": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "2b8f06f920f0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "41f6f2742424",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fa9b44388cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75268e0ea37",
+    "reviewedArtifactChecksum": "cc52856151e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "615266189e02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a7cb54de4c8",
+    "reviewedArtifactChecksum": "9a987f0ef93a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "62cb2b168265": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9dc4ceaa4e05",
+    "reviewedArtifactChecksum": "04dc21adb90b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6332ca621968": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c422eaca74c",
+    "reviewedArtifactChecksum": "d762c4e3a971",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "e0122f0644a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "d07a53ee8510",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "655893ad7990": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "904aabfd86ab",
+    "reviewedArtifactChecksum": "bfe1a278bf7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "65758201b8ae": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c1dcc0da6d2e",
+    "reviewedArtifactChecksum": "1b24836e13f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6645006a0cb7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "056539408508",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67981edb9ad4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa37a7c8d562",
+    "reviewedArtifactChecksum": "b6bee9e0a0b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67a816af8a73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee604150adb4",
+    "reviewedArtifactChecksum": "c9dbab1fd579",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68dcfc02a679": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5dbfcd37a1ff",
+    "reviewedArtifactChecksum": "12c2e7cd0f37",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68f726502f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "832b3057d8be",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "607e3cf169e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6991493996fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "1bd325daaa0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69a3789c4840": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "79a4cab80516",
+    "reviewedArtifactChecksum": "0d867a325802",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "6ac03b749157",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "bd482364c5d9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "1bb1b4b74b82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b3078795300": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "b2170661dad6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "4f478fb928fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "38108ebaff52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "a72d5983b1c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6d0042d2f554": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07611af3f621",
+    "reviewedArtifactChecksum": "23f375f0a212",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e099b1a7822": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85c8585ef6ce",
+    "reviewedArtifactChecksum": "1c2ecbc7f5aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "fe8ea4ca2843",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "c80217569d96",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "66cc672d693b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "b1cd6c3d6606",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fcaf95e52b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b98247d4d4a3",
+    "reviewedArtifactChecksum": "426132992047",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fec31e40f4a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc934cbc82b8",
+    "reviewedArtifactChecksum": "81316cdb1b42",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7016f027bcf1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "d31d54b8eb5e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70dea50257fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "1d0f25711253",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70e6b211c5ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bfd219d920b4",
+    "reviewedArtifactChecksum": "7c11dee236d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "5a21d28f59fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71355ee91724": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f168dc59d8b",
+    "reviewedArtifactChecksum": "d7b3e90b7f0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71a0edbac544": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "ecb70c7478f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "c6bcc35f1493",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "f38a0fdcf35c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "449ce41dde99",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "73a6511dc29e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "728cfd09e417",
+    "reviewedArtifactChecksum": "619fef9ccdc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "3da293342767",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "48b0ddd952a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "768526487e8d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f1c03a7a813",
+    "reviewedArtifactChecksum": "9f4d3b675b16",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "523c5c6d72af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "770640dfddef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "658f428eb92d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "41cbd66153f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "787cfd599758": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "af996ee2d439",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7905fe6d550c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "3a57a198ec56",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79227f845a2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "2c4c37ee5ac6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "259fc7a53b3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79bdba6f2250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "04bbc3224d0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b25a77c44de": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "faa74e7fc8c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b973ace62af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "3696d9001d40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "ab9688a97efb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cfb99272578": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "342dd7b4d080",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "e23e80a65fcc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "328dfdabe96d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "618836b5b96c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "d97681ab81bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "4fc9cd7a7b8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "834ab8919949": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ddbe0761021",
+    "reviewedArtifactChecksum": "e131dbb3265c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8357db8ead93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "846d1964fbdf",
+    "reviewedArtifactChecksum": "3e64e06bc4bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "83ff3768d42b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c3e7617c972",
+    "reviewedArtifactChecksum": "97cf49912c1e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "840b6e4c3983": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "575ac8693ee3",
+    "reviewedArtifactChecksum": "57acb1b49690",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "847f17f3f95c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba380c49e96f",
+    "reviewedArtifactChecksum": "4a1109c6ed00",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "5be627045eed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "86efedaffa3e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "971ad06e6880",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "874c251ff2f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "b44c8c0e3b70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "65c66c41837c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "87f3b4c32e4f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "405b0711392d",
+    "reviewedArtifactChecksum": "e7d854f7c743",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "39afed64842b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88f014a33e2a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "eb320cf72426",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "894c44a995a2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8eec53904a2",
+    "reviewedArtifactChecksum": "dccacdd545aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "895960b69952": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "a325fdeaced2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a1f5f5998cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2d71fda9dbb3",
+    "reviewedArtifactChecksum": "7b23bb882af2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "e5a6533dab1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a90e1694881": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "7a7b6b84734d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "14c360a11781",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c90417df6d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a607c0fb4184",
+    "reviewedArtifactChecksum": "804a10c401ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "ce03a1af0976",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "485dd0368919",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "73d2ecb78db4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "181cd4c3f799",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "b037a9a41b19",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8fe7ed30c4ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a9cc5890cb7",
+    "reviewedArtifactChecksum": "6784eede7785",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "a7c656c4fa55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "9f2f4c585c86",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "911c19a4391b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8d806844167e",
+    "reviewedArtifactChecksum": "66b6d3123ca9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "052811906505",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9173ef378024": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "73c2d23edc52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91a17d5206d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f80b0c183e1",
+    "reviewedArtifactChecksum": "53915c7cc645",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91ec966e3abb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "ffd094aaa2b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "920c6926e747": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "8e97e283a81a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "98ef67e30cbb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "028816fbbf30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "1093d50f17b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93c182d3aefb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "675b74823034",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "947be2b6d997": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "a0ce814bc9c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "94ed41b87579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "adb1da920293",
+    "reviewedArtifactChecksum": "ee487e54b65f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "36e23160b9ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9717b437111c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "b10fd8ef6e12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977fefa2b934": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78dc929ff375",
+    "reviewedArtifactChecksum": "b4d1146f744c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "9bc24c8ce0e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "04c8d1872a9b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "2a87e4a0008b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9974666c3acb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71d3d1fa5eeb",
+    "reviewedArtifactChecksum": "462343f2365d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "e474d9273ea5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "3a46e653ce64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99ac5a75449c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "b9abba382473",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9a2d779f8ddb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22a817436ead",
+    "reviewedArtifactChecksum": "c7bd5d0af943",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "0d53b9dd117f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "da47acfc3aad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9be3d7110c75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "18cd69710f7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c0e04762e99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "409e8afd3ba2",
+    "reviewedArtifactChecksum": "71fdccace599",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "c7ad1429d9b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cca5e2b3dde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "478c9fb1fb03",
+    "reviewedArtifactChecksum": "5b0285f94d87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9dac2dae8bfc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aef58f46958a",
+    "reviewedArtifactChecksum": "012da8d2ea14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "456519d73885",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e910f3b95c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "222b5e4fda0b",
+    "reviewedArtifactChecksum": "afb497644039",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ed4f6b88b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c3118fbc5ef5",
+    "reviewedArtifactChecksum": "d5c2a792571e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "a0b3a09de76c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "d831bed35dfa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "f8dbcff7e6c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a013e57e6d51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3676bc6af0c3",
+    "reviewedArtifactChecksum": "dd004e842a87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a084de008c94": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "2f22f43f691b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a09d65985659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "05dfceafb99c",
+    "reviewedArtifactChecksum": "cb92f99c4eb8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "ea266bf8e5ff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "f72b30e2866d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "b406c742e770",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a20d3822a38f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "e5e0dac40368",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "792262f84704",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "887f29248fa5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a39b591d8c3b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a234de78d008",
+    "reviewedArtifactChecksum": "38b7389dd125",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a3e50e79cb89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fbf819fbfc3",
+    "reviewedArtifactChecksum": "8f2d793a72da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a47d77950ec1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "ca3e30a7f32b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "3a4d69005c48",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "60061c0b8574",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a58c512532df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "0907eeae9de1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "c26f07717ebb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a781503cf508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "1035c1a95ada",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a84541c0018a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "c3b1b6de78da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "ea0b475d76ad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d139dba458": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6189bdf610c",
+    "reviewedArtifactChecksum": "68d992a28fb1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d874e28508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "44aa5e793fe8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "c6bbbc705a40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9241caf70ac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "25699da31ab8",
+    "reviewedArtifactChecksum": "0724131aa1e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "8cd176133c9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "6a011689f039",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "da4131312046",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "e1efb4bcbb1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "c8d2192f4ce8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ad8614720882": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d4fc106119f",
+    "reviewedArtifactChecksum": "ef0de6d5d41c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "adca306765ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "447813cbdecb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ae12a241076c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "aa6bad3ef571",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "76acccc48b21",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "97047bae6ccc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "72799e4c19c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afa2656c1d4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9062cb86b8e5",
+    "reviewedArtifactChecksum": "244d9378bfa0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "5844416bc8ee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "da9d327cadeb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "9256b8ce0c1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3437893d89d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "d5f21de545fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "0d365a6d96af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b35c9fa7658c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52f2757246e6",
+    "reviewedArtifactChecksum": "854709c4c799",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "e0dd57a2ef55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "9817db3e9e89",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "9c74e15e5c98",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "edb0f5c55558",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "a229e80cfd6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b5e0c3c14836": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e5859746672",
+    "reviewedArtifactChecksum": "9580eced3a9e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "703f60153a58",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "2705cc25a131",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6e55869de51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "ea429094aefb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b74ad340c930": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "38eae3964597",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b893149a8671": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c53aa635287a",
+    "reviewedArtifactChecksum": "75707f8003ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b89d812e25e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "77c7678cb02e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b8c030205d86": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "2e11347c04d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "3153c152144e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b993c1885a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "c646198d049e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ba62b8d37772": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c238c0c4184",
+    "reviewedArtifactChecksum": "704eea400a7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "baa06a413558": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb0421c78c54",
+    "reviewedArtifactChecksum": "fccf3fb4b5fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "782f068742b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bb33cc433026": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "19700cca425d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bd874c5e02d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b205dfd4c7b0",
+    "reviewedArtifactChecksum": "4ac771153504",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "f0adad5ed3a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "b5c0d715483e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "9a769f5aaa88",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "ed4c99283ee6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bed989744195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a326351226e",
+    "reviewedArtifactChecksum": "abf29f4e2290",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "436a9fb51ad3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bfba92751be8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "346d47321248",
+    "reviewedArtifactChecksum": "57f283206025",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0198b907108": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "04d0a2a7d5d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c01a333cfbd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9026217dfd87",
+    "reviewedArtifactChecksum": "671be9402482",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "c5cce4a629b1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "647aca8dd8ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a547f8fee6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9d006aaa7074",
+    "reviewedArtifactChecksum": "c4b5d9e2f236",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "0a617fdbbf67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1956ef24421": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a70fceb5d9f7",
+    "reviewedArtifactChecksum": "885a0c7fa4f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "d3dcd3a9d0e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "af2ae224edf4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "d31ae46b9465",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2aae816fe63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c5a8fc3c87b",
+    "reviewedArtifactChecksum": "a01d930e1e2e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c365c23d9a69": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "950e892e033c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c384585f8b2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "51b68a25d21c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "ca5de3cbf197",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "e128fa2ccfb1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c666b9b4014e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "b6e73c99f12d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "41e89f29ae7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "c7066b4d023e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c70904777c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "6e5733823a56",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "3e4a93ddd616",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "62356153ea44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "aab64c630de0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c98e5c457e1e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8bc16ce3029",
+    "reviewedArtifactChecksum": "2909751df386",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "0e219994af27",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "13a9dbf83b9a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc078724f871": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "86f2fd5744e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc23c187984a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3b18a4f3d32",
+    "reviewedArtifactChecksum": "8df922094bcc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "346f627ee87c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccc43113008f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "05ec8424d25c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccf567b604be": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "552be14672e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "e33141c33b51",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "58a177728897",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "28fefc57c334",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "d5613ac36a0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "64baab392e7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "f0f61276cf35",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cff9f70a9137": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0888293ad9f",
+    "reviewedArtifactChecksum": "3b631f67cdde",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "dd3e92a9df58",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "784f7663e8b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "5f5b8830fe91",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "33372e4f9bbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "180ef69e2fa5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "05a33184720c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d636956bdddc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "17959af455bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "bd95f3ef4738",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6e252fb4880": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "77223ece101a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "26959cf0bb69",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "5de2419f4711",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d78377cf53f4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62ce15566253",
+    "reviewedArtifactChecksum": "fe6db90bed09",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d82f4527c76a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6517985e895c",
+    "reviewedArtifactChecksum": "5efae73e6355",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d833dc5abe59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ff8e0fc1088",
+    "reviewedArtifactChecksum": "ce131f947f04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "e989296e33b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8bd574de179": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ed010eb61ee",
+    "reviewedArtifactChecksum": "a064f44b64f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d99717df8788": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "746e2830ce5d",
+    "reviewedArtifactChecksum": "daad95ee5fae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "9acc53f17443",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "c72525d36b5c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "ce4751a0d455",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "858d3f5ae50b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dba8340fd0f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2f5928f73e0",
+    "reviewedArtifactChecksum": "9888dc8a6621",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "555f237edad8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "c98af4e5faba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc4b3f6dab6e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bbbc8180df94",
+    "reviewedArtifactChecksum": "a46de86631cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc62b97bc1fc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "607d1c185682",
+    "reviewedArtifactChecksum": "81064f6d8d90",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "aa39e2d8e2f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc73712c1842": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b483aac476e6",
+    "reviewedArtifactChecksum": "48c304bc3e87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "364f17405c75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dcf21d867c91": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7b380339f8c1",
+    "reviewedArtifactChecksum": "abdfc439dd7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "1fd22c3f0e4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dff780783fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "1a3c265d998a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "8d145d20fedc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0f1fb8115ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2208cdd14461",
+    "reviewedArtifactChecksum": "b4cdf30af1db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e173ace9bf90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "26e7dc604855",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2716c39cb46": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88d2297a2338",
+    "reviewedArtifactChecksum": "397e27577cdf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2df0992de37": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f18a7f8283b5",
+    "reviewedArtifactChecksum": "55eb5cc4c0e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "c70b9ac0eadc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e41b80eb587d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "6ecba030b122",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "9402652d1291",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "02aaa7652a1b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "1f84089e65dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5f83394283d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "2715589e522e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "6eec28b1272a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "b638f78e8242",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6f74ca84e32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e68fb1567b85",
+    "reviewedArtifactChecksum": "545cc6bf00c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6fd8da0c247": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aefaba1e21a5",
+    "reviewedArtifactChecksum": "7d5794fb7d36",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e78f02853c98": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7a2357bf6d3",
+    "reviewedArtifactChecksum": "ca4fd2854e34",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "dd255143f56f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "ca99138f53c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9543e32164b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "d063edbedf8b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "9659c23db767",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9f70b059f43": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f2449f49b504",
+    "reviewedArtifactChecksum": "c57f488a97d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea4911d91143": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a921f371596f",
+    "reviewedArtifactChecksum": "7ccc0186417c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea6154c3447d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "d0679b1c034a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb53769b541b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "882c4917c540",
+    "reviewedArtifactChecksum": "6a8f1d0fb2cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "8bdcc94e9fec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "df8beed5a404",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "c1ff145e00bd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "575a94faaf2d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "8de8237b8128",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "51f94024d7a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "1c1cb0501f5f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "b672eeea2fd2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef8586090398": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "61376a774fc8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "b5cd66be32c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f052abfce10e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "2d00b6acdc7a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f1dc525f26dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0240a925b535",
+    "reviewedArtifactChecksum": "e8284f48aa3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "4d592f76bc75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f49b24114ea9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e89780c7120",
+    "reviewedArtifactChecksum": "e96a3ffc2626",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "f38febad4147",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e29143100c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18726770189",
+    "reviewedArtifactChecksum": "314d9db57f18",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5199b5121f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "a1822936fb7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f56329f28659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "f816937aeb27",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "283ecc1add30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6be37ba0bde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a4060336a6",
+    "reviewedArtifactChecksum": "4ef56fe503d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "ee05c9ac5383",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "a4ff31540948",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "d357e13f2b27",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "d22721bd26f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f889bba5102a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "35c8ecd63ed2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "ff92600e593d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "8687293e964f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "fd4057d22484",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f9cffe716495": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "beaa27cce795",
+    "reviewedArtifactChecksum": "9936cd0f585c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa1f01a51d17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "33418f4fe697",
+    "reviewedArtifactChecksum": "012a29468c1b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "eb90e6ab362d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa9731c2000f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da9922d1bc7d",
+    "reviewedArtifactChecksum": "6b1b5893d60d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "feb716e7bc63",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb63409aebf0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f40a7e7b42da",
+    "reviewedArtifactChecksum": "f40ee52e9631",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "aaa19a535d7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd76422c14ea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "07d204ccbb02",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "c756bc45535b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe773d7d7377": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "ed539e0be4d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "e4c1420d0bb3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ffbc62a77b85": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cbb7a2feaeb",
+    "reviewedArtifactChecksum": "44fd8b4c2906",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "274b5a811cdc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/pt-BR.json
+++ b/site/src/i18n/reviews/pt-BR.json
@@ -1,0 +1,4962 @@
+{
+  "00d3d57a5195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "18d757c3e105",
+    "reviewedArtifactChecksum": "218ef86e02f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "b54d21ab5c18",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0136284ecc19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "44496a5d34e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "017694778c62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "f15817584142",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "aaf87d23aab3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "34e77c4daf1b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02b3722db38c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44edc2331fb8",
+    "reviewedArtifactChecksum": "e90bc19d10ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "78f4d6cb51ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "050b13aaea68",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "05b4934dab9d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0314e3bcf260": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "46fe50e34613",
+    "reviewedArtifactChecksum": "e2b11b488304",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "c489d113f5ff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "d3139e4a8a12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "05aeec8de484",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "10537ef24986",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "206198044363",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0553e57852fe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c73130ac13b8",
+    "reviewedArtifactChecksum": "f97d0cecd6d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "f38192b2f708",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "e9298ced61f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "06caca08d30b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "5576f178e1a4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "b02ba0848159",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0801185d2115": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5c7d51b77a",
+    "reviewedArtifactChecksum": "e593a39457bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0812b435d117": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "db418567481a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085a4bba12f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "9aea80655167",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085ff06f65f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "16e10a378592",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "64c2f3bd8ad8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "53e39d893aea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0a6672ca248d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "f65d3d9956a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "8e13a6329462",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b405e2734df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "becaf161269b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "9f178562810a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "dff222b45456",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ba871b9578d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "c72d4c09ece4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "5d5a99492f52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "ecefa2d5165b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "f0998cd33968",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1043317e75c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "8fd089b7a0eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "105559626c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e095741cc033",
+    "reviewedArtifactChecksum": "ba2f88249501",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "113c9ab2c6d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387ec1f14afa",
+    "reviewedArtifactChecksum": "744cfc819ee3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "11657ed32877": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "63b92d2012c3",
+    "reviewedArtifactChecksum": "c8f41a4b13dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "1edfa90565d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "12c2481d04b4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9c6ff6175b64",
+    "reviewedArtifactChecksum": "0186b0c091c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "dbb22e06045b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "13ba3af78782": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f35ddb881ae7",
+    "reviewedArtifactChecksum": "bdd17a22fd19",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "b045e48fa76d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "14597b195403": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c17e54fbe09a",
+    "reviewedArtifactChecksum": "98d73b828d30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15538e51d812": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "935eb3882193",
+    "reviewedArtifactChecksum": "c304e8496126",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "80e97a4f26fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "be21988abbd8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "211d714dd26f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "16f123e593db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "837006c69d50",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "171dea657096": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91799cf35e77",
+    "reviewedArtifactChecksum": "c5343ea331a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "fc2364530291",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "d715287029d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "e148d4b25967",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "182021fcf3dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0eff80aeaad",
+    "reviewedArtifactChecksum": "d625c2d885a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1880d7035ea2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "8aa09fe7a619",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18da3456241d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6f5a6f71f9d9",
+    "reviewedArtifactChecksum": "04b37f5d59d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18f288d70060": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "97d73ea26d5b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "f9f4ada513a4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1af3df552a07": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "f34d2d22e1f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "a792dafc9c7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "cfe2b83f9519",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "55fd9ecff4d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "800ef1a18c25",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1cbba0417673": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "046b5b95baff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d16e17134e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "36b0f7f7efdd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "0f87e91b15ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "dd3609bf6e43",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "155cb5463656",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1f594885b9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "664f8d2e1433",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1fb07c3b4b99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d2ce08d29a8",
+    "reviewedArtifactChecksum": "a32acde99601",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "0336909bbf7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "1df850d2a66c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "ca6e7c70ecd1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "a245aaf8d284",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "41fac94f9067",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "231992fee1a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "c95908869285",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "23226868cf80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "267006baa10b",
+    "reviewedArtifactChecksum": "fe385479ad6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "0d60905c6d51",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "260ed6c2147f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73a812d2aaf7",
+    "reviewedArtifactChecksum": "6cab39e8ad40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2620e5135442": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "898d2af58acc",
+    "reviewedArtifactChecksum": "b464e792938e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2639a76cf00e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "75394706ac95",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2652985596d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eddea5c0dbca",
+    "reviewedArtifactChecksum": "69d063971772",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "268307c5793e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e73f6dbefda5",
+    "reviewedArtifactChecksum": "47489c7fa363",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "26e1f4eddd7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44093fc53faa",
+    "reviewedArtifactChecksum": "a6432fa2fbc8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "27bacca060cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "81664c530a0a",
+    "reviewedArtifactChecksum": "b513a6e768c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "39ebe4d07feb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "28bef9a984ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b5c9754c6f0e",
+    "reviewedArtifactChecksum": "cdcf741dadd0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "ae940d8c5254",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "f0f2896f7591",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "299685fcb8dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "96f78b68dbac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29be9776c3b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "95bbff68bd78",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a95da601676": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f3cd6bdb534d",
+    "reviewedArtifactChecksum": "59a1d62180e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "c571a20f8f07",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "7bc0f07bbd2f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2c4b652466d9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ccc760fcbc2",
+    "reviewedArtifactChecksum": "8d886e9613c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "1aae3bdc5cac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "dc82674ab623",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da9ee24ad74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4186cea3bf4d",
+    "reviewedArtifactChecksum": "c6351dd35209",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "b95af56ba590",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2f10814fd823": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "243e51ead8f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "5c492c312100",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "300efdae24f6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "18f7836cb878",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "204da37ecc7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "7ae9e216d6ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "3f99d2641430",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "c7714d5af1c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "edaeea4b3e71",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "ae754c5ed385",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "90a190c2c4a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "59626c15a5a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "28d756e9aa71",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3515c5083027": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "554e4ef6a5f3",
+    "reviewedArtifactChecksum": "36b20c9fc223",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "351e79d06ae1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "358d6127c306",
+    "reviewedArtifactChecksum": "5d9e75cca120",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "17d9143a8e2d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "364e72458b36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5605da08c0e6",
+    "reviewedArtifactChecksum": "ff006cc932a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "36794f399aa0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "b019d7a24e7d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3755b3465820": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "788a5febdf8a",
+    "reviewedArtifactChecksum": "afc195df4826",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3858678780f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b9a6690fdf4",
+    "reviewedArtifactChecksum": "37be946fddef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "64bee251efe9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "8ba938a3a1ca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39d6048bf91e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3a2c2fbc8ec",
+    "reviewedArtifactChecksum": "31529fdead70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39f7098079f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e2c27847ee1",
+    "reviewedArtifactChecksum": "c6bb6f29a8e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3b9e9f29c1dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69a67afce7c6",
+    "reviewedArtifactChecksum": "24911300fdf2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "2c3e384cb810",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cb47a67b81a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "19d587d12601",
+    "reviewedArtifactChecksum": "d280eb1086a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cf3c6a082ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23fa60e1ebba",
+    "reviewedArtifactChecksum": "afa8cae66901",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "58367f682b7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "4a94236811b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3eb92c1b2380": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bf7aa20f745d",
+    "reviewedArtifactChecksum": "fa5e5cf8068e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ef4de40106b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "800baa0ab152",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3efed399a12d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ef55610485f",
+    "reviewedArtifactChecksum": "15183bef24ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "404250f61d0a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6f1fe977608",
+    "reviewedArtifactChecksum": "3d6b64e4ae28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40770c9eb41b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "7f5f113d2040",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40a427168ef7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "5f89aa4f5ee9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40dea2f852c3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "29d5d133ce92",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "6fd4fdbb0f34",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4176b98e2b7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "810032a8dcaa",
+    "reviewedArtifactChecksum": "ca2e0a45e07c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "417d8dfe78c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "583467999376",
+    "reviewedArtifactChecksum": "88b53cd6b79c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "41f029c74cd4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "31a975008694",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "430b718c2c90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "ad4ce0f7ba53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "7e93d280515d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "44d156cf2723": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e049f067e24",
+    "reviewedArtifactChecksum": "1e92d97b8fbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "452e68e4a484": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "e0643cc9d586",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4540c3f34805": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "069f73c770d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45638e198c1d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "7eed28241556",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "2473d014738f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45a8be9c1124": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "189dbae0eb4a",
+    "reviewedArtifactChecksum": "5c7b1a17b1b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45c0ce6bcf2e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "152763825cc8",
+    "reviewedArtifactChecksum": "c95e64d5d29b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "095364db0262",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "460daa6b205d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb1e02435d8e",
+    "reviewedArtifactChecksum": "8cf0c40f14cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4638e59ae7d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a0e59ae686f",
+    "reviewedArtifactChecksum": "eba0bc79eac1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a303cbccf9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ff3f48dc5ef",
+    "reviewedArtifactChecksum": "a1bab40afcd1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a80518c9c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55cd4863a54d",
+    "reviewedArtifactChecksum": "3b60b95eafef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46fc617ad144": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8f8ad09fe7e",
+    "reviewedArtifactChecksum": "dca18292b4ff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "471717404074": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "543890a2848d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4724032fa666": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "cd25fc77290d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "312b833169f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47a892d81764": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "376ecaaeccc6",
+    "reviewedArtifactChecksum": "8bb5a2852a73",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47d245c34a7d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "c7cccaaa7475",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "49a2f3a0811f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "51dc5f124b8f",
+    "reviewedArtifactChecksum": "9db5268e39f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a4da321a45d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04f477efeaa6",
+    "reviewedArtifactChecksum": "be2ed710875a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a6697085e75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad1c8a8ecac9",
+    "reviewedArtifactChecksum": "1f1c75569610",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "d8e2000e1eae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b042b6638a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27c46c50ab30",
+    "reviewedArtifactChecksum": "9abcfda5b5b3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "b9cb037e2e79",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "53cc6ee27872",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "507d595e215b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ca799182440": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a16c03fe7032",
+    "reviewedArtifactChecksum": "f7d64dc61729",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "c8b887e1a4bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "449e961b1c6a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d989a34d147": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "9550ab028910",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "9b9913793b49",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4dfdaf8f07d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a50bbbf99764",
+    "reviewedArtifactChecksum": "577a033cdfa6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e430639b9b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "f37034215ecd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e57a7fe516e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83e635a7828c",
+    "reviewedArtifactChecksum": "ea6ac99b7516",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "66f5e816aff7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "d8ee4b08f507",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "d895949168bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4f8b62bfd681": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d64266bfd70",
+    "reviewedArtifactChecksum": "d5e2c90c59de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "1eafda81548c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "50199f76fe74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c1fb24a9e72",
+    "reviewedArtifactChecksum": "14fb1734779d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "c5a4f7add454",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "1e034d8e756f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "2090592bee2e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52dd3f09bb59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce2975c65c9c",
+    "reviewedArtifactChecksum": "4ac226f53135",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "536dc32faee1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a12ade6eb6f",
+    "reviewedArtifactChecksum": "143aad03cdba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "537cf7f1f745": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb039818c192",
+    "reviewedArtifactChecksum": "5a8e073ac880",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5427ef92c853": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "7bb44adbd8a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5489b3cf2ac1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62d873360da1",
+    "reviewedArtifactChecksum": "364bbda72747",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558cc012978d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9a40936909",
+    "reviewedArtifactChecksum": "238e30b779e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558dc01ae546": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c5045c9c5f05",
+    "reviewedArtifactChecksum": "d486182097c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "560738f98e65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "f76ed7ae8ee0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5615df5d2e0d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "baf17938711f",
+    "reviewedArtifactChecksum": "8c2521f97284",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "563f9b5f6ce3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "092def4efba1",
+    "reviewedArtifactChecksum": "217ef872d94b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5652fbe7f479": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ec4de54fd666",
+    "reviewedArtifactChecksum": "bde0f6647c37",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5697ddf9182f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "a53abd3411a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "56e17946ef8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9233fda5148f",
+    "reviewedArtifactChecksum": "6b24fb76a7e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "57eb4f2ddb92": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2271b8120f36",
+    "reviewedArtifactChecksum": "7a51c2b30729",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "585c7006af9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "ff89ccc67aac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "d4ab5f0ed5cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5931e9bdf9db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "916bf36e3b22",
+    "reviewedArtifactChecksum": "51818adfd53e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "598da2637dc8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "95a1b39bab64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "7b545e87a2c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ad4348c8417": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8e5f70f83529",
+    "reviewedArtifactChecksum": "d33ebb6718bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ae006b13a36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa7092ff2f81",
+    "reviewedArtifactChecksum": "af7b081e2d20",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "9d838bc639db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "2a76db3042ae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "cace88483132",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cef286d4c51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fab982dd28db",
+    "reviewedArtifactChecksum": "0f1d45fae81a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d0cbc370579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "698aba7e4fe0",
+    "reviewedArtifactChecksum": "21e47fd1776f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "f8f0124adab5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f1e9e754358": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "e17a2b92c21b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8b74d92e62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23954b90525f",
+    "reviewedArtifactChecksum": "fede9d671515",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "5421df9464d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fa9b44388cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75268e0ea37",
+    "reviewedArtifactChecksum": "9b4c96fa7328",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fd7dc1f9db5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70417a1c18f0",
+    "reviewedArtifactChecksum": "14e404fc940a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "603b2d01feb0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bab688e65c3f",
+    "reviewedArtifactChecksum": "04bc16e5854e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "60e1839cbb34": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23ded424e7e5",
+    "reviewedArtifactChecksum": "9315fc3a724e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "615266189e02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a7cb54de4c8",
+    "reviewedArtifactChecksum": "4b217dd87d61",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "62cb2b168265": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9dc4ceaa4e05",
+    "reviewedArtifactChecksum": "69c115622ce1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6332ca621968": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c422eaca74c",
+    "reviewedArtifactChecksum": "3e107ebbabaf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "a4c84d6f77ad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "7e6f721567bd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "64f4db9e3e33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "223cf2121461",
+    "reviewedArtifactChecksum": "4300d1c7f692",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "655893ad7990": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "904aabfd86ab",
+    "reviewedArtifactChecksum": "a98e194989e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "65758201b8ae": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c1dcc0da6d2e",
+    "reviewedArtifactChecksum": "532d54f12513",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6645006a0cb7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "9a780201bd0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67981edb9ad4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa37a7c8d562",
+    "reviewedArtifactChecksum": "5a22db6d1b8d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67a816af8a73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee604150adb4",
+    "reviewedArtifactChecksum": "38a3709be861",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67b461209d58": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e95ee7304036",
+    "reviewedArtifactChecksum": "ce88d06914c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68c39b4c6a6f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5106ec4eb948",
+    "reviewedArtifactChecksum": "529555464f87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68dcfc02a679": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5dbfcd37a1ff",
+    "reviewedArtifactChecksum": "1ceb93fe6594",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68f726502f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "cd4779a6612a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "21e452c180e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6991493996fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "e300a48e47ba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69a3789c4840": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "79a4cab80516",
+    "reviewedArtifactChecksum": "fe51973721f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "ed1ccdfe4537",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a2b37d44146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ebbffb505567",
+    "reviewedArtifactChecksum": "6e45d91ac33e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "b7ee95105cfd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6afbca6e9d22": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb05dda45844",
+    "reviewedArtifactChecksum": "92c332324225",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "94fd1818147a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b3078795300": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "fa509fec94d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "4a3cbd36d18c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "2477c1242f17",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c3fa01b5d73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce44981723ba",
+    "reviewedArtifactChecksum": "c8fafd48c19a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "d23121198be5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6d0042d2f554": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07611af3f621",
+    "reviewedArtifactChecksum": "05ba19c82f83",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e099b1a7822": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85c8585ef6ce",
+    "reviewedArtifactChecksum": "1b0b393bcd9e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "853b2347967e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "f615393d758f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "ecd9524cd43b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "3af230ee74ca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fcaf95e52b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b98247d4d4a3",
+    "reviewedArtifactChecksum": "d8e0bb8fc246",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fec31e40f4a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc934cbc82b8",
+    "reviewedArtifactChecksum": "72b1d31697bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7016f027bcf1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "4db82684408c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70dea50257fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "b7784a48f4f9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70e6b211c5ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bfd219d920b4",
+    "reviewedArtifactChecksum": "a134d2b16830",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "f0bbab8540c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71355ee91724": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f168dc59d8b",
+    "reviewedArtifactChecksum": "92f389fd190f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71a0edbac544": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "8e7ab0d5baf6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "386718183fef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "b5bd3d50b3a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "730d964da0cc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "02c64ba307fd",
+    "reviewedArtifactChecksum": "1ee67387e148",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7330608df8b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "1a11bc8a8723",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "238355064faf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "736ab92b893a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ca13f304ebba",
+    "reviewedArtifactChecksum": "7c64d67eff1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "73a6511dc29e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "728cfd09e417",
+    "reviewedArtifactChecksum": "3e21386647e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "dba61628ef3b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "2ebfc31e625e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "75fb83052003": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2997faf42514",
+    "reviewedArtifactChecksum": "6b0a25ae5b78",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "768526487e8d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f1c03a7a813",
+    "reviewedArtifactChecksum": "4142a144c8ba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "d2019c3d365b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "770640dfddef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "3afa3d98bb6d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "d7b0c16868cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "787cfd599758": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "cdaf6fd8357f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7905fe6d550c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "93552e376d1b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79227f845a2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "f44b13114838",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "3590bd8e6986",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79bdba6f2250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "97f273dcfb52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7a6ab8b6e694": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bac15fa24b1e",
+    "reviewedArtifactChecksum": "37ffe84c5c7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b25a77c44de": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "5c56e04827a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b973ace62af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "d3da38d288fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7c0c712700e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9bf2dbbc9f",
+    "reviewedArtifactChecksum": "d3842011b2c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "ec296e4ceec8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cecbe192fc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "195d7bfcd500",
+    "reviewedArtifactChecksum": "6ce2d7e132c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cfb99272578": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "736b5eaf0ef7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7dca0438edf4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a20647f365c",
+    "reviewedArtifactChecksum": "ea63ab9cdb82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "82eccb2b388f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "9295e8f5fe57",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "5c701d11db90",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "a05cb0d49eae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "6ded02fabd8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "23b8bedc98f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "825e6fb23c2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f9084ed9312",
+    "reviewedArtifactChecksum": "5c2418fbfa9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "834ab8919949": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ddbe0761021",
+    "reviewedArtifactChecksum": "d6c6d401860e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8357db8ead93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "846d1964fbdf",
+    "reviewedArtifactChecksum": "921cf8e38ab3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "83ff3768d42b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c3e7617c972",
+    "reviewedArtifactChecksum": "90c433e8df37",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "840b6e4c3983": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "575ac8693ee3",
+    "reviewedArtifactChecksum": "9bf835bf9a73",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "847f17f3f95c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba380c49e96f",
+    "reviewedArtifactChecksum": "957bee821592",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "857e50707831": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "4f7a5ab278d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "3b73d922f668",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "86efedaffa3e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "451fc9b4fed8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "874c251ff2f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "9a0d2431ac49",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "880f8056e00b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "87f3b4c32e4f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "405b0711392d",
+    "reviewedArtifactChecksum": "45846db24e8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "53cbe0ccd399",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88f014a33e2a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "195d528b6f88",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "894c44a995a2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8eec53904a2",
+    "reviewedArtifactChecksum": "d506b4a13fca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "895960b69952": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "75f444b19bb2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a1f5f5998cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2d71fda9dbb3",
+    "reviewedArtifactChecksum": "7344425a1dc5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "461d90d5b39a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a90e1694881": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "e1bd55c0ca2b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8bd8b493eb7a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a017392574e5",
+    "reviewedArtifactChecksum": "b1d1e298417e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c553cc7c664": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "499792e4d375",
+    "reviewedArtifactChecksum": "ff34b15260df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7390cc52c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6713a12925e8",
+    "reviewedArtifactChecksum": "820a828d63a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "32e679794f26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c90417df6d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a607c0fb4184",
+    "reviewedArtifactChecksum": "0a1c7dce52b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "d176cfb541b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "04678b78365b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "530a8300d1de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8e090ccf5a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47f76e5028f9",
+    "reviewedArtifactChecksum": "c2db8133308e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "26aa9ddf249d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "eb30b3577293",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f90aec3d12c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b3ffacce720",
+    "reviewedArtifactChecksum": "2346df8e1cc3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8fe7ed30c4ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a9cc5890cb7",
+    "reviewedArtifactChecksum": "15152c612eef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "f5f9d0810bc3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "35933104a034",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90d086fef9e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7ef0f5883edf",
+    "reviewedArtifactChecksum": "bd3bc277a334",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "911c19a4391b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8d806844167e",
+    "reviewedArtifactChecksum": "a8ea55f2e45f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "60e71a8b2536",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9173ef378024": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "3976d8d4805b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91a17d5206d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f80b0c183e1",
+    "reviewedArtifactChecksum": "a4094807d9ae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91ec966e3abb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "c0d5b9b61b4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "920c6926e747": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "83270d72d4d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "fa15aac0ef36",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "9a77c079221b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "c1cab53562cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9394f9968da3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3dcee651464",
+    "reviewedArtifactChecksum": "6dd096656974",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93c182d3aefb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "5f351a35ae47",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93f286fbc2c8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "37ff0c409aa4",
+    "reviewedArtifactChecksum": "feb234a0e970",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "947be2b6d997": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "3f067ca8fb64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "94ed41b87579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "adb1da920293",
+    "reviewedArtifactChecksum": "f66bedbcec46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9654558acd06": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a12731a191",
+    "reviewedArtifactChecksum": "00a837cb8905",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "3d27304e73f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96f9694b12c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "80d44383df41",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9717b437111c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "f48de35334f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977bc7f55865": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16b8504f3ddc",
+    "reviewedArtifactChecksum": "7427d90c2c7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977fefa2b934": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78dc929ff375",
+    "reviewedArtifactChecksum": "fcef14510a5e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "d5553a42ec67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "233ee0ee73fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "772c1fabfca5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9851c174a194": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd55d897b05c",
+    "reviewedArtifactChecksum": "33d27fd083f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9974666c3acb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71d3d1fa5eeb",
+    "reviewedArtifactChecksum": "453b8cebccc2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "adf9ca441d35",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "bc17a2b6945c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99ac5a75449c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "6d368a35a829",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99aec65eea89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "08ee59c22c25",
+    "reviewedArtifactChecksum": "0cbe20814d33",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9a2d779f8ddb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22a817436ead",
+    "reviewedArtifactChecksum": "19523b699b8f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "7e3eecc8905e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "8c0604c2310a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9be3d7110c75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "747890c2084a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c0e04762e99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "409e8afd3ba2",
+    "reviewedArtifactChecksum": "5609dc009d63",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "bfb581464584",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cc2917611e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "6af71ab22c79",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cca5e2b3dde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "478c9fb1fb03",
+    "reviewedArtifactChecksum": "685e79b03a64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9d588c37e728": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "9223da76580f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9dac2dae8bfc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aef58f46958a",
+    "reviewedArtifactChecksum": "2951d792a82d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "4b20498ed554",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e910f3b95c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "222b5e4fda0b",
+    "reviewedArtifactChecksum": "e81d21093801",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ed4f6b88b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c3118fbc5ef5",
+    "reviewedArtifactChecksum": "0cbc3463b289",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "7a43df27b819",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f1bb8c2f14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd521aa22072",
+    "reviewedArtifactChecksum": "1df342c427da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f9f595534d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47ebf99edfc0",
+    "reviewedArtifactChecksum": "23f6a2144848",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "b1f54067f2fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "492deb5707f3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a013e57e6d51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3676bc6af0c3",
+    "reviewedArtifactChecksum": "d248844238f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a084de008c94": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "f07d229b40b6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a09d65985659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "05dfceafb99c",
+    "reviewedArtifactChecksum": "3bbb7b11990b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "57a838b0b4d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "1352c921c0d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "092482433d8d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a20d3822a38f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "2656e3836ce7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "acb9e5f71614",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "15cf61996010",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a335e0968d76": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a271486f288",
+    "reviewedArtifactChecksum": "b98d86c69589",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a39b591d8c3b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a234de78d008",
+    "reviewedArtifactChecksum": "1c8f592e2bbb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a3e50e79cb89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fbf819fbfc3",
+    "reviewedArtifactChecksum": "a30a0c420264",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a47d77950ec1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "f65a5437b5af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "8971e5cb9959",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a50ab9e1df59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e09f98cd488d",
+    "reviewedArtifactChecksum": "d6bb468da064",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "62bbb18641cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a58c512532df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "ff67a4f6242d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "7f9ae0c03ed1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "e7de169a29fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a781503cf508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "6e91ab94622f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a84541c0018a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "d64eff2f2561",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "d0ca21f012fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d139dba458": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6189bdf610c",
+    "reviewedArtifactChecksum": "b60f6c5908fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d874e28508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "f5836fe8a3e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "ddebc6936b63",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "775de75317d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9241caf70ac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "25699da31ab8",
+    "reviewedArtifactChecksum": "d1b847d01be9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "fabfffe7e3c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "9dfe09019a8b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "5133419f1813",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aac8b0d80e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c55f22e29a79",
+    "reviewedArtifactChecksum": "bef064a46a1e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "5bac7be150e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "44654c125dee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "16eae0249efe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ad8614720882": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d4fc106119f",
+    "reviewedArtifactChecksum": "6c7a8eb4339d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "adca306765ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "c5c4fde12d2c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ae12a241076c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "a17d40d06112",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "f801e2b5ef44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "401f60143b5c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "8ab61f9b9bf7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afa2656c1d4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9062cb86b8e5",
+    "reviewedArtifactChecksum": "39d92f63fb49",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afd30ccf8238": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8baf7e5024e1",
+    "reviewedArtifactChecksum": "5954fc191648",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "ffe6077c4052",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "a2524d69ed7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "4be47ef514dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3437893d89d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "587a97c9c19f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "406c0125703c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b35c9fa7658c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52f2757246e6",
+    "reviewedArtifactChecksum": "23faf8c7d201",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b37902cee452": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e60d5dfd84a3",
+    "reviewedArtifactChecksum": "28df7f7c2e17",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "148cddea74c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "add580738483",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "c5c2424be69e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "729592b96d24",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "59c0f7ddd458",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b594a01df1d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "94660f232c6a",
+    "reviewedArtifactChecksum": "c08b1cc34ff8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b5e0c3c14836": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e5859746672",
+    "reviewedArtifactChecksum": "8ada8a3b9dfd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "88099ba0fd99",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "19de30e47f5d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6e55869de51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "fa44afcc679a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b74ad340c930": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "31f6747a8e22",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b893149a8671": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c53aa635287a",
+    "reviewedArtifactChecksum": "5c082bbf218a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b89d812e25e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "dcf2efbd5d26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b8c030205d86": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "2fcdfbd84cfd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "31b76de5885b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b95499a55c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16809786d5b3",
+    "reviewedArtifactChecksum": "dfb44b026c7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b993c1885a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "85b1bfd77c79",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ba62b8d37772": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c238c0c4184",
+    "reviewedArtifactChecksum": "a5f12c09017b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "baa06a413558": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb0421c78c54",
+    "reviewedArtifactChecksum": "3ffbca1fe715",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "61ce2ac52bf8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bb33cc433026": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "1e3df45fa57a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bd874c5e02d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b205dfd4c7b0",
+    "reviewedArtifactChecksum": "bc5ff0c1e0ee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "e16256c76d74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "eee4c13941a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "7f663b77b2d9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "a3904a4fb46c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bed989744195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a326351226e",
+    "reviewedArtifactChecksum": "73057667e5c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "af4bc1f43abb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bfba92751be8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "346d47321248",
+    "reviewedArtifactChecksum": "65e32f8eb6cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0198b907108": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "6b03ffd7e3d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c01a333cfbd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9026217dfd87",
+    "reviewedArtifactChecksum": "1f8fb73ed6a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "c73c05e67f7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "20944dfbe84f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a547f8fee6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9d006aaa7074",
+    "reviewedArtifactChecksum": "71029d3a1468",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "67875f244504",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1956ef24421": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a70fceb5d9f7",
+    "reviewedArtifactChecksum": "2696b4df37cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1959fdc5642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "314621ba0722",
+    "reviewedArtifactChecksum": "99b0f2d88308",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "8bbc7a0603a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "84aa82964f77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "f9a6d8f20498",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "5dcd5ed6cd5b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2aae816fe63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c5a8fc3c87b",
+    "reviewedArtifactChecksum": "e697cafc2bcb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "1475e931d4d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c365c23d9a69": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "01337157516f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c384585f8b2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "a8c9425dac68",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "44140b9d7d23",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "e7bc7951850c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c5cbee07611f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "0570af667ba7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c666b9b4014e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "75ed5a5aedbc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "358a628b17d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "5ca2eae0c1e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c70904777c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "213fb0a7fddd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "49ac175e0bcc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "876548085f59",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "28fa29711385",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c98e5c457e1e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8bc16ce3029",
+    "reviewedArtifactChecksum": "e14ce35a3224",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "4fa165438d25",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "32a861f5d5b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc053bb55df6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b9c62043d7a5",
+    "reviewedArtifactChecksum": "fff66ceb4768",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc078724f871": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "e9dc7124e94d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc23c187984a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3b18a4f3d32",
+    "reviewedArtifactChecksum": "98401f5df38c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "ec1c6431d36b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccc43113008f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "1f22d504be13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccf567b604be": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "8bee316edf77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "68233b7a1e7d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "c8c667a39a93",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "e3e9647e1663",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "2ef669dfd0d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "d90fee241c8c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "03e31b91f544",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "2bec844643a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cff9f70a9137": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0888293ad9f",
+    "reviewedArtifactChecksum": "8ab379fbb687",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d124e24eca67": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c2a79ee0629",
+    "reviewedArtifactChecksum": "c4f7d1eb52e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "957a6b53ae92",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "aecd2c6a4d3c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d23f62e48d10": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "7fe22e3c754c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "e4e95e3dd8eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d2cee11e428d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "c12ccaa24146",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "ba78cb4b5f0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "bbb4d434df14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d4b951896b54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "74603b189b71",
+    "reviewedArtifactChecksum": "12e3553168df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "e624954186b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "b2177bd8a095",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6109704c9d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "fa546cf42613",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d636956bdddc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "b177ac0f6c97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "912b58c4becd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6bda294b8ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "347186231e5f",
+    "reviewedArtifactChecksum": "d60926206102",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6e252fb4880": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "4f4050cf9159",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "7afdb08f61d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "f99ffae7a205",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d768fd20d606": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "d1749dd891c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d78377cf53f4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62ce15566253",
+    "reviewedArtifactChecksum": "993d4d7b0cfd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d82f4527c76a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6517985e895c",
+    "reviewedArtifactChecksum": "dec9aa40b22b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d833dc5abe59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ff8e0fc1088",
+    "reviewedArtifactChecksum": "c3228a827c8f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "c90cd7aaf06e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8bd574de179": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ed010eb61ee",
+    "reviewedArtifactChecksum": "b189956fdc0b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d99717df8788": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "746e2830ce5d",
+    "reviewedArtifactChecksum": "84bb1c8ec77e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "77658074ca17",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "1b2ff5e723bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "9694933d92b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "286d455faa2b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dba8340fd0f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2f5928f73e0",
+    "reviewedArtifactChecksum": "643d2a64a4d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "28d51ca71cf3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "d8c83357d96d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc4b3f6dab6e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bbbc8180df94",
+    "reviewedArtifactChecksum": "01690bc72c15",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc62b97bc1fc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "607d1c185682",
+    "reviewedArtifactChecksum": "eeaf168424fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "0de5edca97d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc73712c1842": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b483aac476e6",
+    "reviewedArtifactChecksum": "24ec646f58f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc7727f63c0c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb408a2280dd",
+    "reviewedArtifactChecksum": "3cc50a91b560",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "a514cf23f08a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dcf21d867c91": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7b380339f8c1",
+    "reviewedArtifactChecksum": "a0a6e26515aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "aac8b9b4c5b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dff780783fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "71a59dc240a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "22d331892428",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0df9e9c7683": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07c0da77ff02",
+    "reviewedArtifactChecksum": "1c31ac284fdb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0f1fb8115ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2208cdd14461",
+    "reviewedArtifactChecksum": "8c0d88b4466f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e173ace9bf90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "1907b99cd02e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e1e03cafda18": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "11cc7048ff73",
+    "reviewedArtifactChecksum": "8df6ab513548",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2716c39cb46": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88d2297a2338",
+    "reviewedArtifactChecksum": "aa6c5cc585db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2df0992de37": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f18a7f8283b5",
+    "reviewedArtifactChecksum": "42b83b031931",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "7cd16022568c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e41b80eb587d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "2fcb1112ab8d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "8cd3d39b4864",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4ab88456b9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a28a6937d8b",
+    "reviewedArtifactChecksum": "ca77163e6ee8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4d64e14c5e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a8b9fb83ba3b",
+    "reviewedArtifactChecksum": "61e622fc2154",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "49bc2ab7ecca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "cd89159e6f4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5f83394283d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "f09c765bf358",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "21c4f0a03b90",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6aa60b3fa90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "157edbd2a5dd",
+    "reviewedArtifactChecksum": "a49f1b7b0d6e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "0d00a021b038",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6f74ca84e32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e68fb1567b85",
+    "reviewedArtifactChecksum": "82d2f963928e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6fd8da0c247": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aefaba1e21a5",
+    "reviewedArtifactChecksum": "0744d58658b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e78f02853c98": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7a2357bf6d3",
+    "reviewedArtifactChecksum": "7ea57e7912f0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8099b642c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab48a85786be",
+    "reviewedArtifactChecksum": "0568dce720c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "e9e791889487",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e81f8eb0ee5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fee8d86b0c31",
+    "reviewedArtifactChecksum": "893fd7d8fcad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "ae5e47afb6c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9543e32164b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "4adb13a339b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "e843ffd6dccd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9f70b059f43": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f2449f49b504",
+    "reviewedArtifactChecksum": "2411340bfd28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea4911d91143": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a921f371596f",
+    "reviewedArtifactChecksum": "2f1d46cf632a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea6154c3447d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "f67b042ed479",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb53769b541b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "882c4917c540",
+    "reviewedArtifactChecksum": "7e8a7f4c8b58",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "058934567859",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "a778d3450d01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "78c2c8b5bb50",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "c1445a83687a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "1217b8704473",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "aa4c01d69227",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef10fc1fe4d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f61d2cc731a",
+    "reviewedArtifactChecksum": "bf32651e7a50",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "3bb4b22e192f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "2315733d732a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef543bd4a773": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7debec13329",
+    "reviewedArtifactChecksum": "2c900c501bcd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "26daf98b4594",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef8586090398": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "3f23773609ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "82d784a31323",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f052abfce10e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "8bb95d391ced",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f1dc525f26dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0240a925b535",
+    "reviewedArtifactChecksum": "d50708535592",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3096e2ffb64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20e28569e2d2",
+    "reviewedArtifactChecksum": "484533b5b9e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "76cb6fcdfd29",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f49b24114ea9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e89780c7120",
+    "reviewedArtifactChecksum": "9310fa195633",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "ebc1d96bd31b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e29143100c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18726770189",
+    "reviewedArtifactChecksum": "6aca3eda1797",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "18c18f3afe8e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5199b5121f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "65672b0a86c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f56329f28659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "2051cb7005f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "06256a5ec927",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6be37ba0bde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a4060336a6",
+    "reviewedArtifactChecksum": "0ca523842238",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "29f035113292",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "8285393bdea0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "94cc754536c5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f83ee3caa04e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a47e936b4941",
+    "reviewedArtifactChecksum": "42ca33501650",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "f77a50eecae0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f889bba5102a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "619cdd4edcce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "758ecc517b84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "cf1763b955e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93775fd8ce0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41bb23f3a44e",
+    "reviewedArtifactChecksum": "3a0ab7dd433e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "8ded13e922ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f9cffe716495": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "beaa27cce795",
+    "reviewedArtifactChecksum": "eae49089ffe7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa1f01a51d17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "33418f4fe697",
+    "reviewedArtifactChecksum": "5b269c1e6194",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "09f913ae09f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa9731c2000f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da9922d1bc7d",
+    "reviewedArtifactChecksum": "06f979a4c33a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "3f562e040066",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb63409aebf0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f40a7e7b42da",
+    "reviewedArtifactChecksum": "0209a0466a2a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "28a86dc66737",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd76422c14ea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "3000ebbd8411",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fdab9848b160": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bc70dfe515b2",
+    "reviewedArtifactChecksum": "0d9ed18bcbdd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "dba5f673ccfb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe773d7d7377": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "0fa610c4ad46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "f67c3c73b9fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ff88e6723334": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "fdc2c49962c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ffbc62a77b85": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cbb7a2feaeb",
+    "reviewedArtifactChecksum": "5bf8f76cd199",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "479cd81e0815",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/ru.json
+++ b/site/src/i18n/reviews/ru.json
@@ -1,0 +1,1666 @@
+{
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "163db470cfc6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0136284ecc19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "ed96baf68c13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "bb5dc4110d91",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "18f108c3f7af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "55619f9a4689",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "219ea156a8c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "4fc3fc9887fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "0aafafdd492d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "d251028c3d62",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "f99e5ad9ead0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "23df60918b55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "a08885fb8d04",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0801185d2115": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5c7d51b77a",
+    "reviewedArtifactChecksum": "dbd9dddfaf10",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "b4b3c0b59a6e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b405e2734df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "cae5df330c3f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "8e99a2a31523",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "af0238faf539",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "14597b195403": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c17e54fbe09a",
+    "reviewedArtifactChecksum": "b4f49c861cf4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "5a100c6584f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "40aa2e184db2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "1d1309b72db8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18f288d70060": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "ba3e85835e46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "0db4b218b3ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1af3df552a07": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "052f94ef8122",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "e6238716f942",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "c5bc6c11e99c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "50b1cb901af9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d16e17134e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "8ac0aa49540f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "7f42d58e05cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "0bde3aba674b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "677897804cc2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "11250b9164bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "3386b2a861fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "88bc222fbdd5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2639a76cf00e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "473d97141e97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "6cc8ef632b9d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "4e5a581ad08b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "300efdae24f6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "8d386c9dc5fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "42bd80f12a51",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "a076c85edb6f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "d803d4e5129c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "02e2f8e88ab6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "d6a3c374cd55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "a9792d8b7eb5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "d532fa165f95",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "a63c31ed37e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3515c5083027": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "554e4ef6a5f3",
+    "reviewedArtifactChecksum": "b270a6b909c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "351e79d06ae1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "358d6127c306",
+    "reviewedArtifactChecksum": "7d0c2f4fd137",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "1375eefd443a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "426669c492bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39d6048bf91e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3a2c2fbc8ec",
+    "reviewedArtifactChecksum": "728c1691c4df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39f7098079f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e2c27847ee1",
+    "reviewedArtifactChecksum": "d9339a4a4521",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "3658a5262280",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40770c9eb41b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "037b978f65cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "b514e75ced69",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "452e68e4a484": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "0f89b9a1e300",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45638e198c1d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "b68862ec26c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "0bd855b78527",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "43bc71c83dbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "471717404074": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "6eb8b45ad521",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "112ed3093be4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47d245c34a7d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "f5df77113929",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "2536c1db0503",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "3951b300ff7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "6eefb77daedf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "8cea7cf5f2fb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "a80b2983e783",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "960ffbbc4ac3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "560738f98e65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "069b3baf7744",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "9eb1981c9ab8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "85dcc950d439",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "cd2f03b801a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cef286d4c51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fab982dd28db",
+    "reviewedArtifactChecksum": "42e449dafbe5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "7bb74462fa1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f1e9e754358": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "57aa775749a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8b74d92e62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23954b90525f",
+    "reviewedArtifactChecksum": "f3cec1b91753",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "45546d5b9dbd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fa9b44388cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75268e0ea37",
+    "reviewedArtifactChecksum": "037ed45813ca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "5b1f7fe3a09e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "64f4db9e3e33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "223cf2121461",
+    "reviewedArtifactChecksum": "9b1f2c8e8f54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67a816af8a73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee604150adb4",
+    "reviewedArtifactChecksum": "8746f7ab28c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67b461209d58": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e95ee7304036",
+    "reviewedArtifactChecksum": "b1f7286e8cce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "9613f97b88a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "fbf64502320d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e099b1a7822": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85c8585ef6ce",
+    "reviewedArtifactChecksum": "ff9a0e76498b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "f277b3632c6a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "5abb529e8670",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "200580b930d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "3f6bea9b79e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "2d25844f9f2b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7905fe6d550c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "4dc4338e520b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "36d2d7d738b3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "9b0388c69953",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "2d7697031672",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "be8c2f982fed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "6d3ce14bdd7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "491d54bb6424",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "ee2283c928ee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "ff22a925b7c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "857e50707831": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "b2fe947b4155",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "50124fbb5a65",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "f793259b614e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8bd8b493eb7a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a017392574e5",
+    "reviewedArtifactChecksum": "c0af0e42c1e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "501c3f3ba1af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "6bb24b1a1e4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "4d18fc74d8a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "5598ba827156",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8e090ccf5a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47f76e5028f9",
+    "reviewedArtifactChecksum": "219e6f96dc35",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "0fb18630050e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "e49a1c0796d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "bb86127d5a85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "84758f8b0b36",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "b484d690811e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "920c6926e747": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "c27d6c47f35c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "5dc9c369abda",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "2413703924cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "cfd5525454bd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977fefa2b934": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78dc929ff375",
+    "reviewedArtifactChecksum": "28890f9e5797",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "5f6347d337f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "977494ff0e4f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "3a9ef967f3b8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a084de008c94": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "35f9e3c847bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "a05e6d2bf627",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "0462c452956a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a20d3822a38f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "f27795741cbc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "fccf632050a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "34cb987f3491",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "ba263b979b9f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "261b107fa98b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "819371f4fe0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "06e7871cdf73",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "b787f7ffd172",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "45bb4e8cc586",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "c158af9c7814",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "968bb8c798a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "37361d6c199f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "c96c8985d29e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "df4eba33b3ff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "a5db96f4f910",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b74ad340c930": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "0fca5ef2ef63",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "f4cf923cc403",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "f9baba02cfb7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "82087feec83e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "62e97936d387",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "998cb7291054",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "93d77112ddfa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "71187d584847",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "d7998e81d540",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "2b22dbd4c6e1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2aae816fe63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c5a8fc3c87b",
+    "reviewedArtifactChecksum": "ab69f0124622",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "5178027f13a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "f6cf8a11e6db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "e5b618d11bc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "1b23ec8b4947",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "0ed4622d4427",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "9f40dc596f90",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "a1db19646436",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "39a1c207ca1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d124e24eca67": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c2a79ee0629",
+    "reviewedArtifactChecksum": "2d6c5aa1790a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "fe2851d08833",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "f5ed03b72a51",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d2cee11e428d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "6fbfba6823c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "d7a7f5a6f6c9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "7fcef6d24c4f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d4b951896b54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "74603b189b71",
+    "reviewedArtifactChecksum": "85bfbec19f79",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "8e6f13e60c57",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "52166ad3d2a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6109704c9d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "8d0c448da24a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "95b9d49a0e96",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "593a4bc45170",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d768fd20d606": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "500ddba9c809",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc4b3f6dab6e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bbbc8180df94",
+    "reviewedArtifactChecksum": "cbaab85e26ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc62b97bc1fc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "607d1c185682",
+    "reviewedArtifactChecksum": "6c73c7575839",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "05f408b8a82a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "868a20a32a7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0df9e9c7683": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07c0da77ff02",
+    "reviewedArtifactChecksum": "7f3fcdefd304",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "cdd39d244378",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6aa60b3fa90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "157edbd2a5dd",
+    "reviewedArtifactChecksum": "cf86dcb29e65",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e81f8eb0ee5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fee8d86b0c31",
+    "reviewedArtifactChecksum": "dee3f8858b7a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "746ddc05634c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9543e32164b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "be623429c0e8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "593f3a567ac1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea6154c3447d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "24ed75bbf854",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "54ea64a41a74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "a67e0875d048",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "7b1cb3335946",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "0ae86bc7a802",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "30cbf1d02b1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "9e99bdb09666",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "d7b774c277aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5199b5121f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "39fefdb4a463",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f56329f28659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "07e78f10aec0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6be37ba0bde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a4060336a6",
+    "reviewedArtifactChecksum": "36759745d464",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "b37a5a3f09fe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "6690df682c23",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "f3c8b512f17e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f83ee3caa04e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a47e936b4941",
+    "reviewedArtifactChecksum": "3631321b6c86",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "ae124e3887e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f889bba5102a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "4cc6d8cc0cad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "a81f195cc710",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "253a94eb92aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93775fd8ce0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41bb23f3a44e",
+    "reviewedArtifactChecksum": "a5046c72ca16",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "87e13ab85144",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f9cffe716495": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "beaa27cce795",
+    "reviewedArtifactChecksum": "138260efcb7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "a98788e36e41",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "429908add6ae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb63409aebf0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f40a7e7b42da",
+    "reviewedArtifactChecksum": "fa7b5a554c07",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "97b65b752e8d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/tr.json
+++ b/site/src/i18n/reviews/tr.json
@@ -1,0 +1,4402 @@
+{
+  "00d3d57a5195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "18d757c3e105",
+    "reviewedArtifactChecksum": "7d13529be87d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "d30829df8389",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "017694778c62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89649092021f",
+    "reviewedArtifactChecksum": "48ead2142ab7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "021a11a45320": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9deb91371a0f",
+    "reviewedArtifactChecksum": "f9c60bd98f94",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0250a153895c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "362e5daaa10e",
+    "reviewedArtifactChecksum": "49434f8415a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02b3722db38c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44edc2331fb8",
+    "reviewedArtifactChecksum": "84d5d84a52e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "8a8d64ce1936",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "343ad1df96e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "12c3ab39e262",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "f641db542a08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "03ec1a367585": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f17e513a7b74",
+    "reviewedArtifactChecksum": "9b5e7bd56fb8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "042fbf5a6e42": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0056af1a215e",
+    "reviewedArtifactChecksum": "f657ec1c34b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "0945456f4313",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "99be522bfeb8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0553e57852fe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c73130ac13b8",
+    "reviewedArtifactChecksum": "05ad6db6027b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "e3c061bea60b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "30b93dd1cbbf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "06caca08d30b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "a6c6fa59885e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0740bf78b7b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b222d8c0d72",
+    "reviewedArtifactChecksum": "e99cd49e8888",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0801185d2115": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5c7d51b77a",
+    "reviewedArtifactChecksum": "192d27da5078",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085a4bba12f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "04efcae06429",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085ff06f65f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "726819253854",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "9bdaa8c9bc4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "089459eaa101",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0a6672ca248d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "ec57ad157973",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "b0bb8afdd6df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b405e2734df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "7ecd3034f774",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "2e6006ea2ae5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "bbbef29a714f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ba871b9578d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "b6c66a8934a4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "b03b363aaa0e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "68d1400231d5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "c6f1253fb1ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1043317e75c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "0da7ed13476f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "105559626c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e095741cc033",
+    "reviewedArtifactChecksum": "09dea756ee7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "113c9ab2c6d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387ec1f14afa",
+    "reviewedArtifactChecksum": "be3cec5b191c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "9b616b0ad57f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "12c2481d04b4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9c6ff6175b64",
+    "reviewedArtifactChecksum": "a1f99bf4d017",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "eafa55cf7370",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "1e7f8efc3291",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "14597b195403": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c17e54fbe09a",
+    "reviewedArtifactChecksum": "a2e5cbde9b6a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15538e51d812": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "935eb3882193",
+    "reviewedArtifactChecksum": "9dfc1d2b1d54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "4ad7c2ac1cbd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "d3d0be94bfc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "ba7c2fd5a19a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "16f123e593db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "7db9d6a29b2b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "171dea657096": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91799cf35e77",
+    "reviewedArtifactChecksum": "edc87ecfaf6b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "1857f1d20f90",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "b8ee40ee406f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "fef6751ea202",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "182021fcf3dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f0eff80aeaad",
+    "reviewedArtifactChecksum": "5ede69b398c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1880d7035ea2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "cb0cd989a503",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18da3456241d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6f5a6f71f9d9",
+    "reviewedArtifactChecksum": "1bb640da1432",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18f288d70060": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42bda05e6f37",
+    "reviewedArtifactChecksum": "6dc800d97838",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "dca2e9836ad5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1af3df552a07": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "5a98dd66b7ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c0a3a9faad3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ffc79a6190e",
+    "reviewedArtifactChecksum": "c5ae1dd081a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "e7d79c42ffa2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "05f0d933d61c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1cbba0417673": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "6ec66eb77e6e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d16e17134e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "af3c2aef0346",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "eec1b9a9d289",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "fcdb5fd03d32",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eb49d4d5811": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ffa753f1a2c",
+    "reviewedArtifactChecksum": "813fa656d7d9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1f594885b9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c99f6497b3e",
+    "reviewedArtifactChecksum": "43521471967c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "f3f7afafa51e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "3ba8f948cf75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "6a0964cb69a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "c8b2c42d6201",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "69ba2cc24cf0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "231992fee1a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "5fc21874a8d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "23226868cf80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "267006baa10b",
+    "reviewedArtifactChecksum": "3612265476ad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "5df84f582c75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "260ed6c2147f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73a812d2aaf7",
+    "reviewedArtifactChecksum": "6712926cc40f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2620e5135442": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "898d2af58acc",
+    "reviewedArtifactChecksum": "cd052ded9326",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2639a76cf00e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "d67a5bb97d94",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "26e1f4eddd7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44093fc53faa",
+    "reviewedArtifactChecksum": "5db412c3f99e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "27bacca060cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "81664c530a0a",
+    "reviewedArtifactChecksum": "bb42471d3761",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "e085426ca9cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "28bef9a984ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b5c9754c6f0e",
+    "reviewedArtifactChecksum": "9be406ec8617",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "7c180b700c1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "4b9da9ee0897",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "299685fcb8dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "72e9c0527242",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29be9776c3b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "197e2035b102",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a95da601676": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f3cd6bdb534d",
+    "reviewedArtifactChecksum": "3b5a2192f7a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "4bdf2818b8e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2c4b652466d9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ccc760fcbc2",
+    "reviewedArtifactChecksum": "034405848e74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "9ceb757f71f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "3faf3b1ec41f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da9ee24ad74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4186cea3bf4d",
+    "reviewedArtifactChecksum": "fd6b46c5ff67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "9ea3f6896680",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2f10814fd823": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "f27c20bae65c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "86ba2805e093",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "300efdae24f6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c302b9d52024",
+    "reviewedArtifactChecksum": "3fe84fc7f117",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "e3988fee90ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "1c51ab4e876b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "5b6d5c396abf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "19e2c7b75b70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "330550d83e6c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a9de0ba5887",
+    "reviewedArtifactChecksum": "67349681c09c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "7fca66726f76",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "0f090a089ee1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "c55859b6466a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3427fd6e0fa8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f0c71ac37d3",
+    "reviewedArtifactChecksum": "3f2fa87aa639",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "351e79d06ae1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "358d6127c306",
+    "reviewedArtifactChecksum": "f26b9ad02e74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "85c5f71d1948",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "364e72458b36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5605da08c0e6",
+    "reviewedArtifactChecksum": "c9d8be2c5960",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "36794f399aa0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "a6b4203befbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3755b3465820": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "788a5febdf8a",
+    "reviewedArtifactChecksum": "9e1fa3f5a4ca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3858678780f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b9a6690fdf4",
+    "reviewedArtifactChecksum": "b760e5828b48",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "716fc3f16b70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39d6048bf91e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3a2c2fbc8ec",
+    "reviewedArtifactChecksum": "af8fbb30d134",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39f7098079f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e2c27847ee1",
+    "reviewedArtifactChecksum": "8488340fe1f8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3b9e9f29c1dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69a67afce7c6",
+    "reviewedArtifactChecksum": "0c109ca0be82",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3c9ffca52a5e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e7363db774c8",
+    "reviewedArtifactChecksum": "7b5ac000562c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cb47a67b81a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "19d587d12601",
+    "reviewedArtifactChecksum": "c6c775285191",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cf3c6a082ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23fa60e1ebba",
+    "reviewedArtifactChecksum": "fce30bbc81dc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "cedb51ea6ca4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddf4a6144a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "35a052ad1225",
+    "reviewedArtifactChecksum": "426ce6b44053",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3eb92c1b2380": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bf7aa20f745d",
+    "reviewedArtifactChecksum": "fadc538f12a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ef4de40106b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "64453725bc9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3efed399a12d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ef55610485f",
+    "reviewedArtifactChecksum": "b8d0ea021a1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "404250f61d0a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6f1fe977608",
+    "reviewedArtifactChecksum": "8922888b2348",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40770c9eb41b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "d138b24fe964",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40a427168ef7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "ea34595e10c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40dea2f852c3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "2ff6d33799f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "fba8efa09142",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4176b98e2b7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "810032a8dcaa",
+    "reviewedArtifactChecksum": "c164af1b0a2c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "417d8dfe78c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "583467999376",
+    "reviewedArtifactChecksum": "fce08ab58857",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "41f029c74cd4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "49acb6f4b83a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "430b718c2c90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "95fca023c3e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "ea089c6507f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "44d156cf2723": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e049f067e24",
+    "reviewedArtifactChecksum": "fc6a695fda01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "452e68e4a484": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "9b4cbb1371da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4540c3f34805": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "b41d56fcfc84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45638e198c1d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "89f0cfad6d48",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "459fcec528e6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22999b1d8aa8",
+    "reviewedArtifactChecksum": "5a0a7a67b228",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45a8be9c1124": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "189dbae0eb4a",
+    "reviewedArtifactChecksum": "87e6c964812f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "d27607c6cfcd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "460daa6b205d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb1e02435d8e",
+    "reviewedArtifactChecksum": "92341ce11f2c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4638e59ae7d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a0e59ae686f",
+    "reviewedArtifactChecksum": "e5dead682a4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a303cbccf9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ff3f48dc5ef",
+    "reviewedArtifactChecksum": "9b2ead7e96ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a80518c9c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55cd4863a54d",
+    "reviewedArtifactChecksum": "fc7b339c0104",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46fc617ad144": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8f8ad09fe7e",
+    "reviewedArtifactChecksum": "cee42e2d6e37",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "471717404074": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "be21f3fb033f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4724032fa666": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "ea6d5387d520",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "7db79948572c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47a892d81764": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "376ecaaeccc6",
+    "reviewedArtifactChecksum": "06995f2d4950",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47d245c34a7d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "f8314484f2f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "49a2f3a0811f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "51dc5f124b8f",
+    "reviewedArtifactChecksum": "03ebe1895852",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a6697085e75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad1c8a8ecac9",
+    "reviewedArtifactChecksum": "1e1f52e2346b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "32827e4b0061",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b042b6638a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27c46c50ab30",
+    "reviewedArtifactChecksum": "39cbc31ac687",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "edabf87d7eb4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "37e6107223e7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "150f348f78bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "2fe9351966e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "3fab0a2a66c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d989a34d147": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "b101bf3a7026",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "1fe5174abc8a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e430639b9b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "5fc23cb5fd56",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e57a7fe516e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83e635a7828c",
+    "reviewedArtifactChecksum": "2fedab30f0e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e8809f5dfd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c69eeab9441",
+    "reviewedArtifactChecksum": "9a83c0a79d3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "02c10c05d66c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "c28a12614af5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4f8b62bfd681": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d64266bfd70",
+    "reviewedArtifactChecksum": "d4d8134d998f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "a4f414a13193",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "449a6733566d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "a7f0c31415e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "35e6b769a530",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52dd3f09bb59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce2975c65c9c",
+    "reviewedArtifactChecksum": "5b126beeaa58",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "536dc32faee1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a12ade6eb6f",
+    "reviewedArtifactChecksum": "b6268b3a30d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "537cf7f1f745": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb039818c192",
+    "reviewedArtifactChecksum": "2d7a62a053d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5427ef92c853": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "540f9d402648",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5489b3cf2ac1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62d873360da1",
+    "reviewedArtifactChecksum": "2f1112ae953a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558cc012978d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9a40936909",
+    "reviewedArtifactChecksum": "3847fd102863",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "558dc01ae546": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c5045c9c5f05",
+    "reviewedArtifactChecksum": "3967a228a60b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "560738f98e65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "3646dd7dde55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5615df5d2e0d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "baf17938711f",
+    "reviewedArtifactChecksum": "1ef4c2a6f436",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "563f9b5f6ce3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "092def4efba1",
+    "reviewedArtifactChecksum": "c68ea0bb903d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5652fbe7f479": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ec4de54fd666",
+    "reviewedArtifactChecksum": "8571f04a9891",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5697ddf9182f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "7eb128c64249",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "56e17946ef8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9233fda5148f",
+    "reviewedArtifactChecksum": "8050f4c8a39a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "57eb4f2ddb92": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2271b8120f36",
+    "reviewedArtifactChecksum": "552d669d72cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "585c7006af9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "355181661215",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "2b900a69992a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5931e9bdf9db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "916bf36e3b22",
+    "reviewedArtifactChecksum": "ffdac78c3bd5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "598da2637dc8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "e403740ee280",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "f2c05491f696",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ad4348c8417": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8e5f70f83529",
+    "reviewedArtifactChecksum": "de123e7dcc0c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "ce39c30a2a7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "4bfd16f28be1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "26ba2e967ef8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cef286d4c51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fab982dd28db",
+    "reviewedArtifactChecksum": "4b83383855ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d0cbc370579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "698aba7e4fe0",
+    "reviewedArtifactChecksum": "1f86359d0260",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "775dd6bb6d41",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f1e9e754358": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "97f8365bfb54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8b74d92e62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23954b90525f",
+    "reviewedArtifactChecksum": "2f17f7473ad3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "4ef7c32ba662",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fd7dc1f9db5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70417a1c18f0",
+    "reviewedArtifactChecksum": "840f162ebad1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "60e1839cbb34": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23ded424e7e5",
+    "reviewedArtifactChecksum": "0dd128f46aa8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6332ca621968": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c422eaca74c",
+    "reviewedArtifactChecksum": "aa82f6fdb3ba",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "15ccf3c230e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "096cb6972714",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "655893ad7990": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "904aabfd86ab",
+    "reviewedArtifactChecksum": "34f5526bd9ad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "65758201b8ae": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c1dcc0da6d2e",
+    "reviewedArtifactChecksum": "d0ba7c2bd6d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6645006a0cb7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "47e142c4c5b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67b461209d58": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e95ee7304036",
+    "reviewedArtifactChecksum": "a398a8937257",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68c39b4c6a6f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5106ec4eb948",
+    "reviewedArtifactChecksum": "258e6ad824b1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68f726502f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f79e6d2af1d",
+    "reviewedArtifactChecksum": "a7d7547428b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69850664cf89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8271b938f6",
+    "reviewedArtifactChecksum": "761f7ed3a6e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6991493996fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "0c203f8d2c1e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "69a3789c4840": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "79a4cab80516",
+    "reviewedArtifactChecksum": "a4be7bd63cf3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "6bc901c518d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a2b37d44146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ebbffb505567",
+    "reviewedArtifactChecksum": "51de9fb1b693",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "7cd0be340939",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6afbca6e9d22": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb05dda45844",
+    "reviewedArtifactChecksum": "03181beb9d44",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "660ea69c9017",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b3078795300": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "da8204cda66a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "a13669a22dc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "bed70ce4b9a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "0fa9b8ba68c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "a7a25ce8ffa4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f168e04611e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6756b205dbd7",
+    "reviewedArtifactChecksum": "3bcf3a60904c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "751b1c3fa43d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "2090868890b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fcaf95e52b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b98247d4d4a3",
+    "reviewedArtifactChecksum": "d87597326a7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7016f027bcf1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "edf15f23eea6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70e6b211c5ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bfd219d920b4",
+    "reviewedArtifactChecksum": "2403afab2e1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "50980eb6fa4e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71355ee91724": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f168dc59d8b",
+    "reviewedArtifactChecksum": "04cadb78e5a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71a0edbac544": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "91680b82fd8e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "9e7123c8fc85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "d63341542308",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "730d964da0cc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "02c64ba307fd",
+    "reviewedArtifactChecksum": "23c1197b8827",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7330608df8b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "f539a8b658ff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7332830d0455": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb424516512e",
+    "reviewedArtifactChecksum": "19dca2516418",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "736ab92b893a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ca13f304ebba",
+    "reviewedArtifactChecksum": "d1b83379cf0b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "73a6511dc29e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "728cfd09e417",
+    "reviewedArtifactChecksum": "6675f705ea9d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "18f4814c8a46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "f7cfabbd7ede",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "75fb83052003": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2997faf42514",
+    "reviewedArtifactChecksum": "65f656b4c8e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "768526487e8d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f1c03a7a813",
+    "reviewedArtifactChecksum": "cc2b58f37274",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "0e08602d7e85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "770640dfddef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "89d02edc36f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "777bbec39cd3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "787cfd599758": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "b4232f525b63",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7905fe6d550c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "c21b1a761e74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79227f845a2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "d5cc07a145cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "4d968ee3d069",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79bdba6f2250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "6a3499157320",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7a6ab8b6e694": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bac15fa24b1e",
+    "reviewedArtifactChecksum": "6ebb4e32dc11",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b25a77c44de": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "f162e50decfb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b973ace62af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "0453b7004295",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7c0c712700e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9bf2dbbc9f",
+    "reviewedArtifactChecksum": "2f824c6eb1cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "63675beac8a7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cecbe192fc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "195d7bfcd500",
+    "reviewedArtifactChecksum": "78a45432517f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cfb99272578": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "cecdf98d1324",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7dca0438edf4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a20647f365c",
+    "reviewedArtifactChecksum": "fc1d5de0ee1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7e47ce4777e7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f36b258c08f7",
+    "reviewedArtifactChecksum": "680aca6275aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "e44d56b47544",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "73cea22a8d83",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "0f509a694cf1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "dc8f3fa25d5c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "821350279daf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfd74e306354",
+    "reviewedArtifactChecksum": "bfac98aa2f0c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "825e6fb23c2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f9084ed9312",
+    "reviewedArtifactChecksum": "7279871fb019",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "834ab8919949": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ddbe0761021",
+    "reviewedArtifactChecksum": "7d5a46fcd11b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8357db8ead93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "846d1964fbdf",
+    "reviewedArtifactChecksum": "fe2ef3ba4287",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "83ff3768d42b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2c3e7617c972",
+    "reviewedArtifactChecksum": "84f13bb3ed65",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "840b6e4c3983": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "575ac8693ee3",
+    "reviewedArtifactChecksum": "7c51f26a541c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "847f17f3f95c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba380c49e96f",
+    "reviewedArtifactChecksum": "ca9fbc067b29",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "857e50707831": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "49a854ad7b70",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "2b490a497b56",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "86efedaffa3e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "94323dd95697",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "874c251ff2f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "cefbde56552a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "543729ec7160",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "87f3b4c32e4f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "405b0711392d",
+    "reviewedArtifactChecksum": "de43693b500e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "e8d4770e24f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88f014a33e2a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "718b0af6521b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "895960b69952": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "5f0101fe9303",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a1f5f5998cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2d71fda9dbb3",
+    "reviewedArtifactChecksum": "d43e3c190b0c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "fd13a8748646",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a90e1694881": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "fedb584996ca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8bd8b493eb7a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a017392574e5",
+    "reviewedArtifactChecksum": "774a23e361d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c553cc7c664": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "499792e4d375",
+    "reviewedArtifactChecksum": "19be5958f9b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7390cc52c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6713a12925e8",
+    "reviewedArtifactChecksum": "477ed3b89e69",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "483d7bd4a6ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c90417df6d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a607c0fb4184",
+    "reviewedArtifactChecksum": "0215fe35c7c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8ce4aa90e8af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53e9d1857f48",
+    "reviewedArtifactChecksum": "601cf8294fc2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "9e6107b416bd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8e090ccf5a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47f76e5028f9",
+    "reviewedArtifactChecksum": "ab00d88de3cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "8bd93894a9a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "02247e00cabe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90bbb7c2ceda": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8092679339c1",
+    "reviewedArtifactChecksum": "c83fbb007238",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "90d086fef9e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7ef0f5883edf",
+    "reviewedArtifactChecksum": "4cbbd2c45c87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "911c19a4391b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8d806844167e",
+    "reviewedArtifactChecksum": "dec81f80bfcd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "035eb180b94b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9173ef378024": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "57b5730bec46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91ec966e3abb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "5bc16c44260e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "920c6926e747": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff8c82402faa",
+    "reviewedArtifactChecksum": "c55a8d8606d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "44a9fa28bf13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "76d5a1d89486",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "aa9dd2ffa11e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9394f9968da3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3dcee651464",
+    "reviewedArtifactChecksum": "91a042d8732f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93c182d3aefb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "3ab5f615314d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93f286fbc2c8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "37ff0c409aa4",
+    "reviewedArtifactChecksum": "e2fb955f8af6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "947be2b6d997": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18b602a7ec8",
+    "reviewedArtifactChecksum": "bf782eff793a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9654558acd06": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a12731a191",
+    "reviewedArtifactChecksum": "f03e8c7e054e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96deb62c9ac0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16add7e6f4ea",
+    "reviewedArtifactChecksum": "7007cd61a7c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96f9694b12c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "7aa0a88cd54b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9717b437111c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32afb04f5179",
+    "reviewedArtifactChecksum": "7e8ca2ec5243",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977bc7f55865": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16b8504f3ddc",
+    "reviewedArtifactChecksum": "4efb515d08e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "0b197e1d86ad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9829786b38f5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "756c65cdb937",
+    "reviewedArtifactChecksum": "eb5069864654",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "c129e3406ae7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "dadb723b4506",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "679970f0e3d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99ac5a75449c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "7267b607a46f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99aec65eea89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "08ee59c22c25",
+    "reviewedArtifactChecksum": "0551a20c746a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9a2d779f8ddb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22a817436ead",
+    "reviewedArtifactChecksum": "751f157268c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "c078b413ddea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "5b5708f8d779",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c0e04762e99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "409e8afd3ba2",
+    "reviewedArtifactChecksum": "7e7b3b06923f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "adeb341071d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cc2917611e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "f5e586c4db14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cca5e2b3dde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "478c9fb1fb03",
+    "reviewedArtifactChecksum": "8b5c0653efdc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9d588c37e728": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "a19b0db61570",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9dac2dae8bfc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aef58f46958a",
+    "reviewedArtifactChecksum": "b10a9e76e07d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "c3d3076fa862",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e910f3b95c2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "222b5e4fda0b",
+    "reviewedArtifactChecksum": "6e9dceab4277",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ed4f6b88b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c3118fbc5ef5",
+    "reviewedArtifactChecksum": "24791f5be2e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "89d32e0be96d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f1bb8c2f14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd521aa22072",
+    "reviewedArtifactChecksum": "964927f35d88",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f9f595534d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47ebf99edfc0",
+    "reviewedArtifactChecksum": "2b27fe81de12",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "b716ff66689a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "9ac9f0294e57",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a013e57e6d51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3676bc6af0c3",
+    "reviewedArtifactChecksum": "76ba2c8acea9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a084de008c94": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b61da2fbdbc2",
+    "reviewedArtifactChecksum": "1963cc370421",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "a5ca01bb1c1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "9facb38454f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a1bb55d904c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d689442388a",
+    "reviewedArtifactChecksum": "90cc91e8317d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a20d3822a38f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "f6906693579f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "fd63df046527",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "9e41ad2f7ef7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a47d77950ec1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "a2f7ad599a11",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "1e9bee3c067e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a50ab9e1df59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e09f98cd488d",
+    "reviewedArtifactChecksum": "b62d19ee2ad6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "15fd12132e01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a58c512532df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "d3ac70aa9bd4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "b86c24310c98",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "791e492ca524",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a781503cf508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "f7713daaab80",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a84541c0018a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "336842c970bd",
+    "reviewedArtifactChecksum": "aeb980ee9495",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "fd4260590da7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d139dba458": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6189bdf610c",
+    "reviewedArtifactChecksum": "a87fe22274b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d874e28508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "b4f2e0e19f40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "72cb18892bcd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "c99ef5689fde",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "5ded9fb02a85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "995aefa11484",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "c316c60abf9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aac8b0d80e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c55f22e29a79",
+    "reviewedArtifactChecksum": "4ad34deb5346",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "075b174d12f6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "abafa1d4f1f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a734209a698",
+    "reviewedArtifactChecksum": "ed4f6acb086b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "0141ecc7bde4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ad8614720882": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d4fc106119f",
+    "reviewedArtifactChecksum": "7469e64f631a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ae12a241076c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "328772b0de8c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "cb4c9dc6748c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "58a809054d1c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "8e4accfdd873",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afa2656c1d4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9062cb86b8e5",
+    "reviewedArtifactChecksum": "290b164e6601",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afd30ccf8238": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8baf7e5024e1",
+    "reviewedArtifactChecksum": "87566db7b51c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "7c474a936e52",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "a265b4a29535",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "83a98073fcaa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3437893d89d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "a7630e52b8be",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "81037fe6c3e8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b35c9fa7658c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52f2757246e6",
+    "reviewedArtifactChecksum": "b29e3c2e71f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "f816d4d3e2da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "a8179f509b67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "cd8e545de068",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "5dec3a9022fb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "ad0b717459d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b594a01df1d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "94660f232c6a",
+    "reviewedArtifactChecksum": "5dca6ea161e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "9274e80dc1cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "ebf5455fb245",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6e55869de51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "b85d8a90c2df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b74ad340c930": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "a418f40d00c3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b893149a8671": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c53aa635287a",
+    "reviewedArtifactChecksum": "fa8434892dbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b89d812e25e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "50c82f3f3265",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b8c030205d86": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "f2aa3d18cac2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "f752dedad23e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b993c1885a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "6034ceefae90",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ba62b8d37772": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c238c0c4184",
+    "reviewedArtifactChecksum": "4b8891b6d5e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "baa06a413558": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb0421c78c54",
+    "reviewedArtifactChecksum": "71fb70024848",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "d03d182e80a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bb33cc433026": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "5f3f787b8669",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bd874c5e02d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b205dfd4c7b0",
+    "reviewedArtifactChecksum": "ed89ad4f3f3a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be07722555ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2733ee2b0ba6",
+    "reviewedArtifactChecksum": "ee12754d3f48",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "51abb7d1e267",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "a819bcd4b889",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "36de8731cd60",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "7dc57c1cb28e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bfba92751be8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "346d47321248",
+    "reviewedArtifactChecksum": "b0bdd842c15e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0198b907108": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d990d8877fc4",
+    "reviewedArtifactChecksum": "380ad03111e1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c01a333cfbd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9026217dfd87",
+    "reviewedArtifactChecksum": "2929be8892df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "f2c4a830bc26",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "b7eca2f47d54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a547f8fee6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9d006aaa7074",
+    "reviewedArtifactChecksum": "74df0e6f1f32",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "a58bbfabff41",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "bb95e225fa11",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "bd41d4e22f8f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "fcfa4d78a858",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c27ee1ed3d54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a4f0c6af427e",
+    "reviewedArtifactChecksum": "07bacf8bc6a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "d66596fa212b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c365c23d9a69": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ffce08e35764",
+    "reviewedArtifactChecksum": "020c149f5d54",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c384585f8b2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "ef4edd8f9edf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "53de5ac89796",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c51538d3e644": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "675c28adece5",
+    "reviewedArtifactChecksum": "679e39ca5013",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c5cbee07611f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "4667a810ee77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c666b9b4014e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa13392fa44c",
+    "reviewedArtifactChecksum": "d3038fcd7b29",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c671a3e5c6bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9db5c6774ddc",
+    "reviewedArtifactChecksum": "4c7b5f21865f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "3e5759f6092e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c70904777c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "7926c56fc0d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "f2d944ae12b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "861c9a03dfdc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "743476b1eb16",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "1dee96a7fece",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "6186557bf7bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc053bb55df6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b9c62043d7a5",
+    "reviewedArtifactChecksum": "72f6bd173557",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc078724f871": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "89c0934a58ba",
+    "reviewedArtifactChecksum": "67855131fc13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc23c187984a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3b18a4f3d32",
+    "reviewedArtifactChecksum": "f77addc50ef2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "6ebc90435799",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccc43113008f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "871749b45d60",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccf567b604be": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "403c1312bc3d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccfc1768e8b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78959ad91441",
+    "reviewedArtifactChecksum": "9c4e81dd202c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "e0bb3f2f8759",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "5c738e84ba29",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "6b72555f5f92",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "c1bfc06dd7cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "f6ab1615e2f1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "5caefdd1f329",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "e76bb71af0b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "0bb2c022e9a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d23f62e48d10": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "f4bded998fed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d2cee11e428d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "74328044f4bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "1d125d63ac08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "6b73e1feb53f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d4b951896b54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "74603b189b71",
+    "reviewedArtifactChecksum": "06dabeddfa87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d54ddc21563b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b0922593b58",
+    "reviewedArtifactChecksum": "1b7347e24cfb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6109704c9d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "c7c3f958e757",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d636956bdddc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "f7c366c34356",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "fa7ff8bcad06",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6bda294b8ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "347186231e5f",
+    "reviewedArtifactChecksum": "be940997d8e9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6e252fb4880": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "e2d36a6a093e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "6f7fb98e916f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "b16dbad1fe16",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d768fd20d606": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "40945d31b8fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d78377cf53f4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62ce15566253",
+    "reviewedArtifactChecksum": "ebc8d7500e7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d82f4527c76a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6517985e895c",
+    "reviewedArtifactChecksum": "defd2b0ace80",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d833dc5abe59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ff8e0fc1088",
+    "reviewedArtifactChecksum": "77f44a57c493",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "e256b41c6591",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8bd574de179": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ed010eb61ee",
+    "reviewedArtifactChecksum": "23c25a21b7f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "a3fefa63ebb3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "8818de09691c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "b07670c8f13b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "f7a63440e577",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dba8340fd0f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2f5928f73e0",
+    "reviewedArtifactChecksum": "dd22c53b4db2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "8cd646dd758e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "8b8099b6cdda",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc4b3f6dab6e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bbbc8180df94",
+    "reviewedArtifactChecksum": "84b954b34973",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "1e538caa7c46",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc73712c1842": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b483aac476e6",
+    "reviewedArtifactChecksum": "5a5493443b0a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc7727f63c0c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb408a2280dd",
+    "reviewedArtifactChecksum": "dd53ba2874d1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "4bbcc2e1c6e3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dcf21d867c91": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7b380339f8c1",
+    "reviewedArtifactChecksum": "d2c3690db7b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "20257b46202b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dff780783fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "c49bb52449da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "2075c6e9739f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0f1fb8115ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2208cdd14461",
+    "reviewedArtifactChecksum": "aedd24beb13c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e173ace9bf90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "33d37ae77430",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e1e03cafda18": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "11cc7048ff73",
+    "reviewedArtifactChecksum": "21ed3414d51b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2716c39cb46": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88d2297a2338",
+    "reviewedArtifactChecksum": "b7fd8c3849d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2df0992de37": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f18a7f8283b5",
+    "reviewedArtifactChecksum": "29f15b359244",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "a21ef86e49e5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e41b80eb587d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "f801518a3a13",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "1060dcf81d59",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4d64e14c5e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a8b9fb83ba3b",
+    "reviewedArtifactChecksum": "23d626dfe533",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "d22d51c85091",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "18a7d9ab8f1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5f83394283d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "c22dba9f405e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "827a7cf32a91",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6aa60b3fa90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "157edbd2a5dd",
+    "reviewedArtifactChecksum": "71f1425c55ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "db2efb63c113",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6f74ca84e32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e68fb1567b85",
+    "reviewedArtifactChecksum": "cfd941889ac7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6fd8da0c247": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aefaba1e21a5",
+    "reviewedArtifactChecksum": "905be6ab6208",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e78f02853c98": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7a2357bf6d3",
+    "reviewedArtifactChecksum": "9216c5727b4b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "04f26e68c82e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e81f8eb0ee5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fee8d86b0c31",
+    "reviewedArtifactChecksum": "cb7d1b1085ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "765d455a566d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9543e32164b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e9d2b585edb8",
+    "reviewedArtifactChecksum": "9fc806f95713",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "a5754032bfc8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9f70b059f43": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f2449f49b504",
+    "reviewedArtifactChecksum": "9b92ffeecbc0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea4911d91143": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a921f371596f",
+    "reviewedArtifactChecksum": "4061d0f5fd97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea6154c3447d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "edfc84cf3d38",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "b9a6c36d2d5c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "47f72aee2555",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "02305d71d4fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "e74a527a0dff",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ed1c4eade3a3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6889ef99d92",
+    "reviewedArtifactChecksum": "826b39c026ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "219ecc368b37",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef10fc1fe4d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f61d2cc731a",
+    "reviewedArtifactChecksum": "d3d3e984334e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "12953aacbec8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef37c26c9bbf": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d5f9fe5a70b4",
+    "reviewedArtifactChecksum": "9bdf07010208",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "a47d295c2896",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef8586090398": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "3db6fa457ff2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "9123f2e8ae59",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f052abfce10e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "f1d6bb738d02",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f1dc525f26dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0240a925b535",
+    "reviewedArtifactChecksum": "c67331b98485",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3096e2ffb64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20e28569e2d2",
+    "reviewedArtifactChecksum": "5c093f95e11b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "12b5bb3db687",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f49b24114ea9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e89780c7120",
+    "reviewedArtifactChecksum": "1707a085440c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "0461eccc24c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e29143100c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18726770189",
+    "reviewedArtifactChecksum": "a6d930e3f287",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "7b222497a972",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5199b5121f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bced52cff23f",
+    "reviewedArtifactChecksum": "37035e29c9c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f56329f28659": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "862514a50548",
+    "reviewedArtifactChecksum": "4dd84727256c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "c725e9de949a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6be37ba0bde": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55a4060336a6",
+    "reviewedArtifactChecksum": "c06d8b752211",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "19702f4f03de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "8a76ad890de3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "35ec7af153c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f83ee3caa04e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a47e936b4941",
+    "reviewedArtifactChecksum": "91ebd60086b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "f294eb5b29e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "c24fd0a6d3ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "608463706519",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93775fd8ce0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41bb23f3a44e",
+    "reviewedArtifactChecksum": "9b6db42b0017",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "e3ce0df921bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa1f01a51d17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "33418f4fe697",
+    "reviewedArtifactChecksum": "8a04156d14f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "b003a6b5d45d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa9731c2000f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da9922d1bc7d",
+    "reviewedArtifactChecksum": "6051bd5fa987",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "997826e3ff57",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb63409aebf0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f40a7e7b42da",
+    "reviewedArtifactChecksum": "98b1acdaf6d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "e6f7dc59d0ae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd76422c14ea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "5ad2fc02adf8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fdab9848b160": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bc70dfe515b2",
+    "reviewedArtifactChecksum": "690e941a00a3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "3c34f1f82cc2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe773d7d7377": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "9dcc65d48b2d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ff88e6723334": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "84ab8fe1b9ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ffbc62a77b85": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cbb7a2feaeb",
+    "reviewedArtifactChecksum": "d47a2e76c1f0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "c9f8755bf289",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/i18n/reviews/zh-TW.json
+++ b/site/src/i18n/reviews/zh-TW.json
@@ -1,0 +1,3890 @@
+{
+  "011974792e13": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10cea740af85",
+    "reviewedArtifactChecksum": "c12b9fd754db",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0136284ecc19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91e8e3b7fcf4",
+    "reviewedArtifactChecksum": "34f30ca76d75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02b3722db38c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44edc2331fb8",
+    "reviewedArtifactChecksum": "2cdb4159543a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02bd87067503": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b052252d5c3",
+    "reviewedArtifactChecksum": "651e86384f7e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "02c118b50bc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4ef5c3430e2c",
+    "reviewedArtifactChecksum": "d9752d40f054",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0309de53eb52": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7913e3e152ef",
+    "reviewedArtifactChecksum": "4ccffdc8503e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0314e3bcf260": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "46fe50e34613",
+    "reviewedArtifactChecksum": "2215e29cbb2c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "035aa9dc92ad": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "213d2942b769",
+    "reviewedArtifactChecksum": "0f520c297aee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04479f67187d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3af4c9fc7c7d",
+    "reviewedArtifactChecksum": "3430cc3985e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "04bae0edf048": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccea0d04dee8",
+    "reviewedArtifactChecksum": "0e90fcba4ddd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0615e56af586": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6475f4c475c",
+    "reviewedArtifactChecksum": "8833d4e155c1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "064da31db8f3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8e6ad594d74",
+    "reviewedArtifactChecksum": "aebf292f50b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "06caca08d30b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d82132fb24c7",
+    "reviewedArtifactChecksum": "690dcebbb70a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0812b435d117": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52280ad8fc82",
+    "reviewedArtifactChecksum": "154efe7a1c5d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085a4bba12f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f605e62f9f0a",
+    "reviewedArtifactChecksum": "4809e4fa04d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "085ff06f65f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0db640952d17",
+    "reviewedArtifactChecksum": "bc9a272d1a85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "08d91c5f3020": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a834b4d1a9b2",
+    "reviewedArtifactChecksum": "1f83be7e913e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "094c40ffb14f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1f64c29c3d5",
+    "reviewedArtifactChecksum": "eb780c3b62ae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0a6672ca248d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d4a78fe0d1c2",
+    "reviewedArtifactChecksum": "1d48b062e426",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ade3f3e0879": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "743192af6c94",
+    "reviewedArtifactChecksum": "c5344ae36001",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b405e2734df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ca9a7e783b8",
+    "reviewedArtifactChecksum": "bbe8a3521d34",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b8d28f4cfa3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "87d4e7a24aa3",
+    "reviewedArtifactChecksum": "df4d6d798dbd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0b9c4f596d01": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "492b12b6a622",
+    "reviewedArtifactChecksum": "ec88cf8f8fc4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0ba871b9578d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7e3ddcc41c13",
+    "reviewedArtifactChecksum": "6a2f81a15959",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0bb057fd76e3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3aa2aa4af0d",
+    "reviewedArtifactChecksum": "6ae915514b36",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0cd2d1919edc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c0ba0a57c2cd",
+    "reviewedArtifactChecksum": "42c2b07f1bd3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "0f5f5bc82df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b05f5a192869",
+    "reviewedArtifactChecksum": "aee081a6ae40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1043317e75c9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "53b65b28d937",
+    "reviewedArtifactChecksum": "88b18b109f40",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "105559626c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e095741cc033",
+    "reviewedArtifactChecksum": "ec02878a6e74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "113c9ab2c6d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387ec1f14afa",
+    "reviewedArtifactChecksum": "c5b7e68573be",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "11657ed32877": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "63b92d2012c3",
+    "reviewedArtifactChecksum": "6a31d7ca4d75",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "126feda70bcc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3395c44f3b61",
+    "reviewedArtifactChecksum": "14d4ceffa024",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "12c2481d04b4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9c6ff6175b64",
+    "reviewedArtifactChecksum": "2c64b3b05286",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "130a350ff0b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "13874e8af019",
+    "reviewedArtifactChecksum": "9b0b6eee8df2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "13ba3af78782": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f35ddb881ae7",
+    "reviewedArtifactChecksum": "1681606e1fa2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1446c7f47aee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6f1a083fa19",
+    "reviewedArtifactChecksum": "ba92c215c3ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15538e51d812": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "935eb3882193",
+    "reviewedArtifactChecksum": "99a588aeffbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "15b9a8d461e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "546ce4a0a06e",
+    "reviewedArtifactChecksum": "fdcf079fe3c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1606e79dd224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3a992d392dd8",
+    "reviewedArtifactChecksum": "b5c3e0a9d257",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "163ff33fc4a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "699311b01e44",
+    "reviewedArtifactChecksum": "d1a154615290",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "16f123e593db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1876160997c7",
+    "reviewedArtifactChecksum": "af80dfae0063",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1785e38f230a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b14ce37415fa",
+    "reviewedArtifactChecksum": "b0cc321b7f8d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "17883fb20765": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10f0970e42bb",
+    "reviewedArtifactChecksum": "47984e0dfd9e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "181a9571c9a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f334b4b8708c",
+    "reviewedArtifactChecksum": "e8e485babebc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1880d7035ea2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "440f19d077ea",
+    "reviewedArtifactChecksum": "20459fe5007d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "18da3456241d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6f5a6f71f9d9",
+    "reviewedArtifactChecksum": "ff81a95fe4af",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1a126268f912": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "be1bf683d2f3",
+    "reviewedArtifactChecksum": "7190daad2daa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1af3df552a07": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9623bdf6eedc",
+    "reviewedArtifactChecksum": "379d75bfbbec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c77e82713b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "90e7213cafe2",
+    "reviewedArtifactChecksum": "33e847198166",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c8383fd62e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "422ccd9a3669",
+    "reviewedArtifactChecksum": "fee257a8951b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1c9499c35ac7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e2c8496d1371",
+    "reviewedArtifactChecksum": "029c91882ac2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1cbba0417673": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3deebc4e14fe",
+    "reviewedArtifactChecksum": "9dc6cbd02cb1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d16e17134e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab8960ea5b9c",
+    "reviewedArtifactChecksum": "352a7b500f18",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1d69cf9d1761": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f451c5ddbeb",
+    "reviewedArtifactChecksum": "eaa93e914146",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1eab7aa23f6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5370f9eaf883",
+    "reviewedArtifactChecksum": "f5b0f6340b84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "1fb07c3b4b99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d2ce08d29a8",
+    "reviewedArtifactChecksum": "f17a5944d371",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2007a7e69fdd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62f36014641c",
+    "reviewedArtifactChecksum": "c5d19caa9853",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "204bbd9ee146": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "995daf45bcf1",
+    "reviewedArtifactChecksum": "859ae7f5dfc9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "20ff6cad791c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ea62c466df11",
+    "reviewedArtifactChecksum": "08ec819f5ae8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "228fef3dbe05": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "45c9a2dd1369",
+    "reviewedArtifactChecksum": "1e73134751b4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2318d5c3d250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1327a659bf4f",
+    "reviewedArtifactChecksum": "2bbd8861d3c4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "231992fee1a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2065fa8f03",
+    "reviewedArtifactChecksum": "6eae71b62683",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "23226868cf80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "267006baa10b",
+    "reviewedArtifactChecksum": "f982cf6d4aec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "234798f9a5cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7aba106f46a",
+    "reviewedArtifactChecksum": "30ba8cf0b6e2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "260ed6c2147f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73a812d2aaf7",
+    "reviewedArtifactChecksum": "f5ceb6b37bd4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2620e5135442": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "898d2af58acc",
+    "reviewedArtifactChecksum": "518c665741a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2639a76cf00e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef2ddf8a568d",
+    "reviewedArtifactChecksum": "370d1e3ecb00",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2652985596d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eddea5c0dbca",
+    "reviewedArtifactChecksum": "f1f123a24cb6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "268307c5793e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e73f6dbefda5",
+    "reviewedArtifactChecksum": "0c87d6d0ca14",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "26e1f4eddd7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "44093fc53faa",
+    "reviewedArtifactChecksum": "603ccb7af396",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "282b1e22f040": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c50108d6f180",
+    "reviewedArtifactChecksum": "8b0d31528647",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "28bef9a984ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b5c9754c6f0e",
+    "reviewedArtifactChecksum": "66b9a3eb1306",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29633c85694f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c36ab643184e",
+    "reviewedArtifactChecksum": "d7950226daf2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "298d2c8d7de5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef6ea395e58c",
+    "reviewedArtifactChecksum": "70d12955a61d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "299685fcb8dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e77f1278a926",
+    "reviewedArtifactChecksum": "6fdcd437f2b8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "29be9776c3b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e6c195d1434",
+    "reviewedArtifactChecksum": "a1f7479e8e30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a95da601676": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f3cd6bdb534d",
+    "reviewedArtifactChecksum": "c37120620a41",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2a9b4417b44f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ccad09e8c3a3",
+    "reviewedArtifactChecksum": "17c2e57bd539",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2b3403ae14e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e8694c8adddb",
+    "reviewedArtifactChecksum": "65ecf03bf6ed",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2cf9f9f6d205": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b309266ed227",
+    "reviewedArtifactChecksum": "5fad1a346e8c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da831d21d09": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cc98939e1059",
+    "reviewedArtifactChecksum": "1b60b09b6ab0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2da9ee24ad74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4186cea3bf4d",
+    "reviewedArtifactChecksum": "4ab3742541b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2e37304a2fbd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd34c901c229",
+    "reviewedArtifactChecksum": "575912b2fe21",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2f10814fd823": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17de3df068b8",
+    "reviewedArtifactChecksum": "06d05e7e63ab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "2fe0313c0bb9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e5bbffc1f72f",
+    "reviewedArtifactChecksum": "6d2627c2d92a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "31ea7d2d9224": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "efc14982a928",
+    "reviewedArtifactChecksum": "06af99163415",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3249521762e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "22040a282554",
+    "reviewedArtifactChecksum": "101c301c9479",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "325247297bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "857507568e41",
+    "reviewedArtifactChecksum": "d3f887526a02",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "32890fa5798a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d42005a9c0c",
+    "reviewedArtifactChecksum": "5ea270033eab",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3340bf62687d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f43a935b4ac0",
+    "reviewedArtifactChecksum": "91859b504451",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33747bd52ad5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e604162de231",
+    "reviewedArtifactChecksum": "5dae08d4b265",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "33c621f7803f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f620b85d5c29",
+    "reviewedArtifactChecksum": "6ebf452fe803",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3515c5083027": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "554e4ef6a5f3",
+    "reviewedArtifactChecksum": "a81d28c276ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "351e79d06ae1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "358d6127c306",
+    "reviewedArtifactChecksum": "f2e1901b17a6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "361cd788164e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a3a27dbf265f",
+    "reviewedArtifactChecksum": "5ab9b0b3b451",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "36794f399aa0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2235403069a8",
+    "reviewedArtifactChecksum": "65da0be04cfe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3755b3465820": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "788a5febdf8a",
+    "reviewedArtifactChecksum": "6f53d9830ac3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "387eb41c0702": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e3b9f7d379e9",
+    "reviewedArtifactChecksum": "c648e0fcedc9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "38a5302d2c2d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6098c8913ab3",
+    "reviewedArtifactChecksum": "b7f7f7248b28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39d6048bf91e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3a2c2fbc8ec",
+    "reviewedArtifactChecksum": "5b2d57d4bdd7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "39f7098079f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1e2c27847ee1",
+    "reviewedArtifactChecksum": "bfd0d8b1b69b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3b9e9f29c1dc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69a67afce7c6",
+    "reviewedArtifactChecksum": "03c6399c5a6c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cb47a67b81a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "19d587d12601",
+    "reviewedArtifactChecksum": "78d78cb0b133",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3cf3c6a082ed": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23fa60e1ebba",
+    "reviewedArtifactChecksum": "143f080efaa3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ddb7afa1aa4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75be72e8265f",
+    "reviewedArtifactChecksum": "ae509d972152",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3ef4de40106b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bdf6caae5207",
+    "reviewedArtifactChecksum": "0437a9e8c3dd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "3efed399a12d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ef55610485f",
+    "reviewedArtifactChecksum": "6685bb448c08",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "404250f61d0a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c6f1fe977608",
+    "reviewedArtifactChecksum": "311742d8b8a0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40770c9eb41b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1489c9d2312b",
+    "reviewedArtifactChecksum": "a05c0d47aa8b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40a427168ef7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9a7263bd6e5d",
+    "reviewedArtifactChecksum": "56e04d94d954",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "40dea2f852c3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "babc35ee6fd5",
+    "reviewedArtifactChecksum": "96e186bc35ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "414a6f8e0c33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4b85e48f5d0d",
+    "reviewedArtifactChecksum": "a05d4861857e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4176b98e2b7e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "810032a8dcaa",
+    "reviewedArtifactChecksum": "c293e421f55f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "41f029c74cd4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8fa784a8d40a",
+    "reviewedArtifactChecksum": "92ef794d8838",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "430b718c2c90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "238d3b61978c",
+    "reviewedArtifactChecksum": "fc5a42e9d174",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "439a815b15a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32eef1620f8d",
+    "reviewedArtifactChecksum": "2711a87efc81",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "452e68e4a484": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71ca18417ebf",
+    "reviewedArtifactChecksum": "b7853aece133",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4540c3f34805": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f1fb750cadab",
+    "reviewedArtifactChecksum": "0112a5c70f95",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45638e198c1d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7af53d2007f6",
+    "reviewedArtifactChecksum": "1edb0532c490",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45a8be9c1124": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "189dbae0eb4a",
+    "reviewedArtifactChecksum": "58d45f47f284",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "45c0ce6bcf2e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "152763825cc8",
+    "reviewedArtifactChecksum": "f47d9fd80447",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4600a60d661b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "379a80269fca",
+    "reviewedArtifactChecksum": "77e5dabd38da",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "460daa6b205d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb1e02435d8e",
+    "reviewedArtifactChecksum": "2e3aab064499",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4638e59ae7d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a0e59ae686f",
+    "reviewedArtifactChecksum": "8c471771ae8c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a303cbccf9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0ff3f48dc5ef",
+    "reviewedArtifactChecksum": "06cac95e219d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "46a80518c9c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55cd4863a54d",
+    "reviewedArtifactChecksum": "9ffcd6a6efb7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "471717404074": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ce891a29a58",
+    "reviewedArtifactChecksum": "67acfc1d14f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4724032fa666": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e443ea484aa9",
+    "reviewedArtifactChecksum": "573dedef9188",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "473606b441c6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f6c556cf24c",
+    "reviewedArtifactChecksum": "1efe5d15bbec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47a892d81764": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "376ecaaeccc6",
+    "reviewedArtifactChecksum": "0827caa5e6cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "47d245c34a7d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "830e4417e0d1",
+    "reviewedArtifactChecksum": "3862c2206e1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "49a2f3a0811f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "51dc5f124b8f",
+    "reviewedArtifactChecksum": "bb7531271639",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4a4da321a45d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04f477efeaa6",
+    "reviewedArtifactChecksum": "539225bd03de",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ab928487496": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10b47f3824d0",
+    "reviewedArtifactChecksum": "bd299032b29a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b042b6638a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27c46c50ab30",
+    "reviewedArtifactChecksum": "28169effb4fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b23697cd68c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4d7d06efc1eb",
+    "reviewedArtifactChecksum": "056c07e016e6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4b64f0419f57": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e6fcf74aef31",
+    "reviewedArtifactChecksum": "7c24b9fd004d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4c3bfe1f75fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c40b429af5e1",
+    "reviewedArtifactChecksum": "10c8184f21aa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ca799182440": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a16c03fe7032",
+    "reviewedArtifactChecksum": "12cce4cc7ba5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d10908bd0bc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1538f837a2c1",
+    "reviewedArtifactChecksum": "7ef22a75cb92",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d7abcb8e25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d89c24719d52",
+    "reviewedArtifactChecksum": "6aa2bd03fd80",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4d989a34d147": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98e6bd641239",
+    "reviewedArtifactChecksum": "e12d7c1f3014",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4df9e62285aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "401816293a77",
+    "reviewedArtifactChecksum": "cf42feade2b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4dfdaf8f07d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a50bbbf99764",
+    "reviewedArtifactChecksum": "34d02a765e85",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4e430639b9b0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a5cc5554fe4",
+    "reviewedArtifactChecksum": "0285893d0a4f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ebc86e57ea6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91c8f2927041",
+    "reviewedArtifactChecksum": "52f3a1cc8941",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4ec378ca0cea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "91186e5263d2",
+    "reviewedArtifactChecksum": "47f52a3b3bbe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4f8b62bfd681": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6d64266bfd70",
+    "reviewedArtifactChecksum": "4a1f7762761d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "4fe8d97559cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26aa0eb0a87d",
+    "reviewedArtifactChecksum": "8030f75d9e28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "50199f76fe74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c1fb24a9e72",
+    "reviewedArtifactChecksum": "bed41d17fa15",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "524727db7cac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "998d7be7cc7b",
+    "reviewedArtifactChecksum": "c51ca15cc9f3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "527ecf1f2eb4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d0eec3fb183e",
+    "reviewedArtifactChecksum": "7071c870a7f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52a2be6f1c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80bb4462c6a6",
+    "reviewedArtifactChecksum": "cb2aaeaadc1b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "52dd3f09bb59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ce2975c65c9c",
+    "reviewedArtifactChecksum": "914f8d62a76a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "536dc32faee1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1a12ade6eb6f",
+    "reviewedArtifactChecksum": "023cb0f6ed91",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "537cf7f1f745": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb039818c192",
+    "reviewedArtifactChecksum": "df821d5da4a4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5427ef92c853": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0fc59c519c3f",
+    "reviewedArtifactChecksum": "3cd388a65114",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5489b3cf2ac1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62d873360da1",
+    "reviewedArtifactChecksum": "b9e05cd9c652",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "560738f98e65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "723649c98a3f",
+    "reviewedArtifactChecksum": "ab991a936cd2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5615df5d2e0d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "baf17938711f",
+    "reviewedArtifactChecksum": "7e407305be7d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "563f9b5f6ce3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "092def4efba1",
+    "reviewedArtifactChecksum": "3a356fb9aa74",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5697ddf9182f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "52af365c5c2c",
+    "reviewedArtifactChecksum": "9b15960988ce",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "57eb4f2ddb92": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2271b8120f36",
+    "reviewedArtifactChecksum": "b643c8084513",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "585c7006af9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0cb236e82cf1",
+    "reviewedArtifactChecksum": "4beae63149b2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "58a3f7167dba": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e4d743a2221",
+    "reviewedArtifactChecksum": "31d68edae778",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5931e9bdf9db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "916bf36e3b22",
+    "reviewedArtifactChecksum": "6824aef3b2c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "598da2637dc8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b383a0894221",
+    "reviewedArtifactChecksum": "8301d8d2f836",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5a3df986f9f8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff1516b62d12",
+    "reviewedArtifactChecksum": "9f0c41a2e497",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ad4348c8417": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8e5f70f83529",
+    "reviewedArtifactChecksum": "7d83844d0c9b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5ae006b13a36": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa7092ff2f81",
+    "reviewedArtifactChecksum": "1777e4174e77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b8156052b93": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "656116112375",
+    "reviewedArtifactChecksum": "64830a20dbc1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5b94a8f404fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a9e3e82048d",
+    "reviewedArtifactChecksum": "0e8666ded426",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5cd417e793b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "55c02dff6e1f",
+    "reviewedArtifactChecksum": "a3d174a91e36",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d0cbc370579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "698aba7e4fe0",
+    "reviewedArtifactChecksum": "a456e84f6bbb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5d72bed48e89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "da2f238915cf",
+    "reviewedArtifactChecksum": "e8a5438a6b9b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f1e9e754358": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b16fd5966e79",
+    "reviewedArtifactChecksum": "f80e4372205c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8b74d92e62": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23954b90525f",
+    "reviewedArtifactChecksum": "5c235d2627d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5f8cb3a5e8f9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb9d7c4d73ee",
+    "reviewedArtifactChecksum": "53223621ca62",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fa9b44388cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75268e0ea37",
+    "reviewedArtifactChecksum": "9b1c8afe3ea2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "5fd7dc1f9db5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70417a1c18f0",
+    "reviewedArtifactChecksum": "14c852e4775f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "603b2d01feb0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bab688e65c3f",
+    "reviewedArtifactChecksum": "9e052b1ab3b1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "60e1839cbb34": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23ded424e7e5",
+    "reviewedArtifactChecksum": "0633876c150c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "62cb2b168265": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9dc4ceaa4e05",
+    "reviewedArtifactChecksum": "2664988fb34d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6332ca621968": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c422eaca74c",
+    "reviewedArtifactChecksum": "c1f844df5571",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "63cbc1ad946c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ac5273cbba3f",
+    "reviewedArtifactChecksum": "8dbec4ed75bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6453aedf71ef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ddbf0f8ad79a",
+    "reviewedArtifactChecksum": "6e6dd1dba644",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "64f4db9e3e33": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "223cf2121461",
+    "reviewedArtifactChecksum": "48013c5a7418",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "65758201b8ae": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c1dcc0da6d2e",
+    "reviewedArtifactChecksum": "26970fad9a9f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6645006a0cb7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7398d83f39bc",
+    "reviewedArtifactChecksum": "c07390eb023d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "67981edb9ad4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fa37a7c8d562",
+    "reviewedArtifactChecksum": "054e68bbb4c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "68dcfc02a679": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5dbfcd37a1ff",
+    "reviewedArtifactChecksum": "c80025b03359",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6991493996fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a400913362f",
+    "reviewedArtifactChecksum": "e91d705436c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a29e6b4d64c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "78d137e5d4dd",
+    "reviewedArtifactChecksum": "9caba55c7953",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6a74b644797c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c7cb6d8ee7eb",
+    "reviewedArtifactChecksum": "e222c24413be",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6afbca6e9d22": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bb05dda45844",
+    "reviewedArtifactChecksum": "60a6a77fb721",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b04e55bf06b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "39d8f1348ec5",
+    "reviewedArtifactChecksum": "5888fded20c0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6b3078795300": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c8c18ab7607f",
+    "reviewedArtifactChecksum": "04966bf62e38",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6bc8dcf6317d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a173d202843",
+    "reviewedArtifactChecksum": "4f8741531247",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6be2f4df213a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e1545a600e26",
+    "reviewedArtifactChecksum": "d1dc27b42003",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6c6b1b1f2443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f4ab5c5ae30c",
+    "reviewedArtifactChecksum": "fcf62bef16b9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6d0042d2f554": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07611af3f621",
+    "reviewedArtifactChecksum": "3a95b961027b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6e92ce657980": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c78890f1578",
+    "reviewedArtifactChecksum": "40bd7eff379b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f4fb6e37e4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3c5d09e2d64d",
+    "reviewedArtifactChecksum": "61a024216934",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6f75cc57d5d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e4fa2d5bc1c8",
+    "reviewedArtifactChecksum": "d8eae9aa4635",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fcaf95e52b2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b98247d4d4a3",
+    "reviewedArtifactChecksum": "bf0778da00eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "6fec31e40f4a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc934cbc82b8",
+    "reviewedArtifactChecksum": "fa2d61701587",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7016f027bcf1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75e249be1662",
+    "reviewedArtifactChecksum": "b4ac2494b99e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70dea50257fa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88b95740afa6",
+    "reviewedArtifactChecksum": "416f5a0c9c90",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70e6b211c5ff": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bfd219d920b4",
+    "reviewedArtifactChecksum": "59478ef46c2c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "70f751a09a5f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f098a65a0973",
+    "reviewedArtifactChecksum": "4890db152511",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "71a0edbac544": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c89d650018d4",
+    "reviewedArtifactChecksum": "795dfd6f1e01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "723870e886d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a360f22d01b7",
+    "reviewedArtifactChecksum": "1d719138eedd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "72448fe4e4b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af26764f93e9",
+    "reviewedArtifactChecksum": "90a0fbc7b575",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "730d964da0cc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "02c64ba307fd",
+    "reviewedArtifactChecksum": "6bed811d961f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7330608df8b7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b94e21f1a154",
+    "reviewedArtifactChecksum": "96ad9953e225",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "736ab92b893a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ca13f304ebba",
+    "reviewedArtifactChecksum": "47ae68ad8fe1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "73a6511dc29e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "728cfd09e417",
+    "reviewedArtifactChecksum": "e3581917d47a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "74335786d7e5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e49c16d3b67f",
+    "reviewedArtifactChecksum": "7652015e6e84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7553d92529e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ebc0d57f36b",
+    "reviewedArtifactChecksum": "1d56bf048683",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "768526487e8d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f1c03a7a813",
+    "reviewedArtifactChecksum": "fe18ed546504",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "76d64ca52b45": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86ed3b9618b9",
+    "reviewedArtifactChecksum": "b1d21e03e922",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "770640dfddef": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7eead063132d",
+    "reviewedArtifactChecksum": "e49851aeb67f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "782abbc43435": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ba5fe613bb45",
+    "reviewedArtifactChecksum": "2c07f494435e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "787cfd599758": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "139b699b3cfd",
+    "reviewedArtifactChecksum": "81eac1dbf73e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7905fe6d550c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "045d0557ac1f",
+    "reviewedArtifactChecksum": "b1b095ecd784",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79227f845a2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "73e131214467",
+    "reviewedArtifactChecksum": "d7310324b4ad",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "795f78f5c9cb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dbfb87ee1826",
+    "reviewedArtifactChecksum": "30f7054344cf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "79bdba6f2250": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "394e2342732b",
+    "reviewedArtifactChecksum": "d171772bc44d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b25a77c44de": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "363aa23e2185",
+    "reviewedArtifactChecksum": "1b5844a1e382",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7b973ace62af": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12b89efce70",
+    "reviewedArtifactChecksum": "64ebc3aa91ef",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cc1d3bd2802": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85f2db89f8b5",
+    "reviewedArtifactChecksum": "718742920e83",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cecbe192fc2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "195d7bfcd500",
+    "reviewedArtifactChecksum": "43e41062f990",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7cfb99272578": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b8bfc12054d",
+    "reviewedArtifactChecksum": "99a5acd79651",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "7dca0438edf4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0a20647f365c",
+    "reviewedArtifactChecksum": "d2a2ce424d71",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "80434583707e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d11b48818567",
+    "reviewedArtifactChecksum": "f3a1ffaa962c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "814fd547d86e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3632a9c32f55",
+    "reviewedArtifactChecksum": "aabfc2ac8b28",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81643690b5e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f6f9f7303b9b",
+    "reviewedArtifactChecksum": "79a914665109",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "81ba03930d2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "283344d14dd5",
+    "reviewedArtifactChecksum": "c0f3d6ad61b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "825e6fb23c2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f9084ed9312",
+    "reviewedArtifactChecksum": "415f95053534",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "834ab8919949": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ddbe0761021",
+    "reviewedArtifactChecksum": "0908b5b45ca1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "857e50707831": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5f755e1e7983",
+    "reviewedArtifactChecksum": "ed449687a561",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "85e7df4b564e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1db71066ccc3",
+    "reviewedArtifactChecksum": "11957ef0c078",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "86efedaffa3e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "59b13cbf3a0e",
+    "reviewedArtifactChecksum": "5665f516dcc8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "874c251ff2f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2946e6cead20",
+    "reviewedArtifactChecksum": "1e716836d117",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "875410c650b8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0dbdc420f61a",
+    "reviewedArtifactChecksum": "4b13bc3278bc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88c94d64ca5d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "69768caee955",
+    "reviewedArtifactChecksum": "78c714042484",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "88f014a33e2a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40ed7b1f0be2",
+    "reviewedArtifactChecksum": "de2de5ff8047",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "894c44a995a2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8eec53904a2",
+    "reviewedArtifactChecksum": "65d7d5890d49",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "895960b69952": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b8210fd3edcc",
+    "reviewedArtifactChecksum": "09eaf6ca938a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a5ba143c20d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4dec1b12c9e4",
+    "reviewedArtifactChecksum": "fbf6270076cd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8a90e1694881": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e48775524ba6",
+    "reviewedArtifactChecksum": "3ed4668f7a5f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c553cc7c664": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "499792e4d375",
+    "reviewedArtifactChecksum": "09ebc8c59f00",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8c7511104c80": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "42926440e3b2",
+    "reviewedArtifactChecksum": "e437ce0c2c72",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d3a504fd30d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "460eb71d7eb8",
+    "reviewedArtifactChecksum": "fb53c4f4bc1e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8d83904b8f5a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db903ccb5fd1",
+    "reviewedArtifactChecksum": "2ddf1c732daf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8e090ccf5a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47f76e5028f9",
+    "reviewedArtifactChecksum": "8e2a60c692a9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f2cf0df5da6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6b76a8485fe3",
+    "reviewedArtifactChecksum": "ed42b783ef7f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f381a482443": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "553129b315bb",
+    "reviewedArtifactChecksum": "4ff90494184d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8f90aec3d12c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5b3ffacce720",
+    "reviewedArtifactChecksum": "f3e57a815faa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "8fe7ed30c4ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a9cc5890cb7",
+    "reviewedArtifactChecksum": "9aa1459574f4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "901ea40700aa": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "54054065f756",
+    "reviewedArtifactChecksum": "222c3cb5071e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "911c19a4391b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8d806844167e",
+    "reviewedArtifactChecksum": "c84ab71f579b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "915d8a703908": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c06862bda7b2",
+    "reviewedArtifactChecksum": "361fdc7878fa",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9173ef378024": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ae470a23be42",
+    "reviewedArtifactChecksum": "fd47beb506e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91a17d5206d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9f80b0c183e1",
+    "reviewedArtifactChecksum": "fd993b6ac757",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "91ec966e3abb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8ce1e2cc2d04",
+    "reviewedArtifactChecksum": "eceda5829e07",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "924b279f0df1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3ae1ca9ce6f6",
+    "reviewedArtifactChecksum": "16e753c9a5d7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "926bb8ebaa04": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86c681a0437b",
+    "reviewedArtifactChecksum": "8e41e957ccbd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "92f7c71aa0e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4782954ae33c",
+    "reviewedArtifactChecksum": "26e560909ab8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9394f9968da3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d3dcee651464",
+    "reviewedArtifactChecksum": "1692c9f83a97",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "93c182d3aefb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "718cf4ddfc55",
+    "reviewedArtifactChecksum": "a6c6c2a72b11",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "94ed41b87579": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "adb1da920293",
+    "reviewedArtifactChecksum": "bb1ea4ae2bae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "96f9694b12c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "713f28431219",
+    "reviewedArtifactChecksum": "aedf3ab5ba87",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "977bc7f55865": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16b8504f3ddc",
+    "reviewedArtifactChecksum": "5e0901ccead0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "97efe22684e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0c61b03a36ae",
+    "reviewedArtifactChecksum": "5b65571d3f27",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "983da4819066": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2af6f7114eaa",
+    "reviewedArtifactChecksum": "b25ff4059989",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9851c174a194": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dd55d897b05c",
+    "reviewedArtifactChecksum": "5b31f11f8bd7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9974666c3acb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "71d3d1fa5eeb",
+    "reviewedArtifactChecksum": "92f96411b4f2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99820d00487b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06c0318ab4a4",
+    "reviewedArtifactChecksum": "6e638ce9e134",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9990019f0e74": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d33e0f7312e",
+    "reviewedArtifactChecksum": "cb409ca93158",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99ac5a75449c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "38f8b9434ef7",
+    "reviewedArtifactChecksum": "53415f852ef5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "99aec65eea89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "08ee59c22c25",
+    "reviewedArtifactChecksum": "4dd002b55eb1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9b9727a77a9e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2961032eaa3f",
+    "reviewedArtifactChecksum": "e28e8df09ccb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9bd4bdaa49c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30babe6f9323",
+    "reviewedArtifactChecksum": "97bb96b55175",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9be3d7110c75": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fe371800183f",
+    "reviewedArtifactChecksum": "7fa42a5e6a9c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9c3c4722a8e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41223c0e77dd",
+    "reviewedArtifactChecksum": "3f17e1aa76bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9cc2917611e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "149fc642408f",
+    "reviewedArtifactChecksum": "fbcbe0b0e98b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9d588c37e728": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "17c62639dd02",
+    "reviewedArtifactChecksum": "26132dda8b4c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9e033fb4e06a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "545110668833",
+    "reviewedArtifactChecksum": "6c63c99fb6df",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ed4f6b88b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c3118fbc5ef5",
+    "reviewedArtifactChecksum": "e2f81f1b9c3f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f0b568bf8a1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6543c01f2b84",
+    "reviewedArtifactChecksum": "7d8e2e40953f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9f9f595534d8": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "47ebf99edfc0",
+    "reviewedArtifactChecksum": "647272d5c3d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9fbb34bb59b3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "93bb6ab80b96",
+    "reviewedArtifactChecksum": "8bdc8e44a289",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "9ff401a65647": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e79ba58c7c7",
+    "reviewedArtifactChecksum": "a489bbed7048",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a013e57e6d51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3676bc6af0c3",
+    "reviewedArtifactChecksum": "6cb624e6e8a8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0d7f0c8aa8c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c1bd581b72f",
+    "reviewedArtifactChecksum": "876be48f565a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a0e9a3b16f63": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff7aa490b915",
+    "reviewedArtifactChecksum": "4e81daeab8b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a20d3822a38f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c895eac7ac37",
+    "reviewedArtifactChecksum": "6eaa58f6f4a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a2460ab23a60": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a9efc6b58a5",
+    "reviewedArtifactChecksum": "04f2ff10163f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a262dd6de9ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "df8dbbc9df1a",
+    "reviewedArtifactChecksum": "139c06c8ef88",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a335e0968d76": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a271486f288",
+    "reviewedArtifactChecksum": "a8d4559e8a99",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a39b591d8c3b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a234de78d008",
+    "reviewedArtifactChecksum": "af5dd97dd363",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a3e50e79cb89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fbf819fbfc3",
+    "reviewedArtifactChecksum": "90bbddd215ec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a47d77950ec1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "12ad30f0e3bc",
+    "reviewedArtifactChecksum": "34ccacdadeda",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a4e8aec9d618": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee46950d0a83",
+    "reviewedArtifactChecksum": "520961bbe444",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a50ab9e1df59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e09f98cd488d",
+    "reviewedArtifactChecksum": "24930e4d4906",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a517ab82b0f1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1b60bccbbc22",
+    "reviewedArtifactChecksum": "eb9328bbc8bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a58c512532df": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7877fa83ca3f",
+    "reviewedArtifactChecksum": "31dc9dfe3e53",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6b2c3fe248c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5cb2edaa0459",
+    "reviewedArtifactChecksum": "9fa663ffe210",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a6f4d96872e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cd7d50f6ecec",
+    "reviewedArtifactChecksum": "0e6a892bf9c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a781503cf508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a35650f2203b",
+    "reviewedArtifactChecksum": "aeae2618a9fd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8749454536e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d6aefa1001c4",
+    "reviewedArtifactChecksum": "01f9dc698b0b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8d874e28508": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b4f93aa16099",
+    "reviewedArtifactChecksum": "8d2af3a33f8c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8ef15a4ae2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab69a90f2c59",
+    "reviewedArtifactChecksum": "fb6863ba5d7b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a8f813117159": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7c6a845cb416",
+    "reviewedArtifactChecksum": "f6ec557ce609",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9241caf70ac": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "25699da31ab8",
+    "reviewedArtifactChecksum": "84f064c24dfd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9294d9380a6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c869ce3c6d40",
+    "reviewedArtifactChecksum": "fb0613a9c630",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "a9f66528e0d7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "049e2f638a18",
+    "reviewedArtifactChecksum": "bdb9d1846e5a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aa1e24da3f2b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62551fbaf61a",
+    "reviewedArtifactChecksum": "fb74d991f41d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ab2f354cd396": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "050f86983074",
+    "reviewedArtifactChecksum": "1670e293041d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ac37ba4d362c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2a65013eef15",
+    "reviewedArtifactChecksum": "4cb7ddd7fc3e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "adca306765ce": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfb42e4f4288",
+    "reviewedArtifactChecksum": "62e5d1e91fe9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ae12a241076c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f85d2504c5a7",
+    "reviewedArtifactChecksum": "5d7c22ae00bb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb71e383642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ed1bb3218ec5",
+    "reviewedArtifactChecksum": "fbf3d57de059",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeb81743ddf7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "49653ec030f0",
+    "reviewedArtifactChecksum": "3129d991b703",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "aeda3ae212cd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fbc268b970e5",
+    "reviewedArtifactChecksum": "40bc9fdf0522",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afa2656c1d4e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9062cb86b8e5",
+    "reviewedArtifactChecksum": "0e1a682572ae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "afd30ccf8238": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8baf7e5024e1",
+    "reviewedArtifactChecksum": "48838bc339ea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b1ab45b906ca": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2ed93efd388d",
+    "reviewedArtifactChecksum": "55afca738d30",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b27220a578ee": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "75648b4162b0",
+    "reviewedArtifactChecksum": "4873acbc4808",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3045580a973": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0d53bc9df905",
+    "reviewedArtifactChecksum": "f6b8dc7f99fc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3437893d89d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "293799ae651f",
+    "reviewedArtifactChecksum": "fed5aa9639d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b34841f6789c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7cfeef51b129",
+    "reviewedArtifactChecksum": "de70a385c544",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b37902cee452": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e60d5dfd84a3",
+    "reviewedArtifactChecksum": "9e89c83f16e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3a950cbe689": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b56716873415",
+    "reviewedArtifactChecksum": "e274812daa06",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b3bbbf217b89": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ef975648cc07",
+    "reviewedArtifactChecksum": "d42b2a0b6458",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4577f326660": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "522c997208d2",
+    "reviewedArtifactChecksum": "82309c9d9826",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b4d8756a63c1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9fd0d5068b88",
+    "reviewedArtifactChecksum": "42d2fbac51b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b58cf4e5cec5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "92069e71e1bd",
+    "reviewedArtifactChecksum": "7d0b4bd666f5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b594a01df1d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "94660f232c6a",
+    "reviewedArtifactChecksum": "c5ff5f10553c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6b663b0ed87": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3c78c06f587",
+    "reviewedArtifactChecksum": "8b456027614a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6c2a0bf375b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7308aca23917",
+    "reviewedArtifactChecksum": "2a152f4ce890",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b6e55869de51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1685081acc73",
+    "reviewedArtifactChecksum": "f05a198ba6c6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b74ad340c930": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20a31cc8438a",
+    "reviewedArtifactChecksum": "a453e2464b5c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b89d812e25e0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "235c80ef9a42",
+    "reviewedArtifactChecksum": "ce31a24570a1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b8c030205d86": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0696a0f29e02",
+    "reviewedArtifactChecksum": "1766cf067bae",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b92d5bd634b5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4631f245a478",
+    "reviewedArtifactChecksum": "feef7c1470cb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b95499a55c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "16809786d5b3",
+    "reviewedArtifactChecksum": "bd4a6cba7218",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "b993c1885a29": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd71930c8982",
+    "reviewedArtifactChecksum": "a31ba495bdb8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "badeb885763a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "43992d23d639",
+    "reviewedArtifactChecksum": "ea40b60a3a48",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bb33cc433026": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4f7bfd776756",
+    "reviewedArtifactChecksum": "08624066fd77",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be0889296f65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0312e60afd47",
+    "reviewedArtifactChecksum": "1b02d0bde201",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "be81dd6a1a51": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad4d848e788a",
+    "reviewedArtifactChecksum": "ce1b7f800b1d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bea767ed39db": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "04d7965e1622",
+    "reviewedArtifactChecksum": "418986b8b30d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bed989744195": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a326351226e",
+    "reviewedArtifactChecksum": "41522e4f56d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "bf82f1e42e83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f00e12f215be",
+    "reviewedArtifactChecksum": "8c43c897946e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c01a333cfbd3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9026217dfd87",
+    "reviewedArtifactChecksum": "77399674fbc4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c046d6c94bd1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a1728d9078a",
+    "reviewedArtifactChecksum": "add7891084cc",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c0a2671af7c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "430516a36c36",
+    "reviewedArtifactChecksum": "19998efca5c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c12e2c5512d1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf29ea138661",
+    "reviewedArtifactChecksum": "4d8311361a72",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1956ef24421": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a70fceb5d9f7",
+    "reviewedArtifactChecksum": "b43e2a92c339",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1959fdc5642": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "314621ba0722",
+    "reviewedArtifactChecksum": "827534dcf748",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c1ad7b8e8d99": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "80f45e9e045d",
+    "reviewedArtifactChecksum": "3521b116292a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2193a84a956": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf4774ad3f7",
+    "reviewedArtifactChecksum": "29776300ffea",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2586087f709": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "98f7ed751a9c",
+    "reviewedArtifactChecksum": "0e4370ca6d3e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c2c4b45b7df5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "26c158b69159",
+    "reviewedArtifactChecksum": "3816e930eac4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c384585f8b2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3d1d59fd0fde",
+    "reviewedArtifactChecksum": "6cbe84b19b56",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c3e308dab99b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "30da4cf15ce6",
+    "reviewedArtifactChecksum": "18c890374fe3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c5cbee07611f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "09165f88325d",
+    "reviewedArtifactChecksum": "5b2e728e75b0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c6a221e04f71": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8c2516339378",
+    "reviewedArtifactChecksum": "a2562b11fae6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c70904777c65": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c75a81b5441b",
+    "reviewedArtifactChecksum": "9c4f8ff3192b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c7c1eb5d5df4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31bda4229a4e",
+    "reviewedArtifactChecksum": "4ef03a4015d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c826cbc01388": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "85ec987a37d7",
+    "reviewedArtifactChecksum": "d85b13bc78f9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c8dc25fbb2d2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c4e5e5a25c6",
+    "reviewedArtifactChecksum": "0780636f5bdd",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "c98e5c457e1e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f8bc16ce3029",
+    "reviewedArtifactChecksum": "60af58481541",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cad75dc8d68f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cfa052de6c01",
+    "reviewedArtifactChecksum": "dd756de8378c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cba1264de4b6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ad045f8092ec",
+    "reviewedArtifactChecksum": "dcc91f2efd60",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc053bb55df6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b9c62043d7a5",
+    "reviewedArtifactChecksum": "4dabff9e0712",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cc2f8a4091d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4fdf293bf1e9",
+    "reviewedArtifactChecksum": "8f8b44da6ca5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccc43113008f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b7f8090ddb00",
+    "reviewedArtifactChecksum": "ac592274105c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ccf567b604be": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "50b0e045bd63",
+    "reviewedArtifactChecksum": "42240e92986f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd0c4f9f61a4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd6c8b140d90",
+    "reviewedArtifactChecksum": "c471acc5bbe2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd398cebf8f2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cf4096351e19",
+    "reviewedArtifactChecksum": "025c20d141b5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cd929d504424": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "634c13ce6e6a",
+    "reviewedArtifactChecksum": "5d6e850b9797",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf405c0f714c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "900bc97a541b",
+    "reviewedArtifactChecksum": "c866ff6869d2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cf84f066d9dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "70ee4d8888e0",
+    "reviewedArtifactChecksum": "c403e00ed4b1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "cfa230785872": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "58642ef8a758",
+    "reviewedArtifactChecksum": "bd3078cb9e64",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d124e24eca67": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5c2a79ee0629",
+    "reviewedArtifactChecksum": "de041b498352",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d16e25ecd710": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "dc876042cb88",
+    "reviewedArtifactChecksum": "f523182b8bf4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d1d8dc2fcce7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00a05c63f72e",
+    "reviewedArtifactChecksum": "22ebb26ee4ee",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d23f62e48d10": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2b5949b00ab5",
+    "reviewedArtifactChecksum": "5270090d2474",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d25788ed5d19": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "23150d16c2d2",
+    "reviewedArtifactChecksum": "9bef592a92ac",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d2cee11e428d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4c3e6cd0bd1e",
+    "reviewedArtifactChecksum": "d2b8508807eb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d32f7ff48696": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "506656a81fc4",
+    "reviewedArtifactChecksum": "d86a8dfa81c2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d3b539e33bf2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e0668ca06ccb",
+    "reviewedArtifactChecksum": "d1589206f4d4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d5ce59e59ff3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "742dcafde397",
+    "reviewedArtifactChecksum": "18bc213f2371",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6109704c9d6": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "3209946e809f",
+    "reviewedArtifactChecksum": "03139b61df0f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d636956bdddc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "db81b9333710",
+    "reviewedArtifactChecksum": "2bbb7f491d55",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d686f64879fb": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "010c07d0a1cb",
+    "reviewedArtifactChecksum": "ecb71b0a194f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6bda294b8ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "347186231e5f",
+    "reviewedArtifactChecksum": "134326ea330f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d6e252fb4880": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e7736aab916",
+    "reviewedArtifactChecksum": "f42c051899bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d70243b6fc64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ee4874b7586b",
+    "reviewedArtifactChecksum": "8ed72f4ec056",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d7677ac50371": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d48f81c491f2",
+    "reviewedArtifactChecksum": "a0cc5c002dfe",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d768fd20d606": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b049dc6f4702",
+    "reviewedArtifactChecksum": "a4bba22cd48d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d78377cf53f4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "62ce15566253",
+    "reviewedArtifactChecksum": "86b586682eda",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d82f4527c76a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6517985e895c",
+    "reviewedArtifactChecksum": "2bb55ec09e60",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d833dc5abe59": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6ff8e0fc1088",
+    "reviewedArtifactChecksum": "d76d508f2642",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d8915378c317": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b65553a429a9",
+    "reviewedArtifactChecksum": "dedf2eef9682",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d99717df8788": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "746e2830ce5d",
+    "reviewedArtifactChecksum": "868f8bfaf725",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "d9d6f1309cbc": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "387195514518",
+    "reviewedArtifactChecksum": "952e64816c37",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "daa5bce3fc54": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f9c11d524265",
+    "reviewedArtifactChecksum": "af6484e927c8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db1dd2f8ea39": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "309d782f16a4",
+    "reviewedArtifactChecksum": "948f9fcf0406",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "db4717458b6a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "72065b8ba445",
+    "reviewedArtifactChecksum": "60e1437ea7a5",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc1311a65bc4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ff31f1dc14bb",
+    "reviewedArtifactChecksum": "3d707124a29b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc41de374da5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6cb6ff1e62cd",
+    "reviewedArtifactChecksum": "661d39341255",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc6e967c7e73": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "cb7f1ad34a2d",
+    "reviewedArtifactChecksum": "0ce237ddefa8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dc7727f63c0c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "eb408a2280dd",
+    "reviewedArtifactChecksum": "ac88b5642ff1",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dce6a906dc66": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0798dae90d6c",
+    "reviewedArtifactChecksum": "99984d20579c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dcf21d867c91": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7b380339f8c1",
+    "reviewedArtifactChecksum": "921686df3b01",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "def270551fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d84ed09c8c03",
+    "reviewedArtifactChecksum": "1eba36b5a2d8",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "dff780783fbe": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f96fa9e38fea",
+    "reviewedArtifactChecksum": "d269a8bad7d3",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e06088bda436": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6e8a2779d84f",
+    "reviewedArtifactChecksum": "e6b0e86f263d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e0df9e9c7683": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "07c0da77ff02",
+    "reviewedArtifactChecksum": "05ae6a53a885",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e173ace9bf90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "82be5605d1fb",
+    "reviewedArtifactChecksum": "2a589a3578ca",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e1e03cafda18": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "11cc7048ff73",
+    "reviewedArtifactChecksum": "89200784ef9e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2716c39cb46": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "88d2297a2338",
+    "reviewedArtifactChecksum": "4a6eccb14596",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e2df0992de37": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f18a7f8283b5",
+    "reviewedArtifactChecksum": "642353c31612",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e3d0e7348f08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c9ce5bc34042",
+    "reviewedArtifactChecksum": "91dc39506d6f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e41b80eb587d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5a5397c22aa6",
+    "reviewedArtifactChecksum": "6b4b971e820c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4a4339afda4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "029d79d10787",
+    "reviewedArtifactChecksum": "7a2be4e69eec",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4ab88456b9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a28a6937d8b",
+    "reviewedArtifactChecksum": "27dddf0177e4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e4d64e14c5e1": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a8b9fb83ba3b",
+    "reviewedArtifactChecksum": "0a1ee0554574",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5c914d15241": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "c070ba38d569",
+    "reviewedArtifactChecksum": "d5137151f024",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5ecf2fd5b30": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "40779bbe4bc0",
+    "reviewedArtifactChecksum": "6877a0d764e0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e5f83394283d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "f38253034834",
+    "reviewedArtifactChecksum": "a9734409e852",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e68b44d99f8e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "e12f96995bc8",
+    "reviewedArtifactChecksum": "2682cdcec010",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6aa60b3fa90": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "157edbd2a5dd",
+    "reviewedArtifactChecksum": "513d567d5e9b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6af724bfa83": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2fb8a987ef8d",
+    "reviewedArtifactChecksum": "13eca8b16001",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e6fd8da0c247": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "aefaba1e21a5",
+    "reviewedArtifactChecksum": "0cef57f1eb24",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e78f02853c98": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a7a2357bf6d3",
+    "reviewedArtifactChecksum": "2bce426291bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8099b642c9f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "ab48a85786be",
+    "reviewedArtifactChecksum": "378fb6b7701c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8182e8f88c4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "557c68bffbc9",
+    "reviewedArtifactChecksum": "de811b3c79c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e8694205d953": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "7a2425cf3c13",
+    "reviewedArtifactChecksum": "201d7e6b16c7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "e9ad87cb6c32": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "af61de38993b",
+    "reviewedArtifactChecksum": "ff43a1dece3d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea4911d91143": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a921f371596f",
+    "reviewedArtifactChecksum": "36b4d44b7939",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ea6154c3447d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "5311acd1d00c",
+    "reviewedArtifactChecksum": "59c1ea6d09f7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eb986f4b9142": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "097a4ede817f",
+    "reviewedArtifactChecksum": "d2ffd6b37e84",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ebd212d934a7": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1cf6d81054e9",
+    "reviewedArtifactChecksum": "2ede26303dda",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ec337321a25d": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "27699101b6f9",
+    "reviewedArtifactChecksum": "70c27a65608e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ecc7d7bdfe02": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "daf95155482d",
+    "reviewedArtifactChecksum": "136b7252df2e",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "eda6aeddc2ec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "32866058e259",
+    "reviewedArtifactChecksum": "d8e8d47d450d",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef10fc1fe4d3": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2f61d2cc731a",
+    "reviewedArtifactChecksum": "f5ce490a90a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef36ec96537f": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "06d80b4adbf7",
+    "reviewedArtifactChecksum": "019799228ff0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef5d632ed2c5": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6231efceff36",
+    "reviewedArtifactChecksum": "652f1ac02553",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ef8586090398": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6946dc19f9a5",
+    "reviewedArtifactChecksum": "78d7d2138b92",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f0257c86b3a0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "99d0f488ff0d",
+    "reviewedArtifactChecksum": "35792c502330",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f052abfce10e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "00c34dc90369",
+    "reviewedArtifactChecksum": "66938a6fe85f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f1dc525f26dd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0240a925b535",
+    "reviewedArtifactChecksum": "d06392bab17b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3096e2ffb64": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "20e28569e2d2",
+    "reviewedArtifactChecksum": "a8433ad35ed4",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f3aa8cbf5c11": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "187f12e04886",
+    "reviewedArtifactChecksum": "ac833db127d6",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f49b24114ea9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "0e89780c7120",
+    "reviewedArtifactChecksum": "f0e248de320f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4a0425aa8e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c96255dfda7",
+    "reviewedArtifactChecksum": "ac259c544648",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e29143100c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d18726770189",
+    "reviewedArtifactChecksum": "d24e42627943",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f4e6a39713e4": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8f8fa01a67e4",
+    "reviewedArtifactChecksum": "0d9320212c67",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f5feb0b58f78": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "d2d591cef04b",
+    "reviewedArtifactChecksum": "adb38408bc61",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6bf65f974c0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4781d24b3fd4",
+    "reviewedArtifactChecksum": "afbc58232e22",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f6e9d07c02fd": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "4e70b519a78c",
+    "reviewedArtifactChecksum": "405f2920de05",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f7078f72ad4b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "6c9b5aa82194",
+    "reviewedArtifactChecksum": "c215035cd59a",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f83ee3caa04e": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "a47e936b4941",
+    "reviewedArtifactChecksum": "a880521080bf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8663cd08a9b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "fd312cf9e7b7",
+    "reviewedArtifactChecksum": "0c59ba861fcb",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f889bba5102a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "8a01c27dcc37",
+    "reviewedArtifactChecksum": "3c14cca9a280",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f8cf4feac2e9": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "31ae8f48bec6",
+    "reviewedArtifactChecksum": "60e8d1e5d3d0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f920eaa9a538": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "86fd28033b57",
+    "reviewedArtifactChecksum": "7c6a681f2b1f",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93775fd8ce0": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "41bb23f3a44e",
+    "reviewedArtifactChecksum": "b58a5a7fe3a2",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f93bdf9fa69a": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "10fa3f4f0141",
+    "reviewedArtifactChecksum": "099f58dd33d9",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "f9cffe716495": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "beaa27cce795",
+    "reviewedArtifactChecksum": "0b9002bbaae0",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fa6c519ddbec": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "515fd38a7218",
+    "reviewedArtifactChecksum": "4376d465936b",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fb60d80de54b": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "1c1df4c99a1b",
+    "reviewedArtifactChecksum": "9349aab83dbf",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd3af468b1e2": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2bdff62d6d22",
+    "reviewedArtifactChecksum": "c58de2b1b827",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fd76422c14ea": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "9bf6066bdfc2",
+    "reviewedArtifactChecksum": "60c92dea3187",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fdab9848b160": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "bc70dfe515b2",
+    "reviewedArtifactChecksum": "5198c00728b7",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe5600667e2c": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b1a01e522599",
+    "reviewedArtifactChecksum": "733fea9dd501",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fe773d7d7377": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "2cf2d4dde55c",
+    "reviewedArtifactChecksum": "cf0f0138fc59",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fedbcfb05b08": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "b3e4d009fdbb",
+    "reviewedArtifactChecksum": "dc04f239fd7c",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "ff88e6723334": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "83f9d2bbb2fd",
+    "reviewedArtifactChecksum": "f8b0b092ab19",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  },
+  "fffa07892f17": {
+    "reviewer": "ai-review",
+    "reviewedAt": "2026-08-25",
+    "reviewedContentHash": "624c4e8d7418",
+    "reviewedArtifactChecksum": "abc7dc2e7022",
+    "automated": true,
+    "approvedScope": "auto-sealed 2026-08-25: first wave granted by policy, AI-review clean, no human pass"
+  }
+}

--- a/site/src/lib/i18n/locales.ts
+++ b/site/src/lib/i18n/locales.ts
@@ -46,7 +46,18 @@ export const SUPPORTED_HUB_LOCALES: readonly Locale[] = LOCALES;
  * its native-review wave, at which point it is added here in a one-line PR.
  * Per-page freshness/completeness/review gating applies on top (see predicate).
  */
-export const INDEXABLE_LOCALES: readonly Locale[] = ['zh'];
+export const INDEXABLE_LOCALES: readonly Locale[] = [
+  'zh',
+  'zh-TW',
+  'ja',
+  'ko',
+  'es',
+  'fr',
+  'ru',
+  'tr',
+  'ar',
+  'pt-BR',
+];
 
 /**
  * Fail-closed guard for a flipped locale, asserted once per build after the


### PR DESCRIPTION
Nav dropped the native-review gate on 2026-08-24 ("we are skipping the native review gate for the ai reviewer pass based on the initial data to iterate and go faster"). The code never followed: `INDEXABLE_LOCALES` was still `['zh']`, and every other locale had **zero** sign-off records, so nine fully translated and AI-reviewed languages were invisible to search.

This turns them on.

## What changes

**Seals the first wave per locale**, using the policy flag #1170 added. Records are honestly attributed: `reviewer: 'ai-review'`, `automated: true`, scope says plainly that no human read them.

**Wires that flag into the nightly**, so pages translated later keep joining instead of needing this done by hand every time.

**Flips the nine locales** in `INDEXABLE_LOCALES`.

## What does NOT change

The other half of the gate. A page is still held back when its required fields are not genuinely translated, or when it carries an unresolved critical or major finding. Those pages stay canonical-to-English and out of the sitemap, exactly as today. This lowers the bar from "a native speaker read it" to "the AI reviewer found nothing serious", which is the decision that was taken; it does not publish text we know is broken.

## Pages entering the index

| locale | sealed | held |
| --- | --- | --- |
| pt-BR | 620 | 0 |
| ja | 605 | 15 |
| fr | 589 | 31 |
| tr | 550 | 70 |
| ko | 493 | 127 |
| zh-TW | 486 | 134 |
| ar | 402 | 218 |
| es | 324 | 296 |
| ru | 208 | 412 |

**4,277 pages**, against 506 live today.

The two lowest are the honest ones. Russian seals 208 because 412 pages still carry unresolved findings from its first full review pass, and Spanish 324 for the same reason. Those join automatically as the nightly retranslates and the findings clear, which is the mechanism that took Chinese from 25% pruned to 4%.

## Verified

675 unit tests, `astro check` 0 errors, lint clean. Sign-off records regenerated from the committed content, not hand-written.

## Worth knowing before merging

The hub's own interface is still partly English in every locale (search box, footer, category labels). #1176 fixes the first two. Turning nine languages on multiplies that visible gap by nine, so #1176 is worth landing close behind this.
