### PR TITLE
fix(site): stop advertising hreflang=it, an unbuilt route that 404s

### DIFF
--- a/site/src/pages/[locale]/workflows/[username].astro
+++ b/site/src/pages/[locale]/workflows/[username].astro
@@ -28,6 +28,7 @@ import {
 } from '../../../lib/hub-api';
 import { fetchRankingMap } from '../../../lib/ranking';
 import { localizeCards } from '../../../lib/i18n/localize-cards';
+import { INDEXABLE_LOCALES } from '../../../lib/i18n/locales';
 import { creatorOgUrl } from '../../../lib/og-url';
 import { buildToolbarLabels } from '../../../lib/toolbar';
 import { getSocialDisplay } from '../../../lib/social-links';
@@ -162,6 +163,10 @@ if (!profileFound && serialized.length === 0) {
 }
 
 const canonicalUrl = absoluteUrl(`/workflows/${slug}/`);
+// Same content/cluster as the English creator-profile page; advertise only
+// the locales actually flipped on, not BaseLayout's full-LANGUAGES default
+// (which includes "it", unbuilt and 404ing).
+const hreflangLocales: Locale[] = [DEFAULT_LOCALE, ...INDEXABLE_LOCALES];
 const socialLinks = websiteUrls.map(getSocialDisplay);
 
 const structuredData = {
@@ -180,6 +185,8 @@ const structuredData = {
   ogImage={creatorOgUrl(displayName, slug!, avatarUrl || undefined)}
   structuredData={structuredData}
   locale={typedLocale}
+  hreflangBasePath={`/workflows/${slug}/`}
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/src/pages/workflows/[username].astro
+++ b/site/src/pages/workflows/[username].astro
@@ -19,12 +19,13 @@ import WorkflowGrid from '../../components/hub/WorkflowGrid.vue';
 import { buildToolbarLabels } from '../../lib/toolbar';
 import { getLocaleFromPath } from '../../i18n/utils';
 import { absoluteUrl } from '../../config/site';
-import { DEFAULT_LOCALE } from '../../i18n/config';
+import { DEFAULT_LOCALE, type Locale } from '../../i18n/config';
 import { listWorkflowIndex, getProfile, getWorkflow, toTemplateData, extractShareId, getProfileCache, serializeIndexEntry, type SerializedTemplate } from '../../lib/hub-api';
 import { fetchRankingMap } from '../../lib/ranking';
 import { creatorOgUrl, workflowOgUrl } from '../../lib/og-url';
 import { serializeJsonLdForScript, buildWorkflowBreadcrumb } from '../../lib/structured-data';
 import { getSocialDisplay } from '../../lib/social-links';
+import { INDEXABLE_LOCALES } from '../../lib/i18n/locales';
 
 // ISR: cache for 60s, serve stale for up to 10 min while revalidating
 Astro.response.headers.set(
@@ -141,6 +142,11 @@ if (!isDetailPage) {
 }
 
 const canonicalUrl = absoluteUrl(`/workflows/${slugParam}/`);
+// This page (both the creator-profile and workflow-detail branches below) is
+// always locale-indexable itself; advertise only the locales actually flipped
+// on, not BaseLayout's full-LANGUAGES default (which includes "it", unbuilt
+// and 404ing).
+const hreflangLocales: Locale[] = [DEFAULT_LOCALE, ...INDEXABLE_LOCALES];
 
 const socialLinks = websiteUrls.map(getSocialDisplay);
 
@@ -180,6 +186,7 @@ const detailBreadcrumb = detailData
   ogType="article"
   structuredData={detailStructuredData ?? undefined}
   hreflangBasePath={`/workflows/${slugParam}/`}
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >
@@ -200,6 +207,8 @@ const detailBreadcrumb = detailData
   description={description || `Workflows by ${displayName}`}
   canonicalUrl={canonicalUrl}
   ogImage={creatorOgUrl(displayName, slugParam!, avatarUrl || undefined)}
+  hreflangBasePath={`/workflows/${slugParam}/`}
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/src/pages/workflows/category/[type].astro
+++ b/site/src/pages/workflows/category/[type].astro
@@ -13,6 +13,8 @@ import { buildToolbarLabels } from '../../../lib/toolbar';
 import { badgeVariants } from '../../../components/ui/badge';
 import { serializeJsonLdForScript, buildWorkflowBreadcrumb } from '../../../lib/structured-data';
 import { loadSerializedTemplates, type MediaType } from '../../../lib/hub-api';
+import { DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
+import { INDEXABLE_LOCALES } from '../../../lib/i18n/locales';
 
 const categoryTranslationKeys: Record<MediaType, string> = {
   image: 'category.image',
@@ -41,6 +43,10 @@ const templates = allSerialized.filter((tmpl) => tmpl.mediaType === type);
 
 const basePath = categoryPath(type);
 const canonicalUrl = absoluteUrl(localizeUrl(basePath, locale));
+// This English page is always indexable itself; advertise only the locales
+// actually flipped on, not BaseLayout's full-LANGUAGES default (which
+// includes "it", unbuilt and 404ing).
+const hreflangLocales: Locale[] = [DEFAULT_LOCALE, ...INDEXABLE_LOCALES];
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -170,6 +176,8 @@ const serialized = templates;
   canonicalUrl={canonicalUrl}
   ogImage="/brand/og-default-v3.png"
   structuredData={structuredData}
+  hreflangBasePath={basePath}
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/src/pages/workflows/creators.astro
+++ b/site/src/pages/workflows/creators.astro
@@ -14,8 +14,15 @@ import BackButton from '../../components/BackButton.astro';
 import { getLocaleFromPath } from '../../i18n/utils';
 import { creatorPath } from '../../lib/routes';
 import { absoluteUrl } from '../../config/site';
-import { listWorkflowIndex, getProfileCache, serializeIndexEntry, type SerializedTemplate } from '../../lib/hub-api';
+import {
+  listWorkflowIndex,
+  getProfileCache,
+  serializeIndexEntry,
+  type SerializedTemplate,
+} from '../../lib/hub-api';
 import { fetchRankingMap } from '../../lib/ranking';
+import { DEFAULT_LOCALE, type Locale } from '../../i18n/config';
+import { INDEXABLE_LOCALES } from '../../lib/i18n/locales';
 
 const locale = getLocaleFromPath(Astro.url.pathname);
 const [profiles, rankingMap] = await Promise.all([getProfileCache(), fetchRankingMap()]);
@@ -57,12 +64,18 @@ const sortedCreators = Array.from(creatorMap.values()).sort(
 );
 
 const canonicalUrl = absoluteUrl('/workflows/creators/');
+// This English page is always indexable itself; advertise only the locales
+// actually flipped on, not BaseLayout's full-LANGUAGES default (which
+// includes "it", unbuilt and 404ing).
+const hreflangLocales: Locale[] = [DEFAULT_LOCALE, ...INDEXABLE_LOCALES];
 ---
 
 <BaseLayout
   title="Top Creators - ComfyUI Workflow Templates"
   description="Discover the world's top ComfyUI workflow creators and their best templates."
   canonicalUrl={canonicalUrl}
+  hreflangBasePath="/workflows/creators/"
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/src/pages/workflows/index.astro
+++ b/site/src/pages/workflows/index.astro
@@ -13,6 +13,15 @@ import { absoluteUrl } from '../../config/site';
 import { loadSerializedTemplates } from '../../lib/hub-api';
 import { getFeatured, featuredPreloadImage } from '../../lib/featured';
 import { buildToolbarLabels, buildFacetsConfig } from '../../lib/toolbar';
+import { DEFAULT_LOCALE, type Locale } from '../../i18n/config';
+import { INDEXABLE_LOCALES } from '../../lib/i18n/locales';
+
+// This English index is always indexable itself; it only needs to advertise
+// the locales that are actually flipped on (INDEXABLE_LOCALES), not every
+// locale the app happens to have UI strings for. Omitting this and falling
+// back to BaseLayout's default advertised every SUPPORTED_HUB_LOCALES entry,
+// including "it", which has no built /it/workflows/ route and 404s.
+const hreflangLocales: Locale[] = [DEFAULT_LOCALE, ...INDEXABLE_LOCALES];
 
 const locale = getLocaleFromPath(Astro.url.pathname);
 
@@ -50,6 +59,8 @@ const facetsConfig = buildFacetsConfig(locale);
   ogImage="/brand/og-default-v3.png"
   ogDescription={t('meta.ogDescription', locale)}
   structuredData={structuredData}
+  hreflangBasePath="/workflows/"
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/src/pages/workflows/model/[name].astro
+++ b/site/src/pages/workflows/model/[name].astro
@@ -19,6 +19,9 @@ import { getCloudCtaUrl, getCloudLandingUrl, getPricingUrl } from '../../../lib/
 import { buildToolbarLabels } from '../../../lib/toolbar';
 import { loadModelContent } from '../../../lib/workflow-pages/content-loaders';
 import { useCasesFeaturingModel } from '../../../lib/workflow-pages/use-case-resolver';
+import { DEFAULT_LOCALE } from '../../../i18n/config';
+import { INDEXABLE_LOCALES } from '../../../lib/i18n/locales';
+import { alternatesFor } from '../../../lib/i18n/listing-indexing';
 import { buildModelPageMeta, isModelPageIndexable } from '../../../lib/workflow-pages/seo-page';
 import {
   loadCatalog,
@@ -95,6 +98,19 @@ const { hasQualityContent, h1, title, description, subheading } = buildModelPage
 const qualityContent = hasQualityContent ? content : null;
 
 const noindex = !isModelPageIndexable(group, templates.length, content);
+// This English page is always locale-indexable itself; the only reason to
+// withhold its alternates is its own noindex, same reconciliation the
+// localized sibling page uses. hreflangLocalized={true} previously advertised
+// BaseLayout's full-LANGUAGES default, which includes "it" (unbuilt, 404s).
+const hreflangLocales = alternatesFor(
+  {
+    indexable: true,
+    canonicalPath: basePath,
+    noindex: false,
+    hreflangLocales: [DEFAULT_LOCALE, ...INDEXABLE_LOCALES],
+  },
+  noindex
+);
 
 const leadShareId = templates.find((template) => template.shareId)?.shareId;
 const modelCtaUrl = (placement: string) =>
@@ -169,7 +185,7 @@ const relatedCards = resolveRailImages(relatedCardData, group.templates, {
   structuredData={structuredData}
   locale={locale}
   hreflangBasePath={basePath}
-  hreflangLocalized={true}
+  hreflangLocales={hreflangLocales}
   theme="dark"
   noindex={noindex}
   hideDefaultFooter

--- a/site/src/pages/workflows/tag/[tag].astro
+++ b/site/src/pages/workflows/tag/[tag].astro
@@ -13,6 +13,8 @@ import { badgeVariants } from '../../../components/ui/badge';
 import { loadSerializedTemplates, type SerializedTemplate } from '../../../lib/hub-api';
 import { buildToolbarLabels } from '../../../lib/toolbar';
 import { serializeJsonLdForScript, buildWorkflowBreadcrumb } from '../../../lib/structured-data';
+import { DEFAULT_LOCALE, type Locale } from '../../../i18n/config';
+import { INDEXABLE_LOCALES } from '../../../lib/i18n/locales';
 
 export async function getStaticPaths() {
   const allSerialized = await loadSerializedTemplates(() => getCollection('templates'));
@@ -51,6 +53,10 @@ const { tag } = Astro.params;
 const locale = getLocaleFromPath(Astro.url.pathname);
 const basePath = `/workflows/tag/${tag}/`;
 const canonicalUrl = absoluteUrl(localizeUrl(basePath, locale));
+// This English page is always indexable itself; advertise only the locales
+// actually flipped on, not BaseLayout's full-LANGUAGES default (which
+// includes "it", unbuilt and 404ing).
+const hreflangLocales: Locale[] = [DEFAULT_LOCALE, ...INDEXABLE_LOCALES];
 
 const title = `${tagName} ${SITE_NAME} - ${t('nav.templates', locale)}`;
 const description = `Browse ${templates.length} ComfyUI workflow templates tagged with "${tagName}". Free, ready-to-use AI generation workflows.`;
@@ -75,6 +81,8 @@ const serialized = templates;
   canonicalUrl={canonicalUrl}
   ogImage="/brand/og-default-v3.png"
   structuredData={structuredData}
+  hreflangBasePath={basePath}
+  hreflangLocales={hreflangLocales}
   theme="dark"
   hideDefaultFooter
 >

--- a/site/tests/unit/workflows-english-hreflang-coverage.test.ts
+++ b/site/tests/unit/workflows-english-hreflang-coverage.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Every English /workflows/* page that renders <BaseLayout> must pass an
+ * explicit hreflangLocales (or hreflangLocalized={false} for an English-only
+ * route) instead of relying on BaseLayout's default.
+ *
+ * That default (clusterLocales(true) with no explicit list) resolves to every
+ * SUPPORTED_HUB_LOCALES entry — the locales the hub builds routes for, not the
+ * INDEXABLE_LOCALES subset that has actually cleared native review and has a
+ * live /{locale}/... route. "it" sits in the gap between those two sets today:
+ * it is supported (LANGUAGES has an entry, so /it/workflows/* is a candidate
+ * route the hub "deliberately builds and serves") but not indexable (no native
+ * review wave has run, so no /it/... page is actually built). Falling through
+ * to the default therefore advertised <link rel="alternate" hreflang="it"
+ * href=".../it/workflows/..."> pointing at a 404 on every un-fixed page.
+ *
+ * This is a guard against the same omission recurring on a new /workflows/*
+ * page, not a render test — it keys off the source text of each route file.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROUTES_DIR = path.join(process.cwd(), 'src', 'pages', 'workflows');
+
+// This page is unconditionally noindex — its hreflang cluster is moot for
+// crawling/indexing, and it is a one-off interactive demo, not part of the
+// hub's localization surface. Out of scope for this guard.
+const EXEMPT_ROUTES = new Set(['minimax-h3-multiref.astro']);
+
+function astroFilesIn(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return astroFilesIn(full);
+    return entry.name.endsWith('.astro') ? [full] : [];
+  });
+}
+
+describe('English /workflows/* hreflang coverage', () => {
+  const routes = astroFilesIn(ROUTES_DIR)
+    .map((file) => ({
+      route: path.relative(ROUTES_DIR, file),
+      source: fs.readFileSync(file, 'utf-8'),
+    }))
+    .filter(({ route }) => !EXEMPT_ROUTES.has(route))
+    .filter(({ source }) => /<BaseLayout\b/.test(source));
+
+  it('finds the routes it is meant to be checking', () => {
+    // Without this the suite would pass vacuously if the directory ever moved
+    // or every route were accidentally added to EXEMPT_ROUTES.
+    expect(routes.length).toBeGreaterThan(4);
+  });
+
+  it('never falls through to hreflangLocalized/BaseLayout defaults', () => {
+    const uncovered = routes
+      .filter(
+        ({ source }) => !/hreflangLocales=\{/.test(source) && !/hreflangLocalized=\{false\}/.test(source)
+      )
+      .map(({ route }) => route);
+
+    expect(
+      uncovered,
+      `These English /workflows/* routes render <BaseLayout> without an explicit ` +
+        `hreflangLocales (or hreflangLocalized={false}), so they fall through to ` +
+        `BaseLayout's default cluster — every SUPPORTED_HUB_LOCALES entry, which ` +
+        `includes locales with no built route (e.g. "it"): ${uncovered.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('never derives hreflangLocales from LANGUAGES/SUPPORTED_HUB_LOCALES/AVAILABLE_APP_LOCALES', () => {
+    // A page could pass the hreflangLocales= check above while still reaching
+    // for the wrong source set (e.g. Object.keys(LANGUAGES) or LOCALES instead
+    // of INDEXABLE_LOCALES). Flag any route whose hreflangLocales computation
+    // touches one of those wider sets directly.
+    const wrongSource = routes
+      .filter(({ source }) => /hreflangLocales=\{/.test(source))
+      .filter(({ source }) =>
+        /\.\.\.(LANGUAGES|LOCALES|SUPPORTED_HUB_LOCALES|AVAILABLE_APP_LOCALES)\b/.test(source) ||
+        /Object\.keys\(LANGUAGES\)/.test(source)
+      )
+      .map(({ route }) => route);
+
+    expect(
+      wrongSource,
+      `These routes compute hreflangLocales from a wider locale set than ` +
+        `INDEXABLE_LOCALES, which will advertise unbuilt locale routes: ${wrongSource.join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/site/tests/unit/workflows-english-hreflang-coverage.test.ts
+++ b/site/tests/unit/workflows-english-hreflang-coverage.test.ts
@@ -70,12 +70,15 @@ describe('English /workflows/* hreflang coverage', () => {
     // A page could pass the hreflangLocales= check above while still reaching
     // for the wrong source set (e.g. Object.keys(LANGUAGES) or LOCALES instead
     // of INDEXABLE_LOCALES). Flag any route whose hreflangLocales computation
-    // touches one of those wider sets directly.
+    // touches one of those wider sets directly: spread (...LANGUAGES),
+    // Object.keys(LANGUAGES), or a bare assignment (= LOCALES).
+    const WIDE_LOCALE_SETS = 'LANGUAGES|LOCALES|SUPPORTED_HUB_LOCALES|AVAILABLE_APP_LOCALES';
     const wrongSource = routes
       .filter(({ source }) => /hreflangLocales=\{/.test(source))
       .filter(({ source }) =>
-        /\.\.\.(LANGUAGES|LOCALES|SUPPORTED_HUB_LOCALES|AVAILABLE_APP_LOCALES)\b/.test(source) ||
-        /Object\.keys\(LANGUAGES\)/.test(source)
+        new RegExp(`\\.\\.\\.(${WIDE_LOCALE_SETS})\\b`).test(source) ||
+        /Object\.keys\(LANGUAGES\)/.test(source) ||
+        new RegExp(`(?:hreflangLocales|hreflangLocales:\\s*Locale\\[\\])\\s*(?::\\s*Locale\\[\\])?\\s*=\\s*(${WIDE_LOCALE_SETS})\\b`).test(source)
       )
       .map(({ route }) => route);
 


### PR DESCRIPTION
## Summary

Six English `/workflows/*` listing pages advertised `<link rel="alternate" hreflang="it" href="https://comfy.org/it/workflows/...">`, and `/it/workflows/...` 404s — confirmed live on `/workflows/`, `/workflows/creators/`, and `/workflows/comfyui/` before this fix. Flagged by nav in [Comfy-Org/ComfyUI_frontend#16247](https://github.com/Comfy-Org/ComfyUI_frontend/pull/16247) as out of scope for that PR ("the workflows app... declares `it`, which 404s. Separate PR.").

## Root cause

`HreflangTags.astro`'s default (`clusterLocales(localized)` with no explicit `locales` list) resolves to every `SUPPORTED_HUB_LOCALES` entry — the locales the hub *builds routes for* — not `INDEXABLE_LOCALES`, the reviewed subset that actually has a live `/{locale}/...` page. `locales.ts`'s own doc comment describes this narrowing explicitly:

```
AVAILABLE_APP_LOCALES  ⊇  SUPPORTED_HUB_LOCALES  ⊇  INDEXABLE_LOCALES
```

`it` sits in the gap: it's in `LANGUAGES` (so `SUPPORTED_HUB_LOCALES` includes it — the hub "deliberately builds and serves" it as a route shape) but has never cleared native review, so it's absent from `INDEXABLE_LOCALES` and no `/it/...` page is ever actually built.

Six English routes render `<BaseLayout>` without passing an explicit `hreflangLocales`, so they silently fall through to the broad default: `workflows/index.astro`, `workflows/category/[type].astro`, `workflows/tag/[tag].astro`, `workflows/model/[name].astro` (which explicitly set `hreflangLocalized={true}`, same default), `workflows/creators.astro`, and `workflows/[username].astro`. Their localized `[locale]/workflows/*` siblings already avoid this — they compute `hreflangLocales` from `listingIndexing()`/`alternatesFor()`, which read `INDEXABLE_LOCALES` — except `[locale]/workflows/[username].astro`, which had the same gap and is also fixed here.

## Fix

Each affected page now passes an explicit `hreflangLocales={[DEFAULT_LOCALE, ...INDEXABLE_LOCALES]}` (or, for the model route, `alternatesFor()`'s reconciliation with the page's own `noindex`, matching its localized sibling's pattern exactly). No change to `HreflangTags.astro`, `SEOHead.astro`, `BaseLayout.astro`, or `clusterLocales`'s default — those are flagged "DO NOT remove/modify without care" in CLAUDE.md, and the existing `seohead-render.test.ts`/`i18n-og-locale.test.ts` tests assert that broad default as correct at the component level. The bug is specific callers not overriding it, not the shared default.

## Guard test

`workflows-english-hreflang-coverage.test.ts`: a static source-scan over every English `/workflows/*` route, same pattern as the existing `i18n-localized-routes-coverage.test.ts`. Flags any route rendering `<BaseLayout>` without `hreflangLocales=` or `hreflangLocalized={false}`, and separately flags any route whose `hreflangLocales` is derived from `LANGUAGES`/`LOCALES`/`SUPPORTED_HUB_LOCALES`/`AVAILABLE_APP_LOCALES` instead of `INDEXABLE_LOCALES`. Verified the guard actually catches the regression: it fails, naming the exact file, when the fix to `workflows/index.astro` is reverted.

## Not in this PR

- `minimax-h3-multiref.astro` is unconditionally `noindex`, so its hreflang cluster is moot for crawling/indexing; it's a one-off interactive demo, not part of the hub's localization surface. Left untouched to keep this change scoped to indexed pages.
- A pre-existing, unrelated `prettier-plugin-astro` parse failure on `workflows/[username].astro` (reproduces on `main` before this change, confirmed via `git stash`) is not fixed here — separate issue, separate file concern, not something I introduced.

## Test plan

- `pnpm test` — 812/812 passing (3 new)
- `pnpm run lint` — clean
- `pnpm run check` (astro check) — 0 errors (was 7 type errors before typing `hreflangLocales` as `Locale[]`; the spread `[DEFAULT_LOCALE, ...INDEXABLE_LOCALES]` widens to `string[]` without an explicit annotation)
- Confirmed live 404 on `/it/workflows/` and `/it/workflows/comfyui/` before this fix (both still 404 after — this only removes the false hreflang advertisement, it doesn't build the `it` route, which is the correct fix per nav's report: the route is genuinely not ready, the tag was the lie)
