### PR TITLE
fix(seo): give localized model pages their SoftwareApplication node

### DIFF
--- a/site/src/lib/workflow-pages/model-page-jsonld.ts
+++ b/site/src/lib/workflow-pages/model-page-jsonld.ts
@@ -1,0 +1,34 @@
+import { buildSoftwareApplicationJsonLd } from '../structured-data';
+
+/**
+ * The entity node a localized model page emits.
+ *
+ * The English route also emits FAQPage and HowTo nodes, and a featureList on the
+ * SoftwareApplication. All three are built from the model landing copy in
+ * src/content/landing/models/, which exists **only in English**: there are no
+ * per-locale variants of those files. Emitting them on a localized page would
+ * put English questions and steps into structured data on a page that declares
+ * inLanguage for its own locale, offering search engines an answer in a language
+ * the reader did not ask for. That is worse than emitting nothing, so a localized
+ * page carries the entity node alone.
+ *
+ * The name and description are safe because they come from buildModelPageMeta,
+ * which resolves them through the UI dictionary for the page's locale.
+ *
+ * Returns an array so the caller renders one script per block, matching the
+ * English route, and so adding a node later needs no change at the call site.
+ */
+export function buildLocalizedModelJsonLd(params: {
+  h1: string;
+  description: string;
+  /** False when the page is too thin for its editorial copy to be trusted. */
+  hasQualityContent: boolean;
+}): object[] {
+  if (!params.hasQualityContent) return [];
+  return [
+    buildSoftwareApplicationJsonLd({
+      name: params.h1,
+      description: params.description,
+    }),
+  ];
+}

--- a/site/src/pages/[locale]/workflows/model/[name].astro
+++ b/site/src/pages/[locale]/workflows/model/[name].astro
@@ -28,6 +28,7 @@ import {
   buildWorkflowBreadcrumb,
   serializeJsonLdForScript,
 } from '../../../../lib/structured-data';
+import { buildLocalizedModelJsonLd } from '../../../../lib/workflow-pages/model-page-jsonld';
 import { listingIndexing, alternatesFor } from '../../../../lib/i18n/listing-indexing';
 import { localizeCards } from '../../../../lib/i18n/localize-cards';
 
@@ -86,7 +87,7 @@ const canonicalUrl = absoluteUrl(indexing.canonicalPath);
 // resolve through the same helper as the English route so the hreflang cluster
 // stays consistent.
 const content = await loadModelContent(family.slug);
