### PR TITLE
fix(i18n): add Italian to OG_LOCALES, unbreaking main

### DIFF
--- a/site/src/i18n/config.ts
+++ b/site/src/i18n/config.ts
@@ -53,4 +53,5 @@ export const OG_LOCALES: Record<Locale, string> = {
   tr: 'tr_TR',
   ar: 'ar_AR',
   'pt-BR': 'pt_BR',
+  it: 'it_IT',
 };

--- a/site/tests/unit/seohead-render.test.ts
+++ b/site/tests/unit/seohead-render.test.ts
@@ -1,6 +1,7 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { describe, expect, it } from 'vitest';
 import SEOHead from '../../src/components/SEOHead.astro';
+import { LANGUAGES } from '../../src/i18n/config';
 
 async function render(pathname: string, props: Record<string, unknown> = {}) {
   const container = await AstroContainer.create();
@@ -20,7 +21,9 @@ describe('SEOHead rendered output', () => {
       (m) => m[1]
     );
     expect(alternates).not.toContain('ko_KR');
-    expect(alternates).toHaveLength(10);
+    // Derived, not a literal: registering a locale should change this number,
+    // and a hard-coded one silently rots the moment it does.
+    expect(alternates).toHaveLength(Object.keys(LANGUAGES).length - 1);
   });
 
   it('emits no alternates for an English-only page', async () => {


### PR DESCRIPTION
## main does not compile

Reproduced on a clean checkout of `origin/main` at `227d6734`:

```
src/i18n/config.ts:44 - error ts(2741): Property 'it' is missing in type
'{ en: string; ... 'pt-BR': string; }' but required in type
'Record<"en" | ... | "it", string>'.
```

`npx astro check`: 1 error. `npx vitest run`: 1 failure, the test asserting `OG_LOCALES` covers every routed locale.

## It also ships a broken tag, which is worse than the compile error

Rendering `SEOHead` through the container on main shows what actually reaches a reader:

```
<meta property="og:locale:alternate" content="pt_BR">
<meta property="og:locale:alternate">        <-- Italian, no content attribute
```

`OG_LOCALES['it']` is `undefined`, so Astro drops the attribute and emits an empty, meaningless meta tag on every page.

The existing render test did **not** catch this, because its regex only counts tags carrying `content="..."`, so the malformed one was invisible and the hardcoded `toHaveLength(10)` still passed. That is why the count is now derived from the locale list: with `it_IT` removed but Italian still registered, the render test now fails with `expected length 11 but got 10`, alongside the coverage test. Verified both.

## Why it happened

Both PRs were correct. #1199 typed `OG_LOCALES` as a full `Record<Locale, string>` **specifically so** registering a locale without an OG entry is a compile error rather than a page that silently claims no language. #1195 registered Italian.

Merging them in that order is what broke: #1199's CI ran before Italian landed and nothing re-checked the combination. The guard worked as designed, just after the merge rather than before.

## The fix

`it: 'it_IT'`, matching the `language_TERRITORY` form the rest of the map uses, plus the derived count in the render test so the next locale needs no test edit.

## Verified locally

- Clean `origin/main`: 1 astro error, 1 failing test, malformed tag in the rendered output.
- This branch: `astro check` 0 errors, **731 tests across 56 files**, lint clean, and the rendered output carries `content="it_IT"` with zero malformed tags.
- Removing `it_IT` while leaving Italian registered fails 2 tests, so the guard is real in both directions.

## Follow-up, not in this PR

Registering Italian also means every English page now advertises `hreflang="it"` while `/it/` is **not** in `INDEXABLE_LOCALES`, so it points at a noindexed page. Confirmed from the rendered output:

```
hreflang advertised: en zh zh-tw ja ko es fr ru tr ar pt-br it x-default
INDEXABLE_LOCALES  : zh zh-TW ja ko es fr ru tr ar pt-BR
advertised but NOT indexable: it
```

Google discards a cluster that references noindexed alternates. This is the state the site was in for every locale before the 26 Aug flip, so it is not novel, but it re-introduces one instance of what that flip cleaned up. Deploys are manual, so it is not live yet. Worth its own PR rather than widening this one, since it is a cluster-behaviour change.