### PR TITLE
fix(seo): drop the dead Framer sitemap reference and refresh the smoke test

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -120,10 +120,10 @@ export default defineConfig({
   redirects: modelSlugRedirects,
   integrations: [
     sitemap({
-      // Use custom filename to avoid collision with Framer's /sitemap.xml
+      // Keep the workflows sitemap family distinct from the marketing site's
+      // /sitemap-index.xml + /sitemap-0.xml (robots.txt points crawlers there;
+      // the routing layer merges both into the root index).
       filenameBase: 'sitemap-workflows',
-      // Include Framer's marketing sitemap in the index
-      customSitemaps: ['https://comfy.org/sitemap.xml'],
       // Include on-demand locale pages that aren't discovered at build time
       customPages: customPages,
       serialize(item) {


### PR DESCRIPTION
## Why

`https://comfy.org/sitemap.xml` has returned 404 since apps/website took over the comfy.org root (Framer is gone; the Astro marketing site emits `/sitemap-index.xml` + `/sitemap-0.xml`, and robots.txt points crawlers there). Two consequences in this repo:

1. `customSitemaps: ['https://comfy.org/sitemap.xml']` makes our `/sitemap-workflows-index.xml` advertise that 404 as its first child — verified live. Google reads a dead child sitemap from us, and `validate-sitemap.ts` HEAD-checks every `<loc>`, which is why the SEO Audit job's sitemap step fails.
2. The weekly **SEO Smoke Test** has failed every run since ~08-17 for three stale expectations: `/templates/` returning 200 (it 301s to `/workflows/` now), the pre-rename `sitemap-templates-index.xml` filename, and the homepage being served by Framer (it's `x-served-by: vercel-website` now).

## What

- Delete the `customSitemaps` entry (this PR). Marketing pages are already covered by the root `/sitemap-index.xml` chain, so nothing is lost.
- The smoke-test refresh could not be pushed from this environment (token lacks the `workflow` scope for `.github/workflows/*`). The verified patch is below — every new expectation curl-checked live today; a maintainer can apply it here or in a follow-up:

```diff
diff --git a/.github/workflows/seo-smoke-test.yml b/.github/workflows/seo-smoke-test.yml
index 11ab3bc..9f7ed38 100644
--- a/.github/workflows/seo-smoke-test.yml
+++ b/.github/workflows/seo-smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check canonical URLs point to comfy.org
         run: |
           echo "Checking canonical URLs..."
-          BODY=$(curl -s --max-time 15 "https://comfy.org/templates/flux_schnell")
+          BODY=$(curl -s --max-time 15 "https://comfy.org/workflows/model/flux/")
           if echo "$BODY" | grep -q 'rel="canonical" href="https://comfy.org/'; then
             echo "✅ Canonical URL points to comfy.org"
           else
@@ -23,19 +23,19 @@ jobs:
             exit 1
           fi
 
-      - name: Check comfy.org templates return 200
+      - name: Check comfy.org workflows hub returns 200
         run: |
-          STATUS=$(curl -sI -o /dev/null -w "%{http_code}" --max-time 15 "https://comfy.org/templates/")
+          STATUS=$(curl -sI -o /dev/null -w "%{http_code}" --max-time 15 "https://comfy.org/workflows/")
           if [ "$STATUS" = "200" ]; then
-            echo "✅ /templates/ returns 200"
+            echo "✅ /workflows/ returns 200"
           else
-            echo "❌ /templates/ returns $STATUS"
+            echo "❌ /workflows/ returns $STATUS"
             exit 1
           fi
 
       - name: Check sitemap is accessible
         run: |
-          STATUS=$(curl -sI -o /dev/null -w "%{http_code}" --max-time 15 "https://comfy.org/sitemap-templates-index.xml")
+          STATUS=$(curl -sI -o /dev/null -w "%{http_code}" --max-time 15 "https://comfy.org/sitemap-workflows-index.xml")
           if [ "$STATUS" = "200" ]; then
             echo "✅ Sitemap accessible"
           else
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check Vercel URL has correct canonical (not self-referencing)
         run: |
-          BODY=$(curl -s --max-time 15 "https://workflow-templates.vercel.app/templates/flux_schnell")
+          BODY=$(curl -s --max-time 15 "https://workflow-templates.vercel.app/workflows/model/flux/")
           if echo "$BODY" | grep -q 'rel="canonical" href="https://comfy.org/'; then
             echo "✅ Vercel deployment canonical points to comfy.org (not self)"
           else
@@ -55,18 +55,18 @@ jobs:
 
       - name: Check X-Served-By headers
         run: |
-          HEADER=$(curl -sI --max-time 15 "https://comfy.org/templates/" | grep -i "x-served-by")
+          HEADER=$(curl -sI --max-time 15 "https://comfy.org/workflows/" | grep -i "x-served-by")
           if echo "$HEADER" | grep -qi "vercel"; then
-            echo "✅ Templates served by Vercel: $HEADER"
+            echo "✅ Workflows served by Vercel: $HEADER"
           else
-            echo "❌ Templates NOT served by Vercel: $HEADER"
+            echo "❌ Workflows NOT served by Vercel: $HEADER"
             exit 1
           fi
 
           HEADER=$(curl -sI --max-time 15 "https://comfy.org/" | grep -i "x-served-by")
-          if echo "$HEADER" | grep -qi "framer"; then
-            echo "✅ Homepage served by Framer: $HEADER"
+          if echo "$HEADER" | grep -qi "vercel"; then
+            echo "✅ Homepage served by Vercel: $HEADER"
           else
-            echo "❌ Homepage NOT served by Framer: $HEADER"
+            echo "❌ Homepage NOT served by Vercel: $HEADER"
             exit 1
           fi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)