### PR TITLE
fix(ci): resume only what the translation run generates

### DIFF
--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -439,12 +439,12 @@ jobs:
           # cost of one UI pass next time; permanence is the worse trade.
           #
           # Pinned to the commit this job checked out, not HEAD. The publish step
-          # above runs `git checkout -B "$STABLE_BRANCH"` and commits, so a failure
-          # after that point leaves HEAD on the automation commit, where --source
-          # would mean "the branch" and bank exactly what this line exists to drop.
-          # Nothing reaches that today (the tree is clean by then, so the guard
-          # below exits first), but the rule should hold by construction rather
-          # than by control flow.
+          # above commits before it pushes, so a failed push or `gh pr create`
+          # lands here with HEAD already on the automation branch, where
+          # --source=HEAD would mean "the branch" and re-bank the very UI output
+          # this line exists to drop. Pinning also makes the revert real instead of
+          # a no-op against HEAD, so the save below still runs and carries the
+          # content progress forward with locales/ back at main's copy.
           git restore --source="$GITHUB_SHA" --staged --worktree -- site/src/i18n/locales
           if git diff --cached --quiet; then
             echo "Run failed before producing any translation changes; nothing to save."

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -109,19 +109,42 @@ jobs:
             # lobe's entry (locales/en.json) plus its outputLocales, and `it` is in
             # this workflow's SUPPORTED list but NOT in .i18nrc.ui.cjs outputLocales,
             # so nothing regenerates locales/it.json at all. Resuming that layer is
-            # also worth nothing: main is ahead of the branch on every locale (206
-            # keys against 205, and Italian 1 against 0, the date.today key added by
-            # #1200), and lobe skips keys that are already translated. Copying it
-            # back could only ever discard merged strings.
+            # also worth nothing: locale:ui fills only MISSING keys, so the branch
+            # can never hold a UI string main lacks, while main routinely holds one
+            # the branch has not caught up to yet. #1200 added date.today to main on
+            # 2026-08-28 and no run carried it onto the branch until 2026-09-01, and
+            # locales/it.json still lacks it because `it` is not an outputLocale.
+            # Copying this layer back could only ever discard merged strings.
             #
-            # Per path, not one command, so a path this branch has not created yet
-            # only loses its own progress instead of discarding every path's.
+            # Per path, not one command. A multi-pathspec checkout is refused as a
+            # whole when any one path is absent from the branch, so naming content/
+            # and review/ together would, on any night review/ is missing, also
+            # decline to restore content/. That discards banked translations to
+            # avoid re-reviewing them, spending the expensive half to save the
+            # cheap one.
+            #
+            # Splitting that pair is not free. Review verdicts are keyed by a hash
+            # of the text they judge, so content restored without its verdicts
+            # re-reviews every entry whose translation differs from main's. The
+            # cost is bounded by the branch's unmerged delta rather than the whole
+            # corpus, and those entries have no reusable verdict on either side
+            # anyway: the branch's verdicts describe the branch's text, main's
+            # describe main's.
+            #
+            # Absence is probed with cat-file rather than inferred from a failed
+            # checkout, because a checkout can fail for reasons that are not
+            # absence. Reporting those as "not there yet" would let a half-restored
+            # tree carry on behind a reassuring log line; anything that is not
+            # plain absence stays fatal under set -e.
             for generated in \
               site/src/i18n/content \
               site/src/i18n/review \
               site/src/i18n/manifest.json; do
-              git checkout "origin/$STABLE_BRANCH" -- "$generated" 2>/dev/null \
-                || echo "No $generated on $STABLE_BRANCH yet; it will be regenerated."
+              if git cat-file -e "origin/$STABLE_BRANCH:$generated" 2>/dev/null; then
+                git checkout "origin/$STABLE_BRANCH" -- "$generated"
+              else
+                echo "No $generated on $STABLE_BRANCH yet; it will be regenerated."
+              fi
             done
             echo "Restored generated translation state from $STABLE_BRANCH (everything else kept from main)."
           else
@@ -403,10 +426,11 @@ jobs:
           #
           # Always main, never the branch. The branch's copy is only ever as new
           # as the last night that wrote it, so preferring it banks a regression
