### PR TITLE
fix(site): unlink the MiniMax H3 demo promo from the workflows hub

### DIFF
--- a/site/src/pages/workflows/index.astro
+++ b/site/src/pages/workflows/index.astro
@@ -76,65 +76,16 @@ const facetsConfig = buildFacetsConfig(locale);
 
     <HubHero count={serialized.length} />
 
-    <!--
-      Run-in-browser demo. Not a template in the index (it is an interactive
-      runner backed by a live deployment), so it is linked explicitly here
-      rather than injected into the grid data.
-    -->
-    <section class="mb-12 grid overflow-hidden rounded-5xl bg-hub-surface p-2 lg:grid-cols-3">
-      <div
-        class="media-frame relative aspect-video min-h-56 overflow-hidden rounded-4xl bg-black lg:aspect-auto lg:min-h-80"
-      >
-        <!-- metadata-only preload + a poster keep the clip's megabytes off the
-             page's critical path; the frame paints before any video bytes. -->
-        <video
-          id="mmh3-promo-video"
-          src="/demos/mmh3/example/example.mp4"
-          poster="/demos/mmh3/example/keyframes/kf_1.webp"
-          autoplay
-          muted
-          loop
-          playsinline
-          preload="metadata"
-          class="h-full w-full object-cover"></video>
-        <script>
-          // Autoplay is a flourish — hold the poster for reduced-motion users.
-          if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-            const promo = document.getElementById('mmh3-promo-video') as HTMLVideoElement | null;
-            promo?.removeAttribute('autoplay');
-            promo?.pause();
-          }
-        </script>
-      </div>
-      <div
-        class="flex min-w-0 flex-col justify-center px-6 py-7 sm:px-8 lg:col-span-2 lg:px-10 lg:py-8"
-      >
-        <span class="text-xs font-semibold uppercase tracking-wider text-brand">
-          Run in your browser
-        </span>
-        <h2 class="mt-4 text-3xl font-normal text-content sm:text-4xl">
-          MiniMax H3 - Motion Context
-        </h2>
-        <p class="mt-4 max-w-2xl text-base leading-relaxed text-content-secondary">
-          Guide one continuous shot with three reference images pinned to exact moments — no
-          install, runs on a live deployment.
-        </p>
-        <a
-          href={localizeUrl('/workflows/minimax-h3-multiref/', locale)}
-          class="mt-6 inline-flex h-10 w-fit items-center justify-center rounded-2xl bg-brand px-6 text-sm font-semibold uppercase tracking-wider text-page transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-page"
-        >
-          Try MiniMax H3
-        </a>
-        <div class="mt-8 flex flex-wrap gap-2">
-          <span class="rounded-full bg-white/4 px-4 py-2 text-sm text-content-secondary">
-            Live deployment
-          </span>
-          <span class="rounded-full bg-white/4 px-4 py-2 text-sm text-content-secondary">
-            Video + audio
-          </span>
-        </div>
-      </div>
-    </section>
+    {
+      /*
+        The "Run in your browser" MiniMax H3 demo promo sat here. It is
+        temporarily unlinked because running the demo fails with a 404
+        (FE-1932). The demo page, its API routes and its assets are untouched —
+        restore the promo by reverting the commit that removed this block, once
+        the 404 is fixed and retested. JS-style comment so the note stays out of
+        the shipped HTML.
+      */
+    }
 
     <!-- Inline search — shows among the filters, docks flush below the navbar once scrolled past. -->
     <HubSearchBar templates={serialized} locale={locale} />


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Temporarily removes the "Run in your browser — MiniMax H3 · Motion Context" promo section from the `/workflows` hub page, so we stop sending people to a demo that 404s.

## Why

