### PR TITLE
Fix 403 CSRF rejection on the MiniMax-H3 demo through comfy.org

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -253,6 +253,15 @@ export default defineConfig({
     skewProtection: true,
   }),
 
+  // The site is served through comfy.org's Framer rewrite, so browsers send
+  // `Origin: https://comfy.org` while requests reach Astro addressed to the
+  // Vercel host — Astro's origin check can never pass and 403s every form
+  // POST (e.g. the MiniMax demo's /run). On-demand mutating routes enforce
+  // their own origin allowlist instead (see src/lib/demos/mmh3/server.ts).
+  security: {
+    checkOrigin: false,
+  },
+
   build: {
     concurrency: Math.max(1, os.cpus().length),
     inlineStylesheets: 'auto',

--- a/site/src/lib/demos/mmh3/server.ts
+++ b/site/src/lib/demos/mmh3/server.ts
@@ -38,3 +38,36 @@ export function describeError(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
 }
+
+/**
+ * Origin guard for the demo's mutating routes (POST /run, DELETE /job/[id]).
+ *
+ * Astro's built-in `security.checkOrigin` compares the Origin header against
+ * the host the request arrived on, which can never match here: the page is
+ * served through comfy.org's Framer rewrite, so browsers send
+ * `Origin: https://comfy.org` while Astro receives the request addressed to
+ * the Vercel deployment. That check is therefore disabled in astro.config.mjs
+ * and replaced by this allowlist, which accepts the sites this demo actually
+ * runs on and still keeps third-party pages from driving the GPU deployment
+ * from their visitors' browsers.
+ */
+export function crossSiteRejection(request: Request): Response | null {
+  const origin = request.headers.get('origin');
+  // Non-browser clients (curl, server-to-server) send no Origin header; the
+  // guard only exists to stop other *websites*, so let those through.
+  if (!origin) return null;
+
+  try {
+    const host = new URL(origin).hostname;
+    const allowed =
+      host === 'comfy.org' ||
+      host.endsWith('.comfy.org') ||
+      host.endsWith('.vercel.app') || // preview + production deployments
+      host === 'localhost' ||
+      host === '127.0.0.1'; // local dev
+    if (allowed) return null;
+  } catch {
+    // Malformed Origin header — treat as cross-site.
+  }
+  return jsonResponse({ error: 'Cross-site requests are not allowed.' }, 403);
+}

--- a/site/src/pages/workflows/api/minimax-h3-multiref/job/[id].ts
+++ b/site/src/pages/workflows/api/minimax-h3-multiref/job/[id].ts
@@ -8,9 +8,12 @@ import {
   type JobOutput,
   type JobStatusResponse,
 } from '@/lib/demos/mmh3/config';
-import { comfyClient, describeError, jsonResponse } from '@/lib/demos/mmh3/server';
+import { comfyClient, crossSiteRejection, describeError, jsonResponse } from '@/lib/demos/mmh3/server';
 
-export const DELETE: APIRoute = async ({ params }) => {
+export const DELETE: APIRoute = async ({ params, request }) => {
+  const rejected = crossSiteRejection(request);
+  if (rejected) return rejected;
+
   const id = params.id;
   if (!id) return jsonResponse({ error: 'Missing job id' }, 400);
 

--- a/site/src/pages/workflows/api/minimax-h3-multiref/run.ts
+++ b/site/src/pages/workflows/api/minimax-h3-multiref/run.ts
@@ -10,7 +10,7 @@ import {
   type DemoSettings,
   type JobActionResponse,
 } from '@/lib/demos/mmh3/config';
-import { comfyClient, describeError, jsonResponse } from '@/lib/demos/mmh3/server';
+import { comfyClient, crossSiteRejection, describeError, jsonResponse } from '@/lib/demos/mmh3/server';
 
 function coerceSettings(raw: unknown): DemoSettings {
   const input = (raw ?? {}) as Partial<DemoSettings>;
@@ -35,6 +35,9 @@ function coerceSettings(raw: unknown): DemoSettings {
 }
 
 export const POST: APIRoute = async ({ request }) => {
+  const rejected = crossSiteRejection(request);
+  if (rejected) return rejected;
+
   let form: FormData;
   try {
     form = await request.formData();


### PR DESCRIPTION
## Summary

Follow-up to [#1213](https://github.com/Comfy-Org/workflow_templates/pull/1213). With the 404 fixed, running the MiniMax-H3 demo on `comfy.org/workflows/minimax-h3-multiref/` now fails one layer deeper:

```
POST https://comfy.org/workflows/api/minimax-h3-multiref/run → 403
"Cross-site POST form submissions are forbidden"
```

**Root cause:** that message is Astro's built-in CSRF protection (`security.checkOrigin`, on by default once any route is `prerender: false`). It compares the browser's `Origin` header against the hostname the request *arrives on*. Behind comfy.org's Framer rewrite those can never match: the browser stamps `Origin: https://comfy.org`, but Framer forwards the request addressed to the Vercel deployment host. Every form POST through the proxy is falsely flagged as cross-site — even though it's genuinely same-origin from the user's side.

This is also why previews never showed it: on a `*.vercel.app` URL there's no proxy, page and API share a hostname, and the check trivially passes. Astro's dev server never arms the check at all, so only production-through-comfy.org exercises this path.

## ELI5

The doorman from the last fix now lets the demo's requests into the right room — but the room has a paranoid clerk (Astro's CSRF check). Every request carries a return address written by your browser ("comfy.org"), and the clerk compares it to the name on the building he works in ("…vercel.app"). Because the doorman re-envelopes every letter to deliver it to the Vercel building, the addresses never match, and the clerk shouts "forgery!" at perfectly honest mail. The fix retires the clerk's building-name comparison and instead gives him a short list of trusted return addresses.

## Changes

- **`site/astro.config.mjs`** — `security: { checkOrigin: false }`: the host comparison is structurally incompatible with serving the site behind a rewriting proxy.
- **`site/src/lib/demos/mmh3/server.ts`** — new `crossSiteRejection()` guard that judges the `Origin` header against an allowlist (`comfy.org`, `*.comfy.org`, `*.vercel.app` for previews/production, `localhost`), so third-party sites still can't drive the GPU deployment from their visitors' browsers. Requests with no `Origin` (curl, server-to-server) pass — the guard exists to stop other *websites*.
- **`run.ts` / `job/[id].ts`** — the mutating routes (`POST /run`, `DELETE /job/:id`) call the guard first.

## Verification

- Astro's middleware source confirms the exact 403 string and trigger condition (form-like content-type + origin/host mismatch); rebuilding this project bakes `checkOrigin: false` into the server manifest (it was `true` before).
- Dev-server checks of the guard: a form POST with `Origin: https://comfy.org` passes through to route validation; `Origin: https://evil.example` gets the allowlist 403.
- All 770 site unit tests pass; ESLint clean.
- ⚠️ Previews can't exercise the proxy path (same-origin by construction) — the definitive test is production through comfy.org after merge + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xL9uRkjmL5QHdMWD8rUu1

---
_Generated by [Claude Code](https://claude.ai/code/session_011xL9uRkjmL5QHdMWD8rUu1)_