### PR TITLE
fix(site): serve the MiniMax H3 demo media from media.comfy.org

### DIFF
--- a/site/src/pages/workflows/index.astro
+++ b/site/src/pages/workflows/index.astro
@@ -89,8 +89,8 @@ const facetsConfig = buildFacetsConfig(locale);
              page's critical path; the frame paints before any video bytes. -->
         <video
           id="mmh3-promo-video"
-          src="/demos/mmh3/example/example.mp4"
-          poster="/demos/mmh3/example/keyframes/kf_1.webp"
+          src="https://media.comfy.org/website/demos/mmh3/example/example.mp4"
+          poster="https://media.comfy.org/website/demos/mmh3/example/keyframes/kf_1.webp"
           autoplay
           muted
           loop

--- a/site/src/pages/workflows/minimax-h3-multiref.astro
+++ b/site/src/pages/workflows/minimax-h3-multiref.astro
@@ -17,25 +17,26 @@ const locale = DEFAULT_LOCALE;
 /** Seed the prompt editor with the text the workflow ships with. */
 const defaultPrompt = String(nodes[INPUT_NODES.prompt.nodeId]?.inputs?.prompt ?? '');
 
-// These assets are committed (public/demos/mmh3/example/.gitignore whitelists
-// them), so the URLs are referenced directly. This page renders on demand, and
-// on Vercel `public/` is served from the CDN without existing on the
-// function's filesystem — an fs check here would wrongly report every asset
-// missing and hide the prompt-guide button and example media.
-const EXAMPLE_ROOT = 'demos/mmh3/example';
+// These assets are served from media.comfy.org (source files stay committed
+// under public/demos/mmh3). Root-relative URLs 404 in production because the
+// comfy.org router resolves them against the website app, which does not have
+// the hub's /demos tree — absolute CDN URLs work on every origin, and the
+// bucket sends access-control-allow-origin: * so the on-click prompt fetch
+// still works cross-origin.
+const EXAMPLE_ROOT = 'https://media.comfy.org/website/demos/mmh3/example';
 
 const exampleKeyframes = KEYFRAMES.map(
-  (slot) => `/${EXAMPLE_ROOT}/keyframes/kf_${slot.index}.webp`
+  (slot) => `${EXAMPLE_ROOT}/keyframes/kf_${slot.index}.webp`
 );
 
 /** The example result, played before the first run. */
-const exampleVideo = `/${EXAMPLE_ROOT}/example.mp4`;
+const exampleVideo = `${EXAMPLE_ROOT}/example.mp4`;
 
 /**
  * A system prompt for writing this workflow's prompts with an agent. Fetched
  * on click rather than inlined, so its ~19 KB stays out of the page payload.
  */
-const agentPromptUrl = '/demos/mmh3/agent-prompt.md';
+const agentPromptUrl = 'https://media.comfy.org/website/demos/mmh3/agent-prompt.md';
 
 const pageTitle = 'MiniMax H3 - Motion Context';
 const description =


### PR DESCRIPTION
comfy.org/workflows/minimax-h3-multiref renders with all three reference keyframes broken, an empty result player, and a dead agent-prompt fetch. Root cause: the page (and the demo card on /workflows) reference the committed public/ assets with root-relative URLs, but behind the comfy.org router those resolve against the website app, which has no /demos tree — all four asset requests 404 in production. (Icons like /icons/node-left.svg only work because copies exist in the website repo's public dir; /icons/caret-right.svg has no copy and 404s too — fixed separately in ComfyUI_frontend.)

Fix: the five demo assets are uploaded to media.comfy.org (gs://comfy-org-videos/website/demos/mmh3/..., all verified HTTP 200, access-control-allow-origin: * so the on-click prompt fetch works cross-origin), and both pages now reference the absolute CDN URLs. Source files stay committed under public/demos/mmh3.

Follow-up worth considering: hub-only root-relative public assets break on comfy.org whenever there is no website-side copy — either the comfy-router should forward the hub's static prefixes, or the hub should adopt an asset-base convention.