### PR TITLE
Fix Image Tools and Video Tools sidebar icons (0.11.52)

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-core"
-version = "0.3.328"
+version = "0.3.329"
 description = "Core helpers for ComfyUI workflow templates"
 readme = {text = "Core helpers for ComfyUI workflow templates.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/packages/core/src/comfyui_workflow_templates_core/manifest.json
+++ b/packages/core/src/comfyui_workflow_templates_core/manifest.json
@@ -6281,7 +6281,7 @@
       "assets": [
         {
           "filename": "index.json",
-          "sha256": "d8d5d6cc854fc0963d78c7ce4174af53697c6acbc9fd35b1df343ad1690af715"
+          "sha256": "0fea0b23a0b454168072f4daa473586ae9cbfd934e6cb4eb0009640e4006b76c"
         }
       ],
       "cdn": {
@@ -6295,7 +6295,7 @@
       "assets": [
         {
           "filename": "index.ar.json",
-          "sha256": "6533d0ec53f7b42d5b6632a636d7ed8bc2dbed3adfa35d6bcac14f0603586018"
+          "sha256": "80d107f22a66d40a0393a57b49411ea6335c81e14f42d149c2b64d31f6683969"
         }
       ],
       "cdn": {
@@ -6309,7 +6309,7 @@
       "assets": [
         {
           "filename": "index.es.json",
-          "sha256": "6522bafdce79763d4b411e14886e956d3f8d7d6b1f3d976dafa8d67e21c2c079"
+          "sha256": "6fd3648f1d737a734d7a11046f949736322a327e6c5dc8d4cf0eae59d9bede02"
         }
       ],
       "cdn": {
@@ -6323,7 +6323,7 @@
       "assets": [
         {
           "filename": "index.fa.json",
-          "sha256": "98aa7bd67bc500705d402e3cc5087a2a7fdbab11427ced5b9df53c148f58491e"
+          "sha256": "9bc840c8e93b84f94ebffb425de19e862d0f09a819cbf1433af0da216831b896"
         }
       ],
       "cdn": {
@@ -6337,7 +6337,7 @@
       "assets": [
         {
           "filename": "index.fr.json",
-          "sha256": "34a3ce8dde7bce50076dbd26fc287d89955247a5588d7f85da4585212f8b7952"
+          "sha256": "080cece3d490adc781af326e9f150384fd961e5cd0db4c407dda715e32d4ac5d"
         }
       ],
       "cdn": {
@@ -6351,7 +6351,7 @@
       "assets": [
         {
           "filename": "index.ja.json",
-          "sha256": "d76949a8feb407ab31134dd71d9e4b7701019f5d0c459f437c4d72b812a26dfd"
+          "sha256": "3a71c4ad9dd0fc6f295c93c4e401d0634167ddf228bc60df7edce3a5da55c5c4"
         }
       ],
       "cdn": {
@@ -6365,7 +6365,7 @@
       "assets": [
         {
           "filename": "index.ko.json",
-          "sha256": "1df2c66d48e80fbe878eb2e58043f3fa5cd9e2b01a06c65b0777d9cf819adf57"
+          "sha256": "bceb5d0121effb094ee60d3333d3bcc1d0a40d10c4dff70ebe62bcc1283a7022"
         }
       ],
       "cdn": {
@@ -6393,7 +6393,7 @@
       "assets": [
         {
           "filename": "index.pt-BR.json",
-          "sha256": "bafd8066a75098f1ceab43fbb6af537273ac160b62deb5e569886894c5e2d764"
+          "sha256": "9eeac1f1a31c14a5c646416f3c7af459c465e9031dc4954b93db264cd25ceb83"
         }
       ],
       "cdn": {
@@ -6407,7 +6407,7 @@
       "assets": [
         {
           "filename": "index.ru.json",
-          "sha256": "6e0c857c730c879a1a75e90ee99502b85a14c622d8eea3c836270ebc91848c2b"
+          "sha256": "ce2eee3e8e055ff158391eadb4a0c26eef112d0becad8a5bf26be5bcc65903fd"
         }
       ],
       "cdn": {
@@ -6435,7 +6435,7 @@
       "assets": [
         {
           "filename": "index.tr.json",
-          "sha256": "c30541d2ceff563f56b90abb136f9d9e9e95ee9992e2b48990bd750cdbcf3b3b"
+          "sha256": "7bb81eff3c37631feedc82dc7db1eb8be1676213c62806b7e036a75813820154"
         }
       ],
       "cdn": {
@@ -6449,7 +6449,7 @@
       "assets": [
         {
           "filename": "index.zh.json",
-          "sha256": "ab81b27212b57381bc0d529174a5acfc4251f93691a313a602272b9376a1c03a"
+          "sha256": "3868e198ae95f03c31c1b9358316951b03faa386c14746d0f581228628a67558"
         }
       ],
       "cdn": {
@@ -6463,7 +6463,7 @@
       "assets": [
         {
           "filename": "index.zh-TW.json",
-          "sha256": "368a8dfd772cb823d2b762ab60c629ab44cc26f0d620979c85da58d7b53832e8"
+          "sha256": "a3486e854058105a8989fa7c858b1e71eca2f823f7cc0e9b162b7ccd3bb8782e"
         }
       ],
       "cdn": {

--- a/packages/json/pyproject.toml
+++ b/packages/json/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-json"
-version = "0.1.63"
+version = "0.1.64"
 description = "Workflow template JSON definitions for ComfyUI"
 readme = {text = "Workflow template JSON definitions for ComfyUI.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "comfyui-workflow-templates-core==0.3.328",
-    "comfyui-workflow-templates-json==0.1.63",
+    "comfyui-workflow-templates-core==0.3.329",
+    "comfyui-workflow-templates-json==0.1.64",
     "comfyui-workflow-templates-media-api==0.3.84",
     "comfyui-workflow-templates-media-video==0.3.101",
     "comfyui-workflow-templates-media-image==0.3.160",
@@ -28,14 +28,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-json = ["comfyui-workflow-templates-json==0.1.63"]
+json = ["comfyui-workflow-templates-json==0.1.64"]
 assets = ["comfyui-workflow-templates-media-assets-01==0.1.37"]
 api = ["comfyui-workflow-templates-media-api==0.3.84"]
 video = ["comfyui-workflow-templates-media-video==0.3.101"]
 image = ["comfyui-workflow-templates-media-image==0.3.160"]
 other = ["comfyui-workflow-templates-media-other==0.3.229"]
 all = [
-    "comfyui-workflow-templates-json==0.1.63",
+    "comfyui-workflow-templates-json==0.1.64",
     "comfyui-workflow-templates-media-assets-01==0.1.37",
     "comfyui-workflow-templates-media-api==0.3.84",
     "comfyui-workflow-templates-media-video==0.3.101",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.11.51"
+version = "0.11.52"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "نوع التوليد",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "أدوات الصور",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "نوع التوليد",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "أدوات الفيديو",
     "templates": [
       {

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "Tipo de generación",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "Herramientas de imagen",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "Tipo de generación",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "Herramientas de vídeo",
     "templates": [
       {

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "نوع تولید",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "ابزارهای تصویر",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "نوع تولید",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "ابزارهای ویدیو",
     "templates": [
       {

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "Type de génération",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "Outils image",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "Type de génération",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "Outils vidéo",
     "templates": [
       {

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "生成タイプ",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "画像ツール",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "生成タイプ",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "ビデオツール",
     "templates": [
       {

--- a/templates/index.json
+++ b/templates/index.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.json
+++ b/templates/index.json
@@ -16745,7 +16745,7 @@
   {
     "moduleName": "default",
     "category": "GENERATION TYPE",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "Image Tools",
     "isEssential": true,
     "type": "image",
@@ -18345,7 +18345,7 @@
   {
     "moduleName": "default",
     "category": "GENERATION TYPE",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "Video Tools",
     "isEssential": true,
     "type": "video",

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "생성 유형",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "이미지 도구",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "생성 유형",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "비디오 도구",
     "templates": [
       {

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "Tipo de geração",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "Ferramentas de imagem",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "Tipo de geração",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "Ferramentas de vídeo",
     "templates": [
       {

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "Тип генерации",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "Инструменты для изображений",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "Тип генерации",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "Инструменты для видео",
     "templates": [
       {

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "Üretim Türü",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "Görüntü Araçları",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "Üretim Türü",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "Video Araçları",
     "templates": [
       {

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "產生類型",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "圖像工具",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "產生類型",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "影片工具",
     "templates": [
       {

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -5975,14 +5975,6 @@
               "file": "interior_college.png",
               "mediaType": "image"
             }
-          ],
-          "outputs": [
-            {
-              "nodeId": 2,
-              "nodeType": "SaveImageAdvanced",
-              "file": "Seedream5.0_Pro_image_edit.png",
-              "mediaType": "image"
-            }
           ]
         },
         "thumbnail": ["input/interior_college.png","output/Seedream5.0_Pro_image_edit.png"],

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -16747,7 +16747,7 @@
     "type": "image",
     "isEssential": true,
     "category": "生成类型",
-    "icon": "icon-[lucide--sparkles]",
+    "icon": "icon-[lucide--maximize-2]",
     "title": "图像工具",
     "templates": [
       {
@@ -18347,7 +18347,7 @@
     "type": "video",
     "isEssential": true,
     "category": "生成类型",
-    "icon": "icon-[lucide--clapperboard]",
+    "icon": "icon-[lucide--wrench]",
     "title": "视频工具",
     "templates": [
       {

--- a/workflow_template_input_files.json
+++ b/workflow_template_input_files.json
@@ -5828,7 +5828,7 @@
         "input",
         "file"
       ],
-      "mime_type": "application/octet-stream"
+      "mime_type": "model/gltf-binary"
     },
     {
       "file_path": "input/transparent_rgb_gaming_mouse.png",

--- a/workflow_template_input_files.json
+++ b/workflow_template_input_files.json
@@ -5828,7 +5828,7 @@
         "input",
         "file"
       ],
-      "mime_type": "model/gltf-binary"
+      "mime_type": "application/octet-stream"
     },
     {
       "file_path": "input/transparent_rgb_gaming_mouse.png",


### PR DESCRIPTION
## Summary
- Image Tools and Video Tools showed empty sidebar icons because `sparkles` and `clapperboard` are not in the ComfyUI frontend Lucide CSS bundle (Tailwind only emits classes that appear as static strings in frontend source).
- Switch to `maximize-2` and `wrench`, which `categoryUtil.ts` already ships, and bump the root package to **0.11.52** for a PyPI release.

## Test plan
- [ ] Open the template selector sidebar and confirm Image Tools and Video Tools now show icons
- [ ] Confirm other essential categories (All, Popular, Image, Video, Use Cases, Node Basics) still render their existing icons
- [ ] After merge with `release`, confirm publish.yml uploads 0.11.52 to PyPI