Running the workflow at [comfy.org/workflows/minimax-h3-multiref/](https://comfy.org/workflows/minimax-h3-multiref/) fails with `Request failed (404): The page could not be found` — reported in `#bug-dump` and filed as [FE-1932](https://linear.app/comfyorg/issue/FE-1932). The hub promo (added in #1177) is the only entry point into that page, so unlinking it takes the broken path out of the funnel while the 404 is diagnosed and retested.

## What changed

One file, `site/src/pages/workflows/index.astro` (+10 / −59): the `<section>` holding the promo video, heading, blurb, "Try MiniMax H3" CTA and tag pills is removed, replaced by a JSX comment (`{/* … */}`, so it does **not** ship in the built HTML) explaining the removal and citing FE-1932.

**Nothing about the feature itself is deleted.** Untouched: `src/pages/workflows/minimax-h3-multiref.astro`, the three API routes under `src/pages/api/workflows/minimax-h3-multiref/`, `src/components/demos/MiniMaxH3Demo.vue`, `src/lib/demos/mmh3/*`, and `public/demos/mmh3/*`. The page still renders at its URL for whoever retests the fix — it is already `noindex` and excluded from the sitemap, which is why the hub promo was its sole entry point.

## Restoring

Revert this PR once the 404 is fixed and retested. (`git log -S 'Try MiniMax H3' -- site/src/pages/workflows/index.astro` also finds it.)

## Verification

- `pnpm run lint` (`eslint --max-warnings 0`) — clean
- `npx prettier --check src/pages/workflows/index.astro` — clean (repo-wide `format:check` has 24 pre-existing failures on files this PR does not touch)
- `npx vitest run` — 57 files / 734 tests passing
- Dev server (`pnpm run sync:en-only && pnpm run dev`): `/workflows` renders with 0 `minimax-h3-multiref` links, no `mmh3-promo-video` element, and no `FE-1932` string in the served HTML; the card grid and search/filter toolbar are unaffected. `/workflows/minimax-h3-multiref/` still returns 200 and renders fully.
- Reviewed by the `deep-reviewer` sub-agent (two independent reviewers + cross-validation): **PASS**, no blocking findings.

Fixes the user-facing symptom only — the underlying 404 stays open on [FE-1932](https://linear.app/comfyorg/issue/FE-1932).

cc @robinhuang11 (tester on the original report)

## Screenshots

![Before: /workflows hub showing the 'Run in your browser — MiniMax H3 · Motion Context' promo section with the 'Try MiniMax H3' CTA between the hero and the search bar](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/77b91e1acd8571f0652e201ae81c5e7cf9a085b03610d2312797d2c3429d671d/pr-images/1787894483265-e01ac99f-78c9-4f0c-acca-c2be0203a18d.png)

![After: /workflows hub with the promo removed — hero flows straight into the 'Browse Workflows' heading, search bar, filters and card grid](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/77b91e1acd8571f0652e201ae81c5e7cf9a085b03610d2312797d2c3429d671d/pr-images/1787894483728-fedfce9c-a9ff-48d4-83d4-7116d73490cf.png)

![The MiniMax H3 demo page at /workflows/minimax-h3-multiref/ still renders fully — reference images, shot description and Run Workflow button all intact](https://pub-1fd11710d4c8405b948c9edc4287a3f2.r2.dev/sessions/77b91e1acd8571f0652e201ae81c5e7cf9a085b03610d2312797d2c3429d671d/pr-images/1787894484111-824313e4-5235-4782-9861-e9a7fd2ce199.png)

---

## Merged `main` in, 28 Aug

`main` moved under this branch. #1208 merged and repointed the promo video's `src` and `poster` at `media.comfy.org`, and both of those lines sit **inside** the `<section>` this PR removes, so the two conflicted on exactly one hunk in one file.

Resolved by taking the deletion. This loses nothing from #1208: `git diff 7406b970 origin/main -- site/src/pages/workflows/index.astro` shows those two lines are the only change `main` made to this file since the merge base, and #1208's remaining changes are to the demo page and its assets, which this PR does not touch. The diff against `main` is still one file, +10 / −59.

### Re-verified after the merge

- `pnpm run lint` (`eslint . --max-warnings 0`) clean
- `npx prettier --check src/pages/workflows/index.astro` clean
- `pnpm run test`: 57 files / 734 tests passing
- Dev server: `/workflows` returns 200 with **0** occurrences each of `minimax-h3-multiref`, `mmh3-promo-video`, `Try MiniMax H3`, `Run in your browser` and `FE-1932` in the served HTML, so the JSX comment stays out of the shipped markup as intended. Hero, search input and card grid all still render.
- `/workflows/minimax-h3-multiref/` still returns 200 and is still `noindex`, so it remains available for retesting.

Independently confirmed the promo was the only entry point: across `site/src` and `site/public` the sole link to the demo is `index.astro` line 123; every other reference to the slug is the Vue component calling its own API routes.

### Why this is still worth merging now that a root cause exists

The 404 was the router, not the slug and not the media. comfy-router forwarded `/workflows/*` but had no rule for `/api/`, so the demo's server routes landed on the website app. comfy-router#39 fixes that and is merged, but its `deploy-production` job runs on `workflow_dispatch` only, so nothing has shipped: production still answers `x-served-by: vercel-website` with a 404 on `/api/workflows/minimax-h3-multiref/queue`.

There is also a trap in doing nothing. Once the nightly `Cron Rebuild Site` picks up #1208, the promo's video and poster start loading from the CDN and the section will *look* healthy while Run still 404s. Merging this removes that failure mode until the router deploy lands.

### Restoring

Revert this PR **and re-dispatch `cron-rebuild-site.yml`**, once comfy-router is deployed and @robinhuang11 has retested. A revert on its own will not change production, for the same reason #1208 has not yet: the hub only updates on the nightly cron or a manual dispatch.

### Authorship note

The substantive change is Glary-Bot's. The only thing added here is the merge commit resolving the #1208 conflict mechanically, as described above.
