### PR TITLE
feat(site): declare the page language in Open Graph tags

### DIFF
--- a/site/src/components/HreflangTags.astro
+++ b/site/src/components/HreflangTags.astro
@@ -5,8 +5,8 @@
  * Tells search engines about language/region variations of the same content.
  * Should be included in <head> for all pages that have localized versions.
  */
-import { LANGUAGES, type Locale } from '../i18n/config';
-import { localizeUrl } from '../i18n/utils';
+import { type Locale } from '../i18n/config';
+import { clusterLocales, localizeUrl } from '../i18n/utils';
 import { absoluteUrl } from '../config/site';
 
 interface Props {
@@ -30,9 +30,8 @@ interface Props {
 
 const { basePath, localized = true, locales } = Astro.props;
 
-// Per-page list wins; otherwise fall back to "all locales / none" by the boolean.
-const alternateLocales: readonly Locale[] =
-  locales ?? (localized ? (Object.keys(LANGUAGES) as Locale[]) : []);
+// Shared with SEOHead's og:locale tags so the two declarations cannot diverge.
+const alternateLocales: readonly Locale[] = clusterLocales(localized, locales);
 
 // hreflang values must be lowercase (e.g. 'zh-tw' not 'zh-TW').
 const hreflangEntries = alternateLocales.map((locale) => ({

--- a/site/src/components/SEOHead.astro
+++ b/site/src/components/SEOHead.astro
@@ -1,6 +1,7 @@
 ---
 import HreflangTags from './HreflangTags.astro';
-import { LANGUAGES, DEFAULT_LOCALE, type Locale } from '../i18n/config';
+import { OG_LOCALES, type Locale } from '../i18n/config';
+import { clusterLocales, getLocaleFromPath, unlocalizePath } from '../i18n/utils';
 import { absoluteUrl, SITE_NAME } from '../config/site';
 import { serializeJsonLdForScript } from '../lib/structured-data';
 
@@ -55,23 +56,16 @@ const OG_IMAGE_MIME: Record<string, string> = {
 const ogImageExt = ogImage.split('?')[0].split('.').pop()?.toLowerCase() ?? '';
 const ogImageType = OG_IMAGE_MIME[ogImageExt] ?? 'image/png';
 
-// Compute hreflang base path if not provided
-// Strip locale prefix from pathname to get the base path
-let computedHreflangBasePath = hreflangBasePath;
-if (!computedHreflangBasePath) {
-  // Check if pathname starts with a locale prefix
-  const pathSegments = pathname.split('/').filter(Boolean);
-  if (pathSegments[0] && pathSegments[0] in LANGUAGES && pathSegments[0] !== DEFAULT_LOCALE) {
-    // Remove locale prefix
-    computedHreflangBasePath = '/' + pathSegments.slice(1).join('/');
-  } else {
-    computedHreflangBasePath = pathname;
-  }
-  // Ensure trailing slash
-  if (!computedHreflangBasePath.endsWith('/')) {
-    computedHreflangBasePath += '/';
-  }
-}
+const computedHreflangBasePath = hreflangBasePath ?? unlocalizePath(pathname);
+
+// Social platforms read og:locale to decide which audience a shared link suits;
+// without it every localized page presents itself as language-neutral. Built from
+// the same cluster the hreflang tags use so the two cannot contradict each other.
+const currentLocale = getLocaleFromPath(pathname);
+const ogAlternateLocales: readonly Locale[] = clusterLocales(
+  hreflangLocalized,
+  hreflangLocales
+).filter((locale) => locale !== currentLocale);
 ---
 
 <meta charset="UTF-8" />
@@ -99,6 +93,12 @@ if (!computedHreflangBasePath) {
 <meta property="og:image:height" content="630" />
 <meta property="og:image:alt" content={title} />
 <meta property="og:site_name" content={SITE_NAME} />
+<meta property="og:locale" content={OG_LOCALES[currentLocale]} />
+{
+  ogAlternateLocales.map((locale) => (
+    <meta property="og:locale:alternate" content={OG_LOCALES[locale]} />
+  ))
+}
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />

--- a/site/src/i18n/config.ts
+++ b/site/src/i18n/config.ts
@@ -32,3 +32,23 @@ export const LOCALE_INDEX_FILES: Record<string, string> = {
 };
 
 export type Locale = keyof typeof LANGUAGES;
+
+/**
+ * Open Graph wants language_TERRITORY, which is not the tag we route on: we say
+ * `ko`, OG wants `ko_KR`. Typed as a full Record so adding a locale without an
+ * entry here is a compile error rather than a page that silently claims no
+ * language.
+ */
+export const OG_LOCALES: Record<Locale, string> = {
+  en: 'en_US',
+  zh: 'zh_CN',
+  'zh-TW': 'zh_TW',
+  ja: 'ja_JP',
+  ko: 'ko_KR',
+  es: 'es_ES',
+  fr: 'fr_FR',
+  ru: 'ru_RU',
+  tr: 'tr_TR',
+  ar: 'ar_AR',
+  'pt-BR': 'pt_BR',
+};

--- a/site/src/i18n/utils.ts
+++ b/site/src/i18n/utils.ts
@@ -36,3 +36,23 @@ export function getLanguageInfo(locale: Locale) {
 export function isRTL(locale: Locale): boolean {
   return LANGUAGES[locale]?.dir === 'rtl';
 }
+
+/**
+ * The locales a page declares as a cluster. Shared so the hreflang tags and the
+ * og:locale tags cannot drift into contradicting each other: an explicit
+ * per-page list wins, otherwise it is all locales or none by the boolean.
+ */
+export function clusterLocales(localized: boolean, locales?: readonly Locale[]): readonly Locale[] {
+  return locales ?? (localized ? (Object.keys(LANGUAGES) as Locale[]) : []);
+}
+
+/**
+ * The locale-independent form of a path, with a trailing slash: the base every
+ * alternate URL is built from. SEOHead used to inline this, one copy of the
+ * locale-prefix rule away from `getLocaleFromPath`.
+ */
+export function unlocalizePath(pathname: string): string {
+  const locale = getLocaleFromPath(pathname);
+  const stripped = locale === DEFAULT_LOCALE ? pathname : pathname.slice(locale.length + 1) || '/';
+  return stripped.endsWith('/') ? stripped : `${stripped}/`;
+}

--- a/site/tests/unit/i18n-og-locale.test.ts
+++ b/site/tests/unit/i18n-og-locale.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { LANGUAGES, OG_LOCALES, DEFAULT_LOCALE, type Locale } from '../../src/i18n/config';
+import { clusterLocales, getLocaleFromPath, unlocalizePath } from '../../src/i18n/utils';
+
+describe('OG_LOCALES', () => {
+  it('covers every routed locale', () => {
+    expect(Object.keys(OG_LOCALES).sort()).toEqual(Object.keys(LANGUAGES).sort());
+  });
+
+  it('uses the language_TERRITORY form Open Graph expects, not our routing tag', () => {
+    for (const [locale, ogLocale] of Object.entries(OG_LOCALES)) {
+      expect(ogLocale, `${locale} must be language_TERRITORY`).toMatch(/^[a-z]{2}_[A-Z]{2}$/);
+    }
+    // The two forms genuinely differ, which is why the map exists.
+    expect(OG_LOCALES.ko).toBe('ko_KR');
+    expect(OG_LOCALES['zh-TW']).toBe('zh_TW');
+    expect(OG_LOCALES['pt-BR']).toBe('pt_BR');
+  });
+});
+
+describe('clusterLocales', () => {
+  it('returns every locale when a page is localized and gives no explicit list', () => {
+    expect(clusterLocales(true)).toEqual(Object.keys(LANGUAGES));
+  });
+
+  it('returns nothing for an English-only page', () => {
+    expect(clusterLocales(false)).toEqual([]);
+  });
+
+  it('lets an explicit list win over the boolean, including an empty one', () => {
+    expect(clusterLocales(true, ['ja', 'ko'])).toEqual(['ja', 'ko']);
+    // A detail page gated non-indexable in every locale passes [] and must not
+    // fall back to advertising all of them.
+    expect(clusterLocales(true, [])).toEqual([]);
+  });
+});
+
+describe('unlocalizePath', () => {
+  /** The implementation SEOHead inlined before this was extracted. */
+  function previousImplementation(pathname: string): string {
+    let basePath: string;
+    const segments = pathname.split('/').filter(Boolean);
+    if (segments[0] && segments[0] in LANGUAGES && segments[0] !== DEFAULT_LOCALE) {
+      basePath = '/' + segments.slice(1).join('/');
+    } else {
+      basePath = pathname;
+    }
+    return basePath.endsWith('/') ? basePath : `${basePath}/`;
+  }
+
+  const paths = [
+    '/',
+    '/workflows/',
+    '/workflows',
+    '/ko/',
+    '/ko/workflows/',
+    '/ko/workflows/some-slug-abc123/',
+    '/pt-BR/workflows/model/wan2-5/',
+    '/zh-TW/workflows/',
+    '/en/workflows/',
+    '/workflows/model/flux/',
+    '/not-a-locale/workflows/',
+  ];
+
+  it.each(paths)('matches the previous inline implementation for %s', (pathname) => {
+    expect(unlocalizePath(pathname)).toBe(previousImplementation(pathname));
+  });
+
+  it('always returns a trailing slash', () => {
+    for (const pathname of paths) expect(unlocalizePath(pathname).endsWith('/')).toBe(true);
+  });
+
+  it('leaves a path whose first segment merely starts with a locale tag alone', () => {
+    // "/korean-guide/" must not be read as the ko locale.
+    expect(unlocalizePath('/korean-guide/')).toBe('/korean-guide/');
+    expect(getLocaleFromPath('/korean-guide/')).toBe(DEFAULT_LOCALE);
+  });
+});
+
+describe('og:locale alternates', () => {
+  function alternatesFor(pathname: string, localized = true, locales?: readonly Locale[]) {
+    const current = getLocaleFromPath(pathname);
+    return clusterLocales(localized, locales)
+      .filter((locale) => locale !== current)
+      .map((locale) => OG_LOCALES[locale]);
+  }
+
+  it('never lists the page own locale as an alternate', () => {
+    expect(alternatesFor('/ko/workflows/')).not.toContain('ko_KR');
+    expect(alternatesFor('/workflows/')).not.toContain('en_US');
+  });
+
+  it('lists every other locale for a fully localized page', () => {
+    expect(alternatesFor('/ko/workflows/')).toHaveLength(Object.keys(LANGUAGES).length - 1);
+  });
+
+  it('emits none for an English-only page', () => {
+    expect(alternatesFor('/workflows/use-cases/upscaling/', false)).toEqual([]);
+  });
+
+  it('follows the per-page gate the hreflang tags follow', () => {
+    expect(alternatesFor('/ja/workflows/x/', true, ['en', 'ja'])).toEqual(['en_US']);
+  });
+});

--- a/site/tests/unit/seohead-render.test.ts
+++ b/site/tests/unit/seohead-render.test.ts
@@ -1,0 +1,41 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, expect, it } from 'vitest';
+import SEOHead from '../../src/components/SEOHead.astro';
+
+async function render(pathname: string, props: Record<string, unknown> = {}) {
+  const container = await AstroContainer.create();
+  return container.renderToString(SEOHead, {
+    props: { title: 'T', description: 'D', ...props },
+    request: new Request(`https://comfy.org${pathname}`),
+  });
+}
+
+describe('SEOHead rendered output', () => {
+  it('declares the page language and the other locales', async () => {
+    const html = await render('/ko/workflows/');
+    expect(html).toContain('<meta property="og:locale" content="ko_KR">');
+    expect(html).toContain('<meta property="og:locale:alternate" content="en_US">');
+    expect(html).not.toContain('content="ko_KR"></meta>');
+    const alternates = [...html.matchAll(/og:locale:alternate" content="([^"]+)"/g)].map(
+      (m) => m[1]
+    );
+    expect(alternates).not.toContain('ko_KR');
+    expect(alternates).toHaveLength(10);
+  });
+
+  it('emits no alternates for an English-only page', async () => {
+    const html = await render('/workflows/use-cases/x/', { hreflangLocalized: false });
+    expect(html).toContain('<meta property="og:locale" content="en_US">');
+    expect(html).not.toContain('og:locale:alternate');
+  });
+
+  it('matches the hreflang cluster exactly', async () => {
+    const html = await render('/ja/workflows/x/', { hreflangLocales: ['en', 'ja'] });
+    const hreflangs = [...html.matchAll(/hreflang="([^"]+)"/g)].map((m) => m[1]);
+    const ogLocales = [...html.matchAll(/og:locale(?::alternate)?" content="([^"]+)"/g)].map(
+      (m) => m[1]
+    );
+    expect(hreflangs.sort()).toEqual(['en', 'ja', 'x-default']);
+    expect(ogLocales.sort()).toEqual(['en_US', 'ja_JP']);
+  });
+});

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,7 +1,10 @@
+/// <reference types="vitest/config" />
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vitest/config';
+import { getViteConfig } from 'astro/config';
 
-export default defineConfig({
+// getViteConfig rather than plain defineConfig so tests can import and render
+// .astro components; without it Vite cannot parse their template syntax.
+export default getViteConfig({
   resolve: {
     // Mirror the tsconfig `@/* → ./src/*` alias so unit tests can import
     // source modules that use it (e.g. composables).


### PR DESCRIPTION
## Why

The hub emits ten `og:` tags and not one of them says which language the page is in. All ten indexable locales currently present themselves to Slack, Facebook and LinkedIn as language-neutral.

This was specified: [TDD: GTM-291](https://app.notion.com/p/3a56d73d365080beb7daf90ae3cdea79) section 8.4 lists "`og:locale` and `og:locale:alternate` added" as part of the indexability cleanups. It never got built.

Verified absent on production before writing anything: `curl https://comfy.org/ko/workflows/ | grep 'og:'` returns ten tags, no `og:locale`.

## What changed

**`OG_LOCALES` in `src/i18n/config.ts`.** Open Graph wants `language_TERRITORY`, which is not the tag we route on: we say `ko`, it wants `ko_KR`. Typed as a full `Record<Locale, string>`, so registering a new locale without an entry here is a compile error rather than a page that silently claims no language.

**Alternates come from the hreflang cluster.** The "which locales does this page declare" rule was inline in `HreflangTags.astro`. It is now `clusterLocales` in `src/i18n/utils.ts` and both components call it, so the `og:locale:alternate` set and the `hreflang` set cannot drift into contradicting each other. Per-page gating (`hreflangLocales`, including `[]`) is respected identically by both.

**`unlocalizePath`.** `SEOHead.astro` carried its own copy of the locale-prefix rule, three lines from the import of `getLocaleFromPath` which implements the same check. Extracted and shared. A test asserts the new function matches the previous inline implementation across eleven path shapes, including `/en/…`, `/pt-BR/…`, a bare `/`, and `/korean-guide/` which must not be read as the `ko` locale.

**`vitest.config.ts` moves to `getViteConfig`.** Without it Vite cannot parse `.astro` template syntax, so no test could import a component and assert its rendered output. All 55 test files still pass and the suite is not slower.

## Verification

22 logic tests plus 3 that render `SEOHead` through Astro's container API and assert the real HTML, including that the `og:locale` set and the `hreflang` set match exactly on a gated page.

Both render assertions were proven able to fail. Breaking the mapping (emitting `ko` instead of `ko_KR`) turns 3 red; removing the self-locale filter so a page lists itself as its own alternate turns 2 red.

## Gate

`npm run lint`, `npx astro check` (0 errors) and `npx vitest run` (717 tests, 55 files) all pass.

## Not in this PR

The other unshipped items from GTM-291 section 8.4: duplicate hreflang emission on English tag and category pages, localizing the hard-coded English relative dates, and structured-data parity on locale pages.