-          # the moment someone merges a UI string: right now main carries 206 keys
-          # and the branch 205, the difference being date.today from #1200. Since
-          # the restore step above no longer reads this layer from the branch,
-          # there is no banked UI progress here left to preserve.
+          # for as long as a merged UI string has not been carried over yet, a gap
+          # that is routinely nights wide (date.today, #1200, sat on main from
+          # 2026-08-28 to 2026-09-01). Since the restore step above no longer reads
+          # this layer from the branch, there is no banked UI progress here left to
+          # preserve.
           git restore --source=HEAD --staged --worktree -- site/src/i18n/locales
           if git diff --cached --quiet; then
             echo "Run failed before producing any translation changes; nothing to save."

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -92,21 +92,38 @@ jobs:
           # a narrow refspec), so both the restore and the later force-with-lease
           # have a real base. Absent branch (first run) -> fetch fails, start fresh.
           if git fetch origin "$STABLE_BRANCH:refs/remotes/origin/$STABLE_BRANCH" 2>/dev/null; then
-            git checkout "origin/$STABLE_BRANCH" -- site/src/i18n || true
-            # The restore above shadows every file under site/src/i18n with the
-            # branch's older copy, so an edit landed on main since the branch was
-            # last updated comes back as a deletion (it took the navbar keys on
-            # 2026-08-12). Take the layers a person edits back from the checkout:
-            # the UI source nothing regenerates, the override layer nothing here
-            # writes, and the sign-off records, whose missing entries this pipeline
-            # would otherwise re-stamp as machine-authored. restore, not checkout,
-            # so a file deleted on main cannot be resurrected from the branch.
-            git restore --source=HEAD --staged --worktree -- \
-              site/src/i18n/locales/en.json \
-              site/src/i18n/overrides \
-              site/src/i18n/reviews \
-              site/src/i18n/human
-            echo "Restored partial translations from $STABLE_BRANCH (human-authored sources kept from the checkout)."
+            # Take back ONLY what this pipeline generates, rather than taking the
+            # whole tree and undoing the parts a person owns. An allowlist of
+            # things to protect has to be extended by hand every time someone adds
+            # a file, and three times nobody did, so the run proposed deleting
+            # their work: the navbar keys on 2026-08-12, the template.api.* strings
+            # on 2026-08-19, and clusterLocales, unlocalizePath, OG_LOCALES and
+            # Italian on 2026-08-27. An allowlist of things to copy cannot do that,
+            # because anything not named here is never touched.
+            #
+            # The failure direction inverts with it: forgetting to name a generated
+            # path costs one re-translation of that path, where forgetting to name
+            # a hand-written path deleted it, silently whenever it was data.
+            #
+            # locales/ is deliberately absent. It is not purely generated: it is
+            # lobe's entry (locales/en.json) plus its outputLocales, and `it` is in
+            # this workflow's SUPPORTED list but NOT in .i18nrc.ui.cjs outputLocales,
+            # so nothing regenerates locales/it.json at all. Resuming that layer is
+            # also worth nothing: main is ahead of the branch on every locale (206
+            # keys against 205, and Italian 1 against 0, the date.today key added by
+            # #1200), and lobe skips keys that are already translated. Copying it
+            # back could only ever discard merged strings.
+            #
+            # Per path, not one command, so a path this branch has not created yet
+            # only loses its own progress instead of discarding every path's.
+            for generated in \
+              site/src/i18n/content \
+              site/src/i18n/review \
+              site/src/i18n/manifest.json; do
+              git checkout "origin/$STABLE_BRANCH" -- "$generated" 2>/dev/null \
+                || echo "No $generated on $STABLE_BRANCH yet; it will be regenerated."
+            done
+            echo "Restored generated translation state from $STABLE_BRANCH (everything else kept from main)."
           else
             echo "No automation branch yet; starting fresh from main."
           fi
@@ -383,11 +400,14 @@ jobs:
           # locale:ui fills only MISSING keys, so an invalid UI string banked
           # here would restore and fail validate forever. (Content is safe:
           # enforce prunes it to disk and re-prunes restored content nightly.)
