### PR TITLE
Cut the comments down, and preload the image the detail hero actually paints

### DIFF
--- a/site/src/components/ThumbnailDisplay.astro
+++ b/site/src/components/ThumbnailDisplay.astro
@@ -12,7 +12,12 @@
 
 import type { ThumbnailVariant } from '../lib/hub-api';
 import { getStillImageUrl, getVideoFrameUrl } from '../lib/video-thumbnail';
-import { hubAssetUrl, hubMediaFor } from '../lib/hub-media';
+import {
+  HERO_STILL_WIDTH,
+  heroPaintsAnimatedStill,
+  hubAssetUrl,
+  hubMediaFor,
+} from '../lib/hub-media';
 import { isVideoFile, isAudioFile } from '../lib/media-utils';
 
 interface Props {
@@ -59,12 +64,6 @@ const primarySrc = hubAssetUrl(primaryOriginal);
 const secondarySrc = hubAssetUrl(secondaryOriginal);
 const isAnimated = mediaSubtype === 'webp';
 /**
- * Width the hero still is requested at. The box is declared 640x360 and the
- * animated sources are 350px wide, so Cloudflare returns the source size rather
- * than upscaling; 640 simply states the box we are sizing for.
- */
-const HERO_STILL_WIDTH = 640;
-/**
  * An eagerly-loaded animated WebP is the worst LCP element on the site.
  * Measured on the LTX-2.3 detail hero: 350x350, 52 frames, 1,870 KB, painted
  * into a 640x360 box, LCP 16.7 s on Lighthouse mobile with 16.0 s of that in
@@ -79,9 +78,23 @@ const HERO_STILL_WIDTH = 640;
  * Only when there is no re-encoded copy, which for animated WebP is always
  * (they are deliberately absent from the manifest) - if one exists, `primarySrc`
  * is already our own right-sized still and there is nothing to improve.
+ *
+ * `heroPaintsAnimatedStill` is the same guard the page's `<link rel="preload">`
+ * uses, and it is what keeps the two in step: the compare-slider and
+ * hover-dissolve branches below are checked BEFORE the animated one and win
+ * whenever there is a second thumbnail, in which case this still is never
+ * rendered and must not be preloaded either.
+ *
+ * The animation URL travels in `data-animated-src` and the `onerror` handler
+ * reads it from there rather than being built by interpolating the URL into a
+ * quoted JS string. A thumbnail filename is upstream data; one apostrophe in it
+ * would close that string and leave the rest as executable script.
  */
 const heroStillSrc =
-  isAnimated && loading === 'eager' && primarySrc === primaryOriginal
+  isAnimated &&
+  loading === 'eager' &&
+  primarySrc === primaryOriginal &&
+  heroPaintsAnimatedStill(thumbnails, variant)
     ? getStillImageUrl(primaryOriginal, HERO_STILL_WIDTH)
     : null;
 const hasSecondImage = thumbnails.length > 1;
@@ -305,7 +318,11 @@ const secondaryVideoPosterUrl = isSecondaryVideo
         draggable="false"
         sizes={sizes}
         class={imgClass}
-        onerror={heroStillSrc ? `this.onerror=null;this.src='${primarySrc}'` : undefined}
+        onerror={
+          heroStillSrc
+            ? 'this.onerror=null;const s=this.dataset.animatedSrc;delete this.dataset.animatedSrc;if(s)this.src=s'
+            : undefined
+        }
       />
     </div>
   ) : variant === 'zoomHover' ? (

--- a/site/src/lib/hub-media.ts
+++ b/site/src/lib/hub-media.ts
@@ -121,43 +121,95 @@ export function hubAssetUrl(url: string): string {
 }
 
 /**
+ * Width the detail hero still is requested at. Read by `ThumbnailDisplay` as
+ * well as by `detailHeroPreload` below: the preload and the element have to name
+ * the same URL, and two copies of the number are two chances to drift.
+ */
+export const HERO_STILL_WIDTH = 640;
+
+/**
+ * The variants `ThumbnailDisplay` checks BEFORE its animated-thumb branch. Each
+ * needs a second thumbnail to win, and when one does the still is never painted.
+ */
+const STILL_PREEMPTING_VARIANTS = new Set(['compareSlider', 'hoverDissolve']);
+
+/**
+ * Whether `ThumbnailDisplay` reaches the branch that paints a still and swaps
+ * the animation in after load. Exported so the component decides it from the
+ * same predicate `detailHeroPreload` below uses.
+ */
+export function heroPaintsAnimatedStill(
+  thumbnails: readonly string[] | undefined,
+  variant?: string | null
+): boolean {
+  if (!thumbnails?.length) return false;
+  const hasSecondImage = thumbnails.length > 1;
+  return !(hasSecondImage && STILL_PREEMPTING_VARIANTS.has(variant ?? ''));
+}
+
+/**
  * The image worth preloading for a detail hero, or null when there is none.
  *
- * `mediaSubtype` is needed because it is what `ThumbnailDisplay` branches on to
- * decide the hero is an animated WebP and paint a still instead of the 1.9 MB
- * original. The preload has to name the URL the element actually renders, so
- * the two read the same inputs and reach the same answer; naming the original
- * here would fetch both.
+ * Mirrors `ThumbnailDisplay` branch for branch, in its order, because a preload
+ * that names a URL the element does not render is a whole extra request for a
+ * picture nobody sees - and it takes `fetchpriority="high"` away from the one
+ * that IS the hero. Measured on `api_wan2_7_video_edit` in the PR preview: a
+ * 19 KB AVIF still preloaded at high priority that the compare slider never
+ * painted, in front of the 1,892 KB and 2,079 KB WebPs it did.
+ *
+ * So it reads the same three inputs the component branches on - the thumbnail
+ * list, the variant, and `mediaSubtype` - rather than only the first thumbnail.
  */
 export function detailHeroPreload(
-  thumbnail: string | null | undefined,
-  mediaSubtype?: string
+  thumbnails: readonly string[] | null | undefined,
+  mediaSubtype?: string,
+  variant?: string | null
 ): string | null {
-  if (!thumbnail) return null;
-  const url = thumbnailPath(thumbnail);
+  const primary = thumbnails?.[0];
+  if (!primary) return null;
+  const url = thumbnailPath(primary);
+
+  // Audio paints an icon, so there is no image worth fetching early.
+  if (isAudioFile(url)) return null;
+
   // A video hero paints its poster first, so that is the image to fetch early,
   // and the frame-transform fallback matters as much as the generated poster:
   // 27 of the catalog's videos have no generated copy, ThumbnailDisplay renders
   // exactly this URL for them, and without it their LCP image is preloaded not
   // at all. `thumbnailPath` is character-for-character what ThumbnailDisplay's
   // own `thumbUrl` produces, so the two cannot become separate requests.
-  //
-  // Mirrors what ThumbnailDisplay paints, branch for branch: a video shows its
-  // poster, audio shows an icon and so has no image worth fetching, and a still
-  // falls back to its ORIGINAL url. That last one was returning null, which
-  // meant the assets deliberately left out of the image manifest - the ones
-  // that saved under 15%, plus every animated WebP - rendered an LCP still that
-  // was never preloaded. `hubAssetUrl` already ends in the same `?? url`.
   if (isVideoFile(url)) return hubMediaFor(url)?.poster ?? getVideoFrameUrl(url);
-  if (isAudioFile(url)) return null;
-  const generated = hubImageFor(url);
-  if (generated) return generated;
-  // No generated copy and the hero is animated: ThumbnailDisplay paints the
-  // Cloudflare still and swaps the animation in after load, so the still is the
-  // LCP image and the only thing worth fetching early. HERO_STILL_WIDTH is
-  // mirrored there; both ask for 640, the box they render into.
-  if (mediaSubtype === 'webp') return getStillImageUrl(url, 640) ?? url;
-  return url;
+
+  // The compare slider layers two full-size images and puts `fetchpriority` on
+  // the SECOND one - the "After" - with the "Before" clipped over its left half.
+  // The second is therefore the one to fetch early; preloading the first would
+  // promote the lower-priority layer ahead of it. Skipped when the second is not
+  // an image, which `as="image"` could not fetch anyway.
+  const secondary = thumbnails?.[1];
+  if (variant === 'compareSlider' && secondary) {
+    const secondaryUrl = thumbnailPath(secondary);
+    if (!isVideoFile(secondaryUrl) && !isAudioFile(secondaryUrl)) return hubAssetUrl(secondaryUrl);
+  }
+
+  // Hover dissolve also needs a second thumbnail, but `fetchpriority` stays on
+  // the first, so the answer is the same as the default branch: the original,
+  // never the still, because that branch is checked before the animated one.
+  if (heroPaintsAnimatedStill(thumbnails, variant) && mediaSubtype === 'webp') {
+    const generated = hubImageFor(url);
+    // A generated copy IS already a right-sized still, so there is nothing to
+    // improve and `primarySrc` names it directly.
+    if (generated) return generated;
+    // Otherwise ThumbnailDisplay paints the Cloudflare still and swaps the
+    // animation in after load, so the still is the LCP image. Both sides read
+    // HERO_STILL_WIDTH, so they ask for the same box.
+    return getStillImageUrl(url, HERO_STILL_WIDTH) ?? url;
+  }
+
+  // zoomHover, hoverDissolve and the default: `primarySrc`, which is our copy
+  // when one exists and the ORIGINAL when it does not. Returning null here was
+  // why every asset left out of the image manifest rendered an LCP still that
+  // was never preloaded at all.
+  return hubAssetUrl(url);
 }
 
 /**

--- a/site/src/pages/[locale]/workflows/[slug].astro
+++ b/site/src/pages/[locale]/workflows/[slug].astro
@@ -184,7 +184,7 @@ const primaryThumbnail = thumbnails[0] || null;
 // worst LCP in the baseline, and there are 4,460 of these against 1,279 English
 // twins. Resolved through the helper ThumbnailDisplay renders from, so the
 // preload and the element cannot become two separate downloads.
-const heroPreload = detailHeroPreload(primaryThumbnail, data.mediaSubtype);
+const heroPreload = detailHeroPreload(thumbnails, data.mediaSubtype, data.thumbnailVariant);
 const ogImage = workflowOgUrl(
   data.title || data.name,
   primaryThumbnail ? primaryThumbnail : undefined,

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -139,7 +139,7 @@ const primaryThumbnail = thumbnails[0] || null;
 // Worst LCP in the baseline at 15.9 s, and it preloads nothing: the hero is
 // discovered by the parser after the stylesheet, behind whatever media the page
 // is already fetching. Same resolver ThumbnailDisplay renders from.
-const heroPreload = detailHeroPreload(primaryThumbnail, data.mediaSubtype);
+const heroPreload = detailHeroPreload(thumbnails, data.mediaSubtype, data.thumbnailVariant);
 const ogImage = workflowOgUrl(
   data.title || data.name,
   primaryThumbnail ? primaryThumbnail : undefined,

--- a/site/tests/unit/hub-media.test.ts
+++ b/site/tests/unit/hub-media.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { detailHeroPreload, hubMediaFor, landingHeroPreload } from '../../src/lib/hub-media';
+import {
+  HERO_STILL_WIDTH,
+  detailHeroPreload,
+  heroPaintsAnimatedStill,
+  hubAssetUrl,
+  hubMediaFor,
+  landingHeroPreload,
+} from '../../src/lib/hub-media';
 import { getStillImageUrl, getVideoFrameUrl } from '../../src/lib/video-thumbnail';
 import generatedAssets from '../../src/data/hub-media-assets.json';
 
@@ -58,15 +65,15 @@ describe('hero preload resolvers', () => {
     `https://comfy-hub-assets.comfy.org/uploads/${id}.${ext}`;
 
   it('preloads the generated poster for a detail hero that has one', () => {
-    expect(detailHeroPreload(upstream(known, 'mp4'))).toBe(
+    expect(detailHeroPreload([upstream(known, 'mp4')])).toBe(
       `https://media.comfy.org/hub-media/posters/${known}.jpg`
     );
   });
 
   it('falls back to the frame transform for a video with no generated copy', () => {
     const url = upstream(unseen, 'mp4');
-    expect(detailHeroPreload(url)).toBe(getVideoFrameUrl(url));
-    expect(detailHeroPreload(url)).toContain('cdn-cgi/media/mode=frame');
+    expect(detailHeroPreload([url])).toBe(getVideoFrameUrl(url));
+    expect(detailHeroPreload([url])).toContain('cdn-cgi/media/mode=frame');
   });
 
   it('preloads the original still when no copy was generated', () => {
@@ -74,7 +81,7 @@ describe('hero preload resolvers', () => {
     // image to fetch early. Returning null here meant every asset left out of
     // the image manifest - the ones saving under 15%, and every animated WebP -
     // painted a hero that was never preloaded.
-    expect(detailHeroPreload(upstream(unseen, 'webp'))).toBe(upstream(unseen, 'webp'));
+    expect(detailHeroPreload([upstream(unseen, 'webp')])).toBe(upstream(unseen, 'webp'));
   });
 
   it('preloads the still, not the original, for an animated WebP hero', () => {
@@ -83,13 +90,14 @@ describe('hero preload resolvers', () => {
     // swaps the animation in after load, so the preload has to name the still
     // or the page fetches both. 640 is mirrored from HERO_STILL_WIDTH there.
     const url = upstream(unseen, 'webp');
-    expect(detailHeroPreload(url, 'webp')).toBe(getStillImageUrl(url, 640));
-    expect(detailHeroPreload(url, 'webp')).toContain('anim=false');
+    expect(detailHeroPreload([url], 'webp')).toBe(getStillImageUrl(url, HERO_STILL_WIDTH));
+    expect(detailHeroPreload([url], 'webp')).toContain('anim=false');
   });
 
   it('preloads nothing for an audio hero, which paints an icon', () => {
-    expect(detailHeroPreload(upstream(unseen, 'mp3'))).toBeNull();
+    expect(detailHeroPreload([upstream(unseen, 'mp3')])).toBeNull();
     expect(detailHeroPreload(null)).toBeNull();
+    expect(detailHeroPreload([])).toBeNull();
   });
 
   it('prefers the still when a landing hero has one, sized at the edge', () => {
@@ -121,5 +129,81 @@ describe('hero preload resolvers', () => {
     expect(landingHeroPreload([])).toBeNull();
     expect(landingHeroPreload(undefined)).toBeNull();
     expect(landingHeroPreload(['track.mp3'])).toBeNull();
+  });
+});
+
+/**
+ * The still is only what the page paints when ThumbnailDisplay actually reaches
+ * its animated-thumb branch. `compareSlider` and `hoverDissolve` are checked
+ * first there and win whenever a second thumbnail exists.
+ *
+ * 45 pages in the live catalog were in that state. Each preloaded an `anim=false`
+ * still at `fetchpriority="high"` that the slider never rendered, in front of the
+ * multi-megabyte images it did - verified on `api_wan2_7_video_edit` in the PR
+ * preview: 19 KB preloaded, 1,892 KB and 2,079 KB painted, neither preloaded.
+ */
+describe('detailHeroPreload follows the variant branches', () => {
+  const id = (n: string) => `https://comfy-hub-assets.comfy.org/uploads/${n}.webp`;
+  const before = id('00000000-0000-0000-0000-000000000000');
+  const after = id('11111111-1111-1111-1111-111111111111');
+
+  it('names the compare slider\'s "After" layer, which carries fetchpriority', () => {
+    // ThumbnailDisplay renders `secondarySrc` first with `fetchpriority`, and
+    // clips `primarySrc` over its left half. Preloading the first would promote
+    // the lower-priority layer ahead of the one that is the hero.
+    expect(detailHeroPreload([before, after], 'webp', 'compareSlider')).toBe(hubAssetUrl(after));
+    expect(detailHeroPreload([before, after], 'webp', 'compareSlider')).not.toContain('anim=false');
+  });
+
+  it('never asks for a still the compare slider will not paint', () => {
+    expect(heroPaintsAnimatedStill([before, after], 'compareSlider')).toBe(false);
+    expect(heroPaintsAnimatedStill([before, after], 'hoverDissolve')).toBe(false);
+  });
+
+  it('names the original for hover dissolve, where fetchpriority stays first', () => {
+    expect(detailHeroPreload([before, after], 'webp', 'hoverDissolve')).toBe(hubAssetUrl(before));
+  });
+
+  it('falls back to the animated branch when the variant has one thumbnail', () => {
+    // Both variants need a second image to win; with one, ThumbnailDisplay drops
+    // through to the animated branch and the still IS what renders.
+    expect(heroPaintsAnimatedStill([before], 'compareSlider')).toBe(true);
+    expect(detailHeroPreload([before], 'webp', 'compareSlider')).toBe(
+      getStillImageUrl(before, HERO_STILL_WIDTH)
+    );
+  });
+
+  it('leaves every other variant on the still path', () => {
+    for (const variant of [undefined, null, '', 'zoomHover', 'hoverZoom']) {
+      expect(heroPaintsAnimatedStill([before, after], variant)).toBe(true);
+      expect(detailHeroPreload([before, after], 'webp', variant)).toBe(
+        getStillImageUrl(before, HERO_STILL_WIDTH)
+      );
+    }
+  });
+
+  it('keeps the video branch ahead of the variant branches', () => {
+    // ThumbnailDisplay checks `isVideo` on the PRIMARY before any variant, so a
+    // video-led compare slider still paints - and preloads - its poster.
+    const video = `https://comfy-hub-assets.comfy.org/uploads/${known}.mp4`;
+    expect(detailHeroPreload([video, after], 'webp', 'compareSlider')).toBe(
+      `https://media.comfy.org/hub-media/posters/${known}.jpg`
+    );
+  });
+
+  it('will not preload a non-image second layer as an image', () => {
+    const video = `https://comfy-hub-assets.comfy.org/uploads/${known}.mp4`;
+    expect(detailHeroPreload([before, video], 'webp', 'compareSlider')).not.toContain('.mp4');
+  });
+
+  it('has nothing to paint without thumbnails', () => {
+    expect(heroPaintsAnimatedStill([], 'compareSlider')).toBe(false);
+    expect(heroPaintsAnimatedStill(undefined)).toBe(false);
+  });
+
+  it('exports the width both sides ask for', () => {
+    // The preload and ThumbnailDisplay read this one constant; two copies of the
+    // number would be two chances to drift into two separate downloads.
+    expect(HERO_STILL_WIDTH).toBe(640);
   });
 });


### PR DESCRIPTION
Superseded by #1227 — GitHub would not re-sync this PR head after the branch was restructured into two commits. Same branch, same work.