-const { h1, title, description } = buildModelPageMeta({
+const { h1, title, description, hasQualityContent } = buildModelPageMeta({
   group: family,
   content,
   locale: typedLocale,
@@ -120,6 +121,14 @@ const breadcrumbStructuredData = buildWorkflowBreadcrumb(typedLocale, { name: h1
   },
   { name: t('labels.models', typedLocale), item: absoluteUrl(modelsIndexPath(typedLocale)) },
 ]);
+
+// The English route emits a SoftwareApplication entity node for the family and
+// this one did not, so the localized pages were absent from that part of the
+// entity graph. See the builder for why the FAQ and how-to nodes stay English-only.
+const jsonLdBlocks = [
+  breadcrumbStructuredData,
+  ...buildLocalizedModelJsonLd({ h1, description, hasQualityContent }),
+];
 
 // matchingTemplates are already SerializedTemplate[] with profile data
 const serialized = matchingTemplates;
@@ -167,11 +176,11 @@ const serialized = matchingTemplates;
     />
   </div>
 
-  <script
-    is:inline
-    type="application/ld+json"
-    set:html={serializeJsonLdForScript(breadcrumbStructuredData)}
-  />
+  {
+    jsonLdBlocks.map((data) => (
+      <script is:inline type="application/ld+json" set:html={serializeJsonLdForScript(data)} />
+    ))
+  }
 
   <Fragment slot="footer">
     <SiteFooter />

--- a/site/tests/unit/model-page-jsonld.test.ts
+++ b/site/tests/unit/model-page-jsonld.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildLocalizedModelJsonLd } from '../../src/lib/workflow-pages/model-page-jsonld';
+import { buildSoftwareApplicationJsonLd } from '../../src/lib/structured-data';
+
+function typesOf(blocks: object[]): string[] {
+  return blocks.map((block) => (block as { '@type': string })['@type']);
+}
+
+describe('buildLocalizedModelJsonLd', () => {
+  const localized = {
+    h1: 'Flux Comfy ワークフロー',
+    description: 'Flux を使った 36 件のすぐに使える ComfyUI ワークフローテンプレート。',
+    hasQualityContent: true,
+  };
+
+  it('emits the SoftwareApplication node the English route emits', () => {
+    expect(typesOf(buildLocalizedModelJsonLd(localized))).toEqual(['SoftwareApplication']);
+  });
+
+  it('carries the localized name and description, not English', () => {
+    const [node] = buildLocalizedModelJsonLd(localized) as Record<string, unknown>[];
+    expect(node.name).toBe(localized.h1);
+    expect(node.description).toBe(localized.description);
+  });
+
+  it('emits nothing when the page is too thin for its editorial copy', () => {
+    expect(buildLocalizedModelJsonLd({ ...localized, hasQualityContent: false })).toEqual([]);
+  });
+
+  it('never carries a featureList, which exists only in English', () => {
+    for (const block of buildLocalizedModelJsonLd(localized)) {
+      expect(block).not.toHaveProperty('featureList');
+    }
+  });
+
+  it('never emits the FAQ or how-to nodes, whose copy exists only in English', () => {
+    const types = typesOf(buildLocalizedModelJsonLd(localized));
+    expect(types).not.toContain('FAQPage');
+    expect(types).not.toContain('HowTo');
+  });
+
+  it('omits featureList by choice, not because the builder drops it', () => {
+    // Guards the reasoning above: if the shared builder ignored featureList the
+    // previous test would pass for the wrong reason and keep passing if someone
+    // started passing English highlights in.
+    const withFeatures = buildSoftwareApplicationJsonLd({
+      name: localized.h1,
+      description: localized.description,
+      featureList: ['Open weights', 'Speed or quality'],
+    });
+    expect(withFeatures).toHaveProperty('featureList', ['Open weights', 'Speed or quality']);
+  });
+});


### PR DESCRIPTION
## Why

`/workflows/model/flux/` emits a `SoftwareApplication` entity node for the model family. `/ja/workflows/model/flux/` does not, so every localized model page is missing from that part of the entity graph.

Verified live before writing anything:

| | English | Japanese |
|---|---|---|
| `/workflows/model/flux/` | CollectionPage, BreadcrumbList, ItemList, ListItem, **SoftwareApplication, FAQPage, HowTo, HowToStep, Question, Answer** | |
| `/ja/workflows/model/flux/` | | CollectionPage, BreadcrumbList, ItemList, ListItem |

Named as an unshipped cleanup in [TDD: GTM-291](https://app.notion.com/p/3a56d73d365080beb7daf90ae3cdea79) section 8.4.

## Why only the entity node crosses over

The FAQ and how-to nodes, and the `featureList` on the SoftwareApplication, are all built from the model landing copy in `src/content/landing/models/`. Those eleven JSON files are **English only**; there are no per-locale variants and the collection loader has no locale dimension.

Emitting them on a localized page would put English questions and steps into structured data on a page that declares `inLanguage` for its own locale, offering search engines an answer in a language the reader did not ask for. That is worse than emitting nothing.

The name and description are safe because `buildModelPageMeta` already resolves them for the page's locale. Confirmed on the live Japanese page: `Flux Comfy Workflows — 無料テンプレート` with a Japanese meta description.

## On `inLanguage`

The TDD pairs this with "`inLanguage` finally matching actual content language". That half is already done: locale pages emit `inLanguage` on their `CollectionPage` node and it is correct. `structured-data.ts` is deliberately untouched here (see below).

## Verification

6 tests on the rule, not on the output shape. Two were proven able to fail:

- Passing the English highlights through as a `featureList` turns the featureList guard red.
- Dropping the thin-content gate turns the quality guard red.

One test asserts the shared builder *does* emit a `featureList` when given one, so the omission reads as a deliberate choice rather than passing because the builder ignores the field.

Gate: `npm run lint`, `npx astro check` (0 errors), `npx vitest run` (698 tests, 55 files).

## Coordination

Scoped to the localized route on purpose.

- **#1171** (approved, merging today) appends to `structured-data.ts` immediately after `buildSoftwareApplicationJsonLd`, with hunk context covering those lines. This PR imports that function and does not edit the file, so there is no overlap.
- **#1164** has hunks straddling the English model route's import block and is waiting on a reviewer. Refactoring the English route now would hand that PR an avoidable conflict, so the English route adopts the builder once #1164 lands. That follow-up removes the duplication that let these two routes drift apart in the first place.