-          if git cat-file -e "refs/remotes/origin/$STABLE_BRANCH:site/src/i18n/locales" 2>/dev/null; then
-            git restore --source="refs/remotes/origin/$STABLE_BRANCH" --staged --worktree -- site/src/i18n/locales
-          else
-            git restore --source=HEAD --staged --worktree -- site/src/i18n/locales
-          fi
+          #
+          # Always main, never the branch. The branch's copy is only ever as new
+          # as the last night that wrote it, so preferring it banks a regression
+          # the moment someone merges a UI string: right now main carries 206 keys
+          # and the branch 205, the difference being date.today from #1200. Since
+          # the restore step above no longer reads this layer from the branch,
+          # there is no banked UI progress here left to preserve.
+          git restore --source=HEAD --staged --worktree -- site/src/i18n/locales
           if git diff --cached --quiet; then
             echo "Run failed before producing any translation changes; nothing to save."
             exit 0

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -114,16 +114,19 @@ jobs:
             # that list rather than the directory, so it rides the PR diff instead
             # of re-entering the build.
             #
-            # locales/ is deliberately absent. It is not purely generated: it is
-            # lobe's entry (locales/en.json) plus its outputLocales, and `it` is in
-            # this workflow's SUPPORTED list but NOT in .i18nrc.ui.cjs outputLocales,
-            # so nothing regenerates locales/it.json at all. Resuming that layer is
-            # also worth nothing: locale:ui fills only MISSING keys, so the branch
-            # can never hold a UI string main lacks, while main routinely holds one
-            # the branch has not caught up to yet. #1200 added date.today to main on
-            # 2026-08-28 and no run carried it onto the branch until 2026-09-01, and
-            # locales/it.json still lacks it because `it` is not an outputLocale.
-            # Copying this layer back could only ever discard merged strings.
+            # locales/ is deliberately absent, for reasons that outlive any
+            # snapshot. It is not purely generated: locales/en.json is lobe's entry
+            # and is hand-edited, which is what made taking the branch's older copy
+            # delete the navbar keys on 2026-08-12; and `it` is in this workflow's
+            # SUPPORTED list but NOT in .i18nrc.ui.cjs outputLocales, so nothing
+            # regenerates locales/it.json at all. Nothing prunes this layer either:
+            # locale:ui fills only MISSING keys, so a bad string that once lands
+            # here is never corrected by a later run.
+            #
+            # Unlike the generated paths, the branch CAN legitimately be ahead here:
+            # a prior run's locale:ui output sits on it until that PR merges. Not
+            # resuming it costs one UI pass over the missing keys, which is the
+            # price of never carrying a hand-edited file backwards.
             #
             # Per path, not one command. A multi-pathspec checkout is refused as a
             # whole when any one path is absent from the branch, so naming content/
@@ -432,15 +435,17 @@ jobs:
           # locale:ui fills only MISSING keys, so an invalid UI string banked
           # here would restore and fail validate forever. (Content is safe:
           # enforce prunes it to disk and re-prunes restored content nightly.)
+          # This deliberately drops the run's own locale:ui output too, at the
+          # cost of one UI pass next time; permanence is the worse trade.
           #
-          # Always main, never the branch. The branch's copy is only ever as new
-          # as the last night that wrote it, so preferring it banks a regression
-          # for as long as a merged UI string has not been carried over yet, a gap
-          # that is routinely nights wide (date.today, #1200, sat on main from
-          # 2026-08-28 to 2026-09-01). Since the restore step above no longer reads
-          # this layer from the branch, there is no banked UI progress here left to
-          # preserve.
-          git restore --source=HEAD --staged --worktree -- site/src/i18n/locales
+          # Pinned to the commit this job checked out, not HEAD. The publish step
+          # above runs `git checkout -B "$STABLE_BRANCH"` and commits, so a failure
+          # after that point leaves HEAD on the automation commit, where --source
+          # would mean "the branch" and bank exactly what this line exists to drop.
+          # Nothing reaches that today (the tree is clean by then, so the guard
+          # below exits first), but the rule should hold by construction rather
+          # than by control flow.
+          git restore --source="$GITHUB_SHA" --staged --worktree -- site/src/i18n/locales
           if git diff --cached --quiet; then
             echo "Run failed before producing any translation changes; nothing to save."
             exit 0

--- a/.github/workflows/i18n-update-hub.yml
+++ b/.github/workflows/i18n-update-hub.yml
@@ -105,6 +105,15 @@ jobs:
             # path costs one re-translation of that path, where forgetting to name
             # a hand-written path deleted it, silently whenever it was data.
             #
+            # It also retires the restore-not-checkout dance the old code needed to
+            # stop the blanket checkout resurrecting a human-authored file deleted
+            # on main: nothing shadows those layers now. A checkout still merges
+            # into the worktree rather than mirroring the branch, so a generated
+            # file for a locale dropped from SUPPORTED_HUB_LOCALES comes back if
+            # the branch still has it, exactly as before. enforce and validate walk
+            # that list rather than the directory, so it rides the PR diff instead
+            # of re-entering the build.
+            #
             # locales/ is deliberately absent. It is not purely generated: it is
             # lobe's entry (locales/en.json) plus its outputLocales, and `it` is in
             # this workflow's SUPPORTED list but NOT in .i18nrc.ui.cjs outputLocales,


### PR DESCRIPTION
## The problem

The nightly translation run resumes from its automation branch by taking the whole `site/src/i18n` tree back, then restoring the layers a person owns. That directory holds two different things: what the pipeline generates, and what people write. The protect-list only ever covered part of the second kind, so it has to be extended by hand every time someone adds a file, and three times nobody did.

- **2026-08-12**: took the manually written navbar keys, shipped as a production bug.
- **2026-08-19**: nearly took the 13 `template.api.*` strings.
- **Now**: the open nightly PR #1196 proposes deleting `clusterLocales`, `unlocalizePath`, the whole `OG_LOCALES` map and Italian. 47 lines merged in the last two days.

Tonight's run would also have deleted the `date.today` translation from **all eleven languages**, which #1200 merged today.

CI catches this only when the deleted thing is code something else imports. On 12 Aug it was data, so it compiled, stayed green, and shipped.

## The change

Invert the rule. Instead of copying everything and undoing the human parts, copy back only the three paths the pipeline writes:

```
site/src/i18n/content
site/src/i18n/review
site/src/i18n/manifest.json
```

Anything not named is never touched, so a file added later is protected without anyone remembering it exists. The failure direction inverts too: forgetting to name a generated path costs one re-translation of that path, where forgetting to name a hand-written path deleted it.

Copied per path rather than in one command, so a path the branch has not created yet loses only its own progress instead of discarding every path's.

### Why `locales/` is excluded rather than listed

It is not purely generated. It is lobe's entry (`locales/en.json`) plus its `outputLocales`, and `it` is in this workflow's `SUPPORTED` list but **not** in `.i18nrc.ui.cjs` `outputLocales`, so nothing regenerates `locales/it.json` at all.

Resuming that layer also buys nothing. Main is ahead of the branch on every locale, 206 keys against 205 and Italian 1 against 0, and `locale:ui` fills only missing keys. Copying it back could only ever discard merged strings.

### The failure-save path had the same defect

It preferred the branch's copy of `locales/` over main's, which banks a regression the moment someone merges a UI string. It now always takes main's. With the resume no longer reading that layer from the branch, there is no banked UI progress left to preserve.

## Verification

Both steps replayed against the real `origin/i18n/hub-translations`:

| Check | Result |
| --- | --- |
| `config.ts`, `index.ts`, `ui.ts`, `utils.ts` | byte-identical to main, **while naming none of them** |
| `human/`, `overrides/`, `reviews/` | untouched, no restore needed |
| `date.today` across all 12 locale files | present in all 12 |
| `content/`, `review/`, `manifest.json` | still carried forward, 20 files |
| A deliberately absent path | logs and continues, does not abort under `set -euo pipefail` |
| YAML parse, `bash -n` on both changed steps | pass |

Before the change the same replay returns `config.ts -23`, `ui.ts -4`, `utils.ts -20`.

## Note on #1196

Not fixed here, deliberately. It is generated output and the fix belongs in the workflow. Once this lands, close #1196 and let the next scheduled run open a clean one.

---

**Update 2026-09-01.** The nightly ran overnight (`2c24f152`, 05:55 UTC) and banked `date.today` onto the automation branch, so the "all eleven languages" figure above is now historical: as of today only `locales/it.json` would still lose it, because `it` is in this workflow's `SUPPORTED` list but not in `.i18nrc.ui.cjs` `outputLocales`. The three TypeScript deletions (`config.ts -23`, `ui.ts -4`, `utils.ts -20`) are unchanged and still live on the branch. The key counts that were quoted in the two code comments went stale for the same reason and have been replaced with the reasoning behind them.
