### PR TITLE
Update Tripo workflows

### DIFF
--- a/packages/core/src/comfyui_workflow_templates_core/manifest.json
+++ b/packages/core/src/comfyui_workflow_templates_core/manifest.json
@@ -1141,7 +1141,7 @@
       "assets": [
         {
           "filename": "api_tripo3_0_image_to_model.json",
-          "sha256": "32ff566804362253884f9e1d58464503fb6246861cc01a161e9291ae6bc6f73b"
+          "sha256": "a9ab6138e142dce595a00fb0871afc6b16ce8f12302d083bd5fd6fed72d42033"
         },
         {
           "filename": "api_tripo3_0_image_to_model-1.webp",
@@ -1159,7 +1159,7 @@
       "assets": [
         {
           "filename": "api_tripo3_0_text_to_model.json",
-          "sha256": "08faff7e6f86cef1d0a0fee163e1eb279db20dcac5eed8227c31780f4b3baf93"
+          "sha256": "a01f54233a593d4d82f256bcd4034753ffb30823b1a13ac004fe1a84cbea1bb0"
         },
         {
           "filename": "api_tripo3_0_text_to_model-1.webp",
@@ -1177,7 +1177,7 @@
       "assets": [
         {
           "filename": "api_tripo_image_to_model.json",
-          "sha256": "b7421efe959c9bb462f62ec901608a7b8bf769d274697b44ab126a1c9c15a02f"
+          "sha256": "25162db9df71a63ca20c9a70a951339fd766fbd7acb07a4a88dee38b23092a16"
         },
         {
           "filename": "api_tripo_image_to_model-1.webp",
@@ -1195,7 +1195,7 @@
       "assets": [
         {
           "filename": "api_tripo_multiview_to_model.json",
-          "sha256": "60cf4e77f64870a4ade9623345c396ad9019a80a233f66b550686f245b83f141"
+          "sha256": "d1d94f664907dce85d3d2f0ffaa91d70de59b825278f1d8de7a9d5e4aa50ce36"
         },
         {
           "filename": "api_tripo_multiview_to_model-1.webp",
@@ -1213,7 +1213,7 @@
       "assets": [
         {
           "filename": "api_tripo_text_to_model.json",
-          "sha256": "2de656757a91b630f8c19552f91829d50ba2eba123507238cad7df96030f967f"
+          "sha256": "d6d00cb0b28aa2e5c41a5a6505f643fa4828f4727e39e4e7265ec0897b9a27e1"
         },
         {
           "filename": "api_tripo_text_to_model-1.webp",
@@ -5939,7 +5939,7 @@
       "assets": [
         {
           "filename": "api_tripo3_1_image_to_model.json",
-          "sha256": "82ac67228acd575cb36b2ca14242dbc695f96a05ce7f8a113114ae29fcd46d08"
+          "sha256": "5b08aca768260776fa6801ac97b4a3dbc27e0ad351a794abe7ee86bd749fe091"
         },
         {
           "filename": "api_tripo3_1_image_to_model-1.webp",
@@ -5957,7 +5957,7 @@
       "assets": [
         {
           "filename": "api_tripo3_1_multiview_to_model.json",
-          "sha256": "699ed010075b73ffa4e2e340a39dc4f5a595340e4800be5091743fa5c7be8678"
+          "sha256": "057605bd9ae9a91f768f93319df5d3f636c341b3517067714f3e61a02737824a"
         },
         {
           "filename": "api_tripo3_1_multiview_to_model-1.webp",
@@ -5975,7 +5975,7 @@
       "assets": [
         {
           "filename": "api_tripo3_1_text_to_model.json",
-          "sha256": "5cea2b1ad3d9da54bca80188d3e51e471db7eec6ae679585ee4417ff97c7fc0a"
+          "sha256": "bd71b7e1e28e42ca0c88f3493d30fc5d9b1171aa3e99ee070696d34336d7ebc0"
         },
         {
           "filename": "api_tripo3_1_text_to_model-1.webp",
@@ -6223,7 +6223,7 @@
       "assets": [
         {
           "filename": "index.json",
-          "sha256": "aff118a70cb8ed26752bb406c73b1fcfc984348d50eac339c92d46e6dcda2980"
+          "sha256": "a2639615beaea7c4bd99b9740bca266ba942c41f4eed09aba0472b5d445e49f9"
         }
       ],
       "cdn": {
@@ -6237,7 +6237,7 @@
       "assets": [
         {
           "filename": "index.ar.json",
-          "sha256": "747fee0a218ae1c6b42b18a5af958c04cb777d21655c7c882f233d29d5c1a262"
+          "sha256": "0ab4d4c4c67c8494ddc1a36f8aa0343b592f6446d671c83273a6c5fefa00445e"
         }
       ],
       "cdn": {
@@ -6251,7 +6251,7 @@
       "assets": [
         {
           "filename": "index.es.json",
-          "sha256": "b3d0fe49a6fbd2143851176c1a98a0043ffff41e6254dff910582c019fa2e7cf"
+          "sha256": "356ab1a1abf13eb0ae30bb13beedc5c8d8d47f8d52751504823d285b4498c772"
         }
       ],
       "cdn": {
@@ -6265,7 +6265,7 @@
       "assets": [
         {
           "filename": "index.fa.json",
-          "sha256": "abeedf8966e97342125fc664b2e48abf7b8b5d1574d6b566eeebe602bb6cd088"
+          "sha256": "cf70a7f4288933225724c1631e69226c51af5a9fcd817212c99a66edccecef93"
         }
       ],
       "cdn": {
@@ -6279,7 +6279,7 @@
       "assets": [
         {
           "filename": "index.fr.json",
-          "sha256": "f35ea57a288071f04383069bc2f75ce35a0a7eb748f27f9d226e5a266dcdaa00"
+          "sha256": "9a8279bae57df8390e964b8d1c8ea5b948498d14aff0f853d593700214e7ca5c"
         }
       ],
       "cdn": {
@@ -6293,7 +6293,7 @@
       "assets": [
         {
           "filename": "index.ja.json",
-          "sha256": "b952151dc0ee5ab61d5d28700e1308441dfd5ce0112d72ce5fcbc3db3425998c"
+          "sha256": "b6877aa476d8a7dc17c73b4c9559be1e8597fb0ebdbfe7423dc407ed60966736"
         }
       ],
       "cdn": {
@@ -6307,7 +6307,7 @@
       "assets": [
         {
           "filename": "index.ko.json",
-          "sha256": "d5277d648fd2ef59e9e8403c5815d7b839aba299caf0a40214fa6859c08ca689"
+          "sha256": "743eec864bd266a0dd8d46a630ef39fd3cf4cffd785b51498875bf69634a57de"
         }
       ],
       "cdn": {
@@ -6321,7 +6321,7 @@
       "assets": [
         {
           "filename": "index.mcp.json",
-          "sha256": "6a72ceb6cefdec0016d1f9e61de1b4bec1da07a427e23ef179261a30ae658eb8"
+          "sha256": "c28ca8e16ab688fdd4d0fb6f7f01c8896bd5f37f2eb3a6967f6898bfebb586d8"
         }
       ],
       "cdn": {
@@ -6335,7 +6335,7 @@
       "assets": [
         {
           "filename": "index.pt-BR.json",
-          "sha256": "795edab67947fd39adb93b804f9f9dd02351768702a74678849eae53b7f89d10"
+          "sha256": "71caa47a1e9768501452291f924af2f3041271544d774dfd7c64f31673542c34"
         }
       ],
       "cdn": {
@@ -6349,7 +6349,7 @@
       "assets": [
         {
           "filename": "index.ru.json",
-          "sha256": "d94945106f68fd42d930b08260b936c383375d64635b13213bab5b5169f7f811"
+          "sha256": "e779d6d4da49d7b1fb98ceec3c1c60a03c6a78d34aeab37407b38560d0121d4a"
         }
       ],
       "cdn": {
@@ -6377,7 +6377,7 @@
       "assets": [
         {
           "filename": "index.tr.json",
-          "sha256": "61ccc3d712712094c03674af4ec45558afd20996e9a08057c910d88b4baa0dff"
+          "sha256": "3df01c6a3ff3814628d73f36cc3fcd56b8d60d88e007b100a9cc852cd45fe9fa"
         }
       ],
       "cdn": {
@@ -6391,7 +6391,7 @@
       "assets": [
         {
           "filename": "index.zh.json",
-          "sha256": "170acefcfb642446fb74e3979412b1ab3be68cf3dfdffe9b8719462fcc2f1c26"
+          "sha256": "943850fbfc8705aea5def2cdcd6526e5c2914b42f95c5f3312ce5ede92054c53"
         }
       ],
       "cdn": {
@@ -6405,7 +6405,7 @@
       "assets": [
         {
           "filename": "index.zh-TW.json",
-          "sha256": "2c97084b0e1e9e0817b2cd9dd8d9952b2573bc88e503a21b1d3b45b8c616b6f3"
+          "sha256": "b68e2829e4349c7a37d0501f8aa6d29932e748d7f7744030534a3e846a1d76db"
         }
       ],
       "cdn": {

--- a/templates/api_tripo3_0_image_to_model.json
+++ b/templates/api_tripo3_0_image_to_model.json
@@ -8,15 +8,15 @@
       "id": 12,
       "type": "Preview3D",
       "pos": [
-        435.33333333333337,
-        753.3333333333334
+        440,
+        750
       ],
       "size": [
         720,
         810
       ],
       "flags": {},
-      "order": 10,
+      "order": 9,
       "mode": 0,
       "inputs": [
         {
@@ -49,21 +49,25 @@
       "widgets_values": [
         "",
         ""
-      ]
+      ],
+      "widgets_values_named": {
+        "model_file": "",
+        "image": ""
+      }
     },
     {
       "id": 1,
       "type": "TripoImageToModelNode",
       "pos": [
-        31.66666666666667,
-        753.3333333333334
+        30,
+        750
       ],
       "size": [
-        291.6666666666667,
-        403.33333333333337
+        300,
+        430
       ],
       "flags": {},
-      "order": 9,
+      "order": 8,
       "mode": 0,
       "inputs": [
         {
@@ -91,6 +95,11 @@
           "links": [
             12
           ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -110,8 +119,26 @@
         "geometry",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        true
       ],
+      "widgets_values_named": {
+        "model_version": "v3.0-20250812",
+        "style": "person:person2cartoon",
+        "texture": true,
+        "pbr": true,
+        "model_seed": 42,
+        "orientation": "default",
+        "texture_seed": 42,
+        "texture_quality": "detailed",
+        "texture_alignment": "geometry",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": true
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -119,20 +146,20 @@
       "id": 13,
       "type": "SaveGLB",
       "pos": [
-        1267.3333333333335,
-        753.3333333333334
+        1270,
+        750
       ],
       "size": [
         650,
         800
       ],
       "flags": {},
-      "order": 11,
+      "order": 10,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 12
         }
       ],
@@ -144,68 +171,25 @@
       "widgets_values": [
         "3d/tripo_image2model",
         ""
-      ]
-    },
-    {
-      "id": 14,
-      "type": "TripoRefineNode",
-      "pos": [
-        -1120,
-        1240
       ],
-      "size": [
-        320.6015625,
-        66
-      ],
-      "flags": {},
-      "order": 0,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": null
-        },
-        {
-          "name": "model task_id",
-          "type": "MODEL_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "TripoRefineNode"
-      },
-      "widgets_values": [],
-      "color": "#432",
-      "bgcolor": "#653"
+      "widgets_values_named": {
+        "filename_prefix": "3d/tripo_image2model",
+        "image": ""
+      }
     },
     {
       "id": 15,
       "type": "TripoRigNode",
       "pos": [
         -1120,
-        1380
+        1452
       ],
       "size": [
-        320.6015625,
-        66
+        330,
+        206
       ],
       "flags": {},
-      "order": 1,
+      "order": 0,
       "mode": 4,
       "inputs": [
         {
@@ -229,6 +213,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -236,7 +225,18 @@
         "ver": "0.16.3",
         "Node name for S&R": "TripoRigNode"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -245,14 +245,14 @@
       "type": "TripoRetargetNode",
       "pos": [
         -1120,
-        1080
+        1211
       ],
       "size": [
-        320.6015625,
-        98
+        330,
+        190
       ],
       "flags": {},
-      "order": 2,
+      "order": 1,
       "mode": 4,
       "inputs": [
         {
@@ -276,6 +276,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -284,8 +289,17 @@
         "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "preset:idle"
+        "preset:idle",
+        "glb",
+        true,
+        false
       ],
+      "widgets_values_named": {
+        "animation": "preset:idle",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -294,23 +308,29 @@
       "type": "TripoConversionNode",
       "pos": [
         -1120,
-        1510
+        1709
       ],
       "size": [
-        320.6015625,
-        466
+        330,
+        470
       ],
       "flags": {},
-      "order": 3,
+      "order": 2,
       "mode": 4,
       "inputs": [
         {
           "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",
+          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID,SEGMENT_TASK_ID",
           "link": null
         }
       ],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "model_3d",
+          "type": "FILE_3D",
+          "links": null
+        }
+      ],
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.16.3",
@@ -336,6 +356,26 @@
         "default",
         false
       ],
+      "widgets_values_named": {
+        "format": "GLTF",
+        "quad": false,
+        "face_limit": -1,
+        "texture_size": 4096,
+        "texture_format": "JPEG",
+        "force_symmetry": false,
+        "flatten_bottom": false,
+        "flatten_bottom_threshold": 0,
+        "pivot_to_center_bottom": false,
+        "scale_factor": 1,
+        "with_animation": false,
+        "pack_uv": false,
+        "bake": false,
+        "part_names": "",
+        "fbx_preset": "blender",
+        "export_vertex_colors": false,
+        "export_orientation": "default",
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -347,16 +387,22 @@
         820
       ],
       "size": [
-        320.6015625,
-        194
+        330,
+        340
       ],
       "flags": {},
-      "order": 4,
+      "order": 3,
       "mode": 4,
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -375,6 +421,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -387,8 +438,23 @@
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -396,15 +462,15 @@
       "id": 2,
       "type": "LoadImage",
       "pos": [
-        -566.6666628381329,
-        753.333333246382
+        -570,
+        750
       ],
       "size": [
-        282.78645833333337,
-        411.1197916666667
+        290,
+        420
       ],
       "flags": {},
-      "order": 5,
+      "order": 4,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -429,21 +495,25 @@
       "widgets_values": [
         "3d_character_front_view.png",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "3d_character_front_view.png",
+        "upload": "image"
+      }
     },
     {
       "id": 4,
       "type": "LoadImage",
       "pos": [
-        -566.6666628381329,
-        1231.4531249130487
+        -570,
+        1230
       ],
       "size": [
-        282.78645833333337,
-        411.1197916666667
+        290,
+        420
       ],
       "flags": {},
-      "order": 6,
+      "order": 5,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -468,21 +538,25 @@
       "widgets_values": [
         "3d_character_left_view.png",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "3d_character_left_view.png",
+        "upload": "image"
+      }
     },
     {
       "id": 3,
       "type": "LoadImage",
       "pos": [
-        -566.6666628381329,
-        1709.5729165797154
+        -570,
+        1710
       ],
       "size": [
-        282.78645833333337,
-        411.1197916666667
+        290,
+        420
       ],
       "flags": {},
-      "order": 7,
+      "order": 6,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -507,7 +581,11 @@
       "widgets_values": [
         "3d_character_back_view.png",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "3d_character_back_view.png",
+        "upload": "image"
+      }
     },
     {
       "id": 19,
@@ -517,11 +595,11 @@
         750
       ],
       "size": [
-        169.32421875,
-        86
+        225,
+        110
       ],
       "flags": {},
-      "order": 8,
+      "order": 7,
       "mode": 0,
       "inputs": [
         {
@@ -531,20 +609,18 @@
           "link": 14
         },
         {
-          "label": "image1",
           "name": "images.image1",
+          "shape": 7,
           "type": "IMAGE",
           "link": 15
         },
         {
-          "label": "image2",
           "name": "images.image2",
           "shape": 7,
           "type": "IMAGE",
           "link": 16
         },
         {
-          "label": "image3",
           "name": "images.image3",
           "shape": 7,
           "type": "IMAGE",
@@ -624,24 +700,23 @@
       "bounding": [
         -1250,
         730,
-        610,
-        1290
+        600,
+        1500
       ],
       "color": "#3f789e",
-      "font_size": 24,
       "flags": {}
     }
   ],
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.45501979362635014,
+      "scale": 0.34705982217821285,
       "offset": [
-        2950.917573857411,
-        -36.85261661773319
+        2709.4526726017975,
+        259.9175226026563
       ]
     },
-    "frontendVersion": "1.39.19",
+    "frontendVersion": "1.51.9",
     "workflowRendererVersion": "LG",
     "VHS_latentpreview": false,
     "VHS_latentpreviewrate": 0,

--- a/templates/api_tripo3_0_text_to_model.json
+++ b/templates/api_tripo3_0_text_to_model.json
@@ -1,80 +1,9 @@
 {
   "id": "ef49adbe-6e63-45c0-9f29-fa4677f627ac",
   "revision": 0,
-  "last_node_id": 37,
-  "last_link_id": 21,
+  "last_node_id": 42,
+  "last_link_id": 24,
   "nodes": [
-    {
-      "id": 31,
-      "type": "Preview3D",
-      "pos": [
-        -5880,
-        1290
-      ],
-      "size": [
-        670,
-        540
-      ],
-      "flags": {},
-      "order": 7,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "camera_info",
-          "shape": 7,
-          "type": "LOAD3D_CAMERA",
-          "link": null
-        },
-        {
-          "name": "bg_image",
-          "shape": 7,
-          "type": "IMAGE",
-          "link": null
-        },
-        {
-          "name": "model_file",
-          "type": "STRING,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_FBX,FILE_3D_OBJ,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
-          "widget": {
-            "name": "model_file"
-          },
-          "link": 20
-        }
-      ],
-      "outputs": [],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.6.0",
-        "Node name for S&R": "Preview3D"
-      },
-      "widgets_values": [
-        "",
-        ""
-      ]
-    },
-    {
-      "id": 5,
-      "type": "MarkdownNote",
-      "pos": [
-        -5870,
-        1890
-      ],
-      "size": [
-        230,
-        88
-      ],
-      "flags": {},
-      "order": 0,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [],
-      "title": "Note",
-      "properties": {},
-      "widgets_values": [
-        "You can use the export function in the preview 3D node to download it.\n\nFor local user the output file will be saved at ComfyUI/output/3d\n"
-      ],
-      "color": "#222",
-      "bgcolor": "#000"
-    },
     {
       "id": 3,
       "type": "TripoTextToModelNode",
@@ -87,16 +16,14 @@
         540
       ],
       "flags": {},
-      "order": 1,
+      "order": 0,
       "mode": 0,
       "inputs": [],
       "outputs": [
         {
           "name": "model_file",
           "type": "STRING",
-          "links": [
-            20
-          ]
+          "links": []
         },
         {
           "name": "model task_id",
@@ -108,6 +35,13 @@
           "type": "FILE_3D_GLB",
           "links": [
             21
+          ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": [
+            23
           ]
         }
       ],
@@ -129,8 +63,27 @@
         "standard",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        true
       ],
+      "widgets_values_named": {
+        "prompt": "Create a 3D game monster design, majestic and powerful creature, muscular build, imposing stature, heroic proportions, noble appearance, muted color palette, earthy tones, natural colors, game-ready asset, professional 3D rendering, studio lighting, white background, high quality",
+        "negative_prompt": "",
+        "model_version": "v3.0-20250812",
+        "style": "None",
+        "texture": true,
+        "pbr": true,
+        "image_seed": 42,
+        "model_seed": 42,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": true
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -138,7 +91,7 @@
       "id": 32,
       "type": "SaveGLB",
       "pos": [
-        -5170,
+        -5414,
         1290
       ],
       "size": [
@@ -146,12 +99,12 @@
         540
       ],
       "flags": {},
-      "order": 8,
+      "order": 5,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 21
         }
       ],
@@ -163,68 +116,25 @@
       "widgets_values": [
         "3d/ComfyUI",
         ""
-      ]
-    },
-    {
-      "id": 33,
-      "type": "TripoRefineNode",
-      "pos": [
-        -6790,
-        1770
       ],
-      "size": [
-        320.6015625,
-        66
-      ],
-      "flags": {},
-      "order": 2,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": null
-        },
-        {
-          "name": "model task_id",
-          "type": "MODEL_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "TripoRefineNode"
-      },
-      "widgets_values": [],
-      "color": "#432",
-      "bgcolor": "#653"
+      "widgets_values_named": {
+        "filename_prefix": "3d/ComfyUI",
+        "image": ""
+      }
     },
     {
       "id": 34,
       "type": "TripoRigNode",
       "pos": [
         -6790,
-        1910
+        1988
       ],
       "size": [
-        320.6015625,
-        66
+        330,
+        206
       ],
       "flags": {},
-      "order": 3,
+      "order": 1,
       "mode": 4,
       "inputs": [
         {
@@ -248,6 +158,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -255,7 +170,18 @@
         "ver": "0.16.3",
         "Node name for S&R": "TripoRigNode"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -264,14 +190,14 @@
       "type": "TripoRetargetNode",
       "pos": [
         -6790,
-        1610
+        1744
       ],
       "size": [
-        320.6015625,
-        98
+        330,
+        190
       ],
       "flags": {},
-      "order": 4,
+      "order": 2,
       "mode": 4,
       "inputs": [
         {
@@ -295,6 +221,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -303,8 +234,17 @@
         "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "preset:idle"
+        "preset:idle",
+        "glb",
+        true,
+        false
       ],
+      "widgets_values_named": {
+        "animation": "preset:idle",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -313,23 +253,29 @@
       "type": "TripoConversionNode",
       "pos": [
         -6790,
-        2040
+        2248
       ],
       "size": [
-        320.6015625,
-        466
+        330,
+        470
       ],
       "flags": {},
-      "order": 5,
+      "order": 3,
       "mode": 4,
       "inputs": [
         {
           "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",
+          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID,SEGMENT_TASK_ID",
           "link": null
         }
       ],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "model_3d",
+          "type": "FILE_3D",
+          "links": null
+        }
+      ],
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.16.3",
@@ -355,6 +301,26 @@
         "default",
         false
       ],
+      "widgets_values_named": {
+        "format": "GLTF",
+        "quad": false,
+        "face_limit": -1,
+        "texture_size": 4096,
+        "texture_format": "JPEG",
+        "force_symmetry": false,
+        "flatten_bottom": false,
+        "flatten_bottom_threshold": 0,
+        "pivot_to_center_bottom": false,
+        "scale_factor": 1,
+        "with_animation": false,
+        "pack_uv": false,
+        "bake": false,
+        "part_names": "",
+        "fbx_preset": "blender",
+        "export_vertex_colors": false,
+        "export_orientation": "default",
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -366,16 +332,22 @@
         1350
       ],
       "size": [
-        320.6015625,
-        194
+        330,
+        340
       ],
       "flags": {},
-      "order": 6,
+      "order": 4,
       "mode": 4,
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -394,6 +366,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -406,21 +383,63 @@
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
+    },
+    {
+      "id": 41,
+      "type": "SaveGLB",
+      "pos": [
+        -5872,
+        1290
+      ],
+      "size": [
+        410,
+        540
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "mesh",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
+          "link": 23
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3"
+      },
+      "widgets_values": [
+        "3d/ComfyUI",
+        ""
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/ComfyUI",
+        "image": ""
+      }
     }
   ],
   "links": [
-    [
-      20,
-      3,
-      0,
-      31,
-      2,
-      "STRING"
-    ],
     [
       21,
       3,
@@ -428,6 +447,14 @@
       32,
       0,
       "FILE_3D_GLB"
+    ],
+    [
+      23,
+      3,
+      3,
+      41,
+      0,
+      "FILE_3D_FBX"
     ]
   ],
   "groups": [
@@ -437,24 +464,23 @@
       "bounding": [
         -6920,
         1260,
-        610,
-        1290
+        600,
+        1500
       ],
       "color": "#3f789e",
-      "font_size": 24,
       "flags": {}
     }
   ],
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.28313293757766095,
+      "scale": 0.4394134294613433,
       "offset": [
-        9388.94046516696,
-        -238.3843237738563
+        7761.359603726377,
+        -523.1539274659609
       ]
     },
-    "frontendVersion": "1.39.19",
+    "frontendVersion": "1.51.9",
     "workflowRendererVersion": "LG",
     "VHS_latentpreview": false,
     "VHS_latentpreviewrate": 0,

--- a/templates/api_tripo3_1_image_to_model.json
+++ b/templates/api_tripo3_1_image_to_model.json
@@ -1,32 +1,34 @@
 {
   "id": "33842e7e-4f7d-4453-8a05-b99007cc20e7",
   "revision": 0,
-  "last_node_id": 11,
+  "last_node_id": 12,
   "last_link_id": 6,
   "nodes": [
     {
       "id": 3,
       "type": "SaveGLB",
       "pos": [
-        4292.624716373926,
-        377.03552466279143
+        4320,
+        380
       ],
       "size": [
-        372.515625,
-        471.703125
+        380,
+        480
       ],
       "flags": {},
-      "order": 7,
+      "order": 6,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 6
         }
       ],
       "outputs": [],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Scene Config": {
           "showGrid": true,
           "backgroundColor": "#282828",
@@ -52,74 +54,37 @@
           }
         },
         "Light Config": {
-          "intensity": 3
+          "intensity": 3,
+          "hdri": {
+            "enabled": false,
+            "hdriPath": "",
+            "showAsBackground": false,
+            "intensity": 1
+          }
         }
       },
       "widgets_values": [
         "3d/Tripo3.1_i2m",
         ""
-      ]
-    },
-    {
-      "id": 4,
-      "type": "TripoRefineNode",
-      "pos": [
-        2883.243820080933,
-        838.6813149543012
       ],
-      "size": [
-        320.59375,
-        96
-      ],
-      "flags": {},
-      "order": 0,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": null
-        },
-        {
-          "name": "model task_id",
-          "type": "MODEL_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "TripoRefineNode",
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3"
-      },
-      "widgets_values": [],
-      "color": "#432",
-      "bgcolor": "#653"
+      "widgets_values_named": {
+        "filename_prefix": "3d/Tripo3.1_i2m",
+        "image": ""
+      }
     },
     {
       "id": 5,
       "type": "TripoRigNode",
       "pos": [
-        2882.802173373719,
-        984.4472580762605
+        2880,
+        1034
       ],
       "size": [
-        320.59375,
-        96
+        330,
+        206
       ],
       "flags": {},
-      "order": 1,
+      "order": 0,
       "mode": 4,
       "inputs": [
         {
@@ -143,14 +108,30 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoRigNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoRigNode"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -158,15 +139,15 @@
       "id": 6,
       "type": "TripoRetargetNode",
       "pos": [
-        2882.198589540527,
-        659.0182221120114
+        2880,
+        792
       ],
       "size": [
-        320.59375,
-        130.65625
+        330,
+        190
       ],
       "flags": {},
-      "order": 2,
+      "order": 1,
       "mode": 4,
       "inputs": [
         {
@@ -190,16 +171,30 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoRetargetNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "preset:idle"
+        "preset:idle",
+        "glb",
+        true,
+        false
       ],
+      "widgets_values_named": {
+        "animation": "preset:idle",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -207,28 +202,34 @@
       "id": 7,
       "type": "TripoConversionNode",
       "pos": [
-        2884.7944907418173,
-        1134.8709646920852
+        2880,
+        1292
       ],
       "size": [
-        320.59375,
-        466
+        340,
+        100
       ],
       "flags": {},
-      "order": 3,
+      "order": 2,
       "mode": 4,
       "inputs": [
         {
           "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",
+          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID,SEGMENT_TASK_ID",
           "link": null
         }
       ],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "model_3d",
+          "type": "FILE_3D",
+          "links": null
+        }
+      ],
       "properties": {
-        "Node name for S&R": "TripoConversionNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoConversionNode"
       },
       "widgets_values": [
         "GLTF",
@@ -250,6 +251,26 @@
         "default",
         false
       ],
+      "widgets_values_named": {
+        "format": "GLTF",
+        "quad": false,
+        "face_limit": -1,
+        "texture_size": 4096,
+        "texture_format": "JPEG",
+        "force_symmetry": false,
+        "flatten_bottom": false,
+        "flatten_bottom_threshold": 0,
+        "pivot_to_center_bottom": false,
+        "scale_factor": 1,
+        "with_animation": false,
+        "pack_uv": false,
+        "bake": false,
+        "part_names": "",
+        "fbx_preset": "blender",
+        "export_vertex_colors": false,
+        "export_orientation": "default",
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -257,20 +278,26 @@
       "id": 8,
       "type": "TripoTextureNode",
       "pos": [
-        2882.198589540527,
-        399.01822211201045
+        2880,
+        400
       ],
       "size": [
-        320.59375,
-        194
+        330,
+        340
       ],
       "flags": {},
-      "order": 4,
+      "order": 3,
       "mode": 4,
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -289,20 +316,40 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoTextureNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoTextureNode"
       },
       "widgets_values": [
         true,
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -310,15 +357,15 @@
       "id": 10,
       "type": "LoadImage",
       "pos": [
-        3420.908210847263,
-        378.68132314125677
+        3420,
+        380
       ],
       "size": [
-        414.921875,
-        558.3125
+        420,
+        560
       ],
       "flags": {},
-      "order": 5,
+      "order": 4,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -336,26 +383,32 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Node name for S&R": "LoadImage"
       },
       "widgets_values": [
         "cybernetic_robot.png",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "cybernetic_robot.png",
+        "upload": "image"
+      }
     },
     {
       "id": 11,
       "type": "TripoImageToModelNode",
       "pos": [
-        3898.9552281226947,
-        382.9745056039202
+        3900,
+        380
       ],
       "size": [
-        350.109375,
-        378.421875
+        370,
+        230
       ],
       "flags": {},
-      "order": 6,
+      "order": 5,
       "mode": 0,
       "inputs": [
         {
@@ -381,9 +434,16 @@
           "links": [
             6
           ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Node name for S&R": "TripoImageToModelNode"
       },
       "widgets_values": [
@@ -398,8 +458,26 @@
         "original_image",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        true
       ],
+      "widgets_values_named": {
+        "model_version": "v3.1-20260211",
+        "style": "None",
+        "texture": true,
+        "pbr": true,
+        "model_seed": 42,
+        "orientation": "default",
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": true
+      },
       "color": "#432",
       "bgcolor": "#653"
     }
@@ -427,10 +505,10 @@
       "id": 1,
       "title": "Tripo Toolset (select and ctrl-b to enable)",
       "bounding": [
-        2752.198589540527,
-        309.0182221120105,
-        615.0015149616574,
-        1345.344479229278
+        2750,
+        310,
+        580,
+        1140
       ],
       "color": "#3f789e",
       "flags": {}
@@ -439,13 +517,13 @@
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.4396421155689783,
+      "scale": 0.4862686071009698,
       "offset": [
-        -1556.6067505536182,
-        348.85675240822366
+        -2138.356844726529,
+        156.55362724862846
       ]
     },
-    "frontendVersion": "1.43.17"
+    "frontendVersion": "1.51.9"
   },
   "version": 0.4
 }

--- a/templates/api_tripo3_1_multiview_to_model.json
+++ b/templates/api_tripo3_1_multiview_to_model.json
@@ -5,112 +5,18 @@
   "last_link_id": 30,
   "nodes": [
     {
-      "id": 38,
-      "type": "TripoRefineNode",
-      "pos": [
-        -7330,
-        1770
-      ],
-      "size": [
-        320.59375,
-        96
-      ],
-      "flags": {},
-      "order": 0,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": null
-        },
-        {
-          "name": "model task_id",
-          "type": "MODEL_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "TripoRefineNode",
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3"
-      },
-      "widgets_values": [],
-      "color": "#432",
-      "bgcolor": "#653"
-    },
-    {
-      "id": 39,
-      "type": "TripoRigNode",
-      "pos": [
-        -7330,
-        1910
-      ],
-      "size": [
-        320.59375,
-        96
-      ],
-      "flags": {},
-      "order": 1,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": null
-        },
-        {
-          "name": "rig task_id",
-          "type": "RIG_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "TripoRigNode",
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3"
-      },
-      "widgets_values": [],
-      "color": "#432",
-      "bgcolor": "#653"
-    },
-    {
       "id": 40,
       "type": "TripoRetargetNode",
       "pos": [
         -7330,
-        1588.9433098026213
+        1752
       ],
       "size": [
-        320.59375,
-        130.65625
+        330,
+        190
       ],
       "flags": {},
-      "order": 2,
+      "order": 0,
       "mode": 4,
       "inputs": [
         {
@@ -134,66 +40,30 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "TripoRetargetNode",
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3"
-      },
-      "widgets_values": [
-        "preset:idle"
-      ],
-      "color": "#432",
-      "bgcolor": "#653"
-    },
-    {
-      "id": 41,
-      "type": "TripoConversionNode",
-      "pos": [
-        -7329.945244087901,
-        2068.7772738034096
-      ],
-      "size": [
-        320.59375,
-        466
-      ],
-      "flags": {},
-      "order": 3,
-      "mode": 4,
-      "inputs": [
+        },
         {
-          "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",
-          "link": null
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
-      "outputs": [],
       "properties": {
-        "Node name for S&R": "TripoConversionNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "GLTF",
-        false,
-        -1,
-        4096,
-        "JPEG",
-        false,
-        false,
-        0,
-        false,
-        1,
-        false,
-        false,
-        false,
-        "",
-        "blender",
-        false,
-        "default",
+        "preset:idle",
+        "glb",
+        true,
         false
       ],
+      "widgets_values_named": {
+        "animation": "preset:idle",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -205,16 +75,22 @@
         1350
       ],
       "size": [
-        320.59375,
-        194
+        330,
+        340
       ],
       "flags": {},
-      "order": 4,
+      "order": 1,
       "mode": 4,
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -233,20 +109,40 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoTextureNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoTextureNode"
       },
       "widgets_values": [
         true,
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -254,20 +150,20 @@
       "id": 43,
       "type": "SaveGLB",
       "pos": [
-        -6019.381887886402,
-        1318.337913556616
+        -6020,
+        1320
       ],
       "size": [
-        667.875,
-        673.234375
+        670,
+        680
       ],
       "flags": {},
-      "order": 9,
+      "order": 8,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 30
         }
       ],
@@ -286,27 +182,37 @@
           "fov": 35
         },
         "Light Config": {
-          "intensity": 3
+          "intensity": 3,
+          "hdri": {
+            "enabled": false,
+            "hdriPath": "",
+            "showAsBackground": false,
+            "intensity": 1
+          }
         }
       },
       "widgets_values": [
         "3d/Tripo_3.1",
         ""
-      ]
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/Tripo_3.1",
+        "image": ""
+      }
     },
     {
       "id": 44,
       "type": "LoadImage",
       "pos": [
-        -6780.074037708911,
-        1303.6153876512785
+        -6780,
+        1300
       ],
       "size": [
-        282.796875,
-        340
+        290,
+        350
       ],
       "flags": {},
-      "order": 5,
+      "order": 2,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -324,26 +230,32 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Node name for S&R": "LoadImage"
       },
       "widgets_values": [
         "castle_front_view.png",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "castle_front_view.png",
+        "upload": "image"
+      }
     },
     {
       "id": 45,
       "type": "LoadImage",
       "pos": [
-        -6780.401693893589,
-        1725.8921811789132
+        -6780,
+        1730
       ],
       "size": [
-        282.796875,
-        340
+        290,
+        350
       ],
       "flags": {},
-      "order": 6,
+      "order": 3,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -361,26 +273,32 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Node name for S&R": "LoadImage"
       },
       "widgets_values": [
         "castle_side_view.png",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "castle_side_view.png",
+        "upload": "image"
+      }
     },
     {
       "id": 46,
       "type": "LoadImage",
       "pos": [
-        -6781.725725926764,
-        2153.875047926168
+        -6780,
+        2150
       ],
       "size": [
-        282.796875,
-        340
+        290,
+        350
       ],
       "flags": {},
-      "order": 7,
+      "order": 4,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -398,26 +316,32 @@
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Node name for S&R": "LoadImage"
       },
       "widgets_values": [
         "castle_back_view.png",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "castle_back_view.png",
+        "upload": "image"
+      }
     },
     {
       "id": 47,
       "type": "TripoMultiviewToModelNode",
       "pos": [
-        -6407.658048045296,
-        1303.849258861723
+        -6410,
+        1300
       ],
       "size": [
         270,
-        358
+        410
       ],
       "flags": {},
-      "order": 8,
+      "order": 7,
       "mode": 0,
       "inputs": [
         {
@@ -461,9 +385,16 @@
           "links": [
             30
           ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Node name for S&R": "TripoMultiviewToModelNode"
       },
       "widgets_values": [
@@ -477,8 +408,164 @@
         "original_image",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        false
       ],
+      "widgets_values_named": {
+        "model_version": "v3.1-20260211",
+        "orientation": "default",
+        "texture": true,
+        "pbr": true,
+        "model_seed": 42,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": false
+      },
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 39,
+      "type": "TripoRigNode",
+      "pos": [
+        -7330,
+        2004
+      ],
+      "size": [
+        330,
+        206
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 4,
+      "inputs": [
+        {
+          "name": "original_model_task_id",
+          "type": "MODEL_TASK_ID",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model_file",
+          "type": "STRING",
+          "links": null
+        },
+        {
+          "name": "rig task_id",
+          "type": "RIG_TASK_ID",
+          "links": null
+        },
+        {
+          "name": "GLB",
+          "type": "FILE_3D_GLB",
+          "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoRigNode"
+      },
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 41,
+      "type": "TripoConversionNode",
+      "pos": [
+        -7330,
+        2272
+      ],
+      "size": [
+        330,
+        458
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 4,
+      "inputs": [
+        {
+          "name": "original_model_task_id",
+          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model_3d",
+          "type": "FILE_3D",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoConversionNode"
+      },
+      "widgets_values": [
+        "GLTF",
+        false,
+        -1,
+        4096,
+        "JPEG",
+        false,
+        false,
+        0,
+        false,
+        1,
+        false,
+        false,
+        false,
+        "",
+        "blender",
+        false,
+        "default",
+        false
+      ],
+      "widgets_values_named": {
+        "format": "GLTF",
+        "quad": false,
+        "face_limit": -1,
+        "texture_size": 4096,
+        "texture_format": "JPEG",
+        "force_symmetry": false,
+        "flatten_bottom": false,
+        "flatten_bottom_threshold": 0,
+        "pivot_to_center_bottom": false,
+        "scale_factor": 1,
+        "with_animation": false,
+        "pack_uv": false,
+        "bake": false,
+        "part_names": "",
+        "fbx_preset": "blender",
+        "export_vertex_colors": false,
+        "export_orientation": "default",
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     }
@@ -524,8 +611,8 @@
       "bounding": [
         -7460,
         1260,
-        610,
-        1290
+        590,
+        1500
       ],
       "color": "#3f789e",
       "flags": {}
@@ -534,13 +621,13 @@
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.3966405075822393,
+      "scale": 0.2596926781805393,
       "offset": [
-        8802.049479605661,
-        -449.2126116590988
+        9841.331372233424,
+        381.2676940332277
       ]
     },
-    "frontendVersion": "1.43.17",
+    "frontendVersion": "1.51.9",
     "workflowRendererVersion": "LG",
     "VHS_latentpreview": false,
     "VHS_latentpreviewrate": 0,

--- a/templates/api_tripo3_1_text_to_model.json
+++ b/templates/api_tripo3_1_text_to_model.json
@@ -1,32 +1,34 @@
 {
   "id": "33842e7e-4f7d-4453-8a05-b99007cc20e7",
   "revision": 0,
-  "last_node_id": 8,
+  "last_node_id": 9,
   "last_link_id": 2,
   "nodes": [
     {
       "id": 3,
       "type": "SaveGLB",
       "pos": [
-        3871.9565542888918,
-        341.3090648142844
+        3870,
+        340
       ],
       "size": [
-        372.515625,
-        471.703125
+        380,
+        480
       ],
       "flags": {},
-      "order": 6,
+      "order": 5,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 2
         }
       ],
       "outputs": [],
       "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.34.0",
         "Scene Config": {
           "showGrid": true,
           "backgroundColor": "#282828",
@@ -52,74 +54,37 @@
           }
         },
         "Light Config": {
-          "intensity": 3
+          "intensity": 3,
+          "hdri": {
+            "enabled": false,
+            "hdriPath": "",
+            "showAsBackground": false,
+            "intensity": 1
+          }
         }
       },
       "widgets_values": [
         "3d/Tripo3.1_t2m",
         ""
-      ]
-    },
-    {
-      "id": 4,
-      "type": "TripoRefineNode",
-      "pos": [
-        2883.243820080933,
-        838.6813149543012
       ],
-      "size": [
-        320.59375,
-        96
-      ],
-      "flags": {},
-      "order": 0,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": null
-        },
-        {
-          "name": "model task_id",
-          "type": "MODEL_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "TripoRefineNode",
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3"
-      },
-      "widgets_values": [],
-      "color": "#432",
-      "bgcolor": "#653"
+      "widgets_values_named": {
+        "filename_prefix": "3d/Tripo3.1_t2m",
+        "image": ""
+      }
     },
     {
       "id": 5,
       "type": "TripoRigNode",
       "pos": [
-        2882.802173373719,
-        984.4472580762605
+        2880,
+        1086
       ],
       "size": [
-        320.59375,
-        96
+        330,
+        206
       ],
       "flags": {},
-      "order": 1,
+      "order": 0,
       "mode": 4,
       "inputs": [
         {
@@ -143,14 +108,30 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoRigNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoRigNode"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -158,15 +139,15 @@
       "id": 6,
       "type": "TripoRetargetNode",
       "pos": [
-        2882.198589540527,
-        659.0182221120114
+        2880,
+        818
       ],
       "size": [
-        320.59375,
-        130.65625
+        330,
+        190
       ],
       "flags": {},
-      "order": 2,
+      "order": 1,
       "mode": 4,
       "inputs": [
         {
@@ -190,16 +171,30 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoRetargetNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "preset:idle"
+        "preset:idle",
+        "glb",
+        true,
+        false
       ],
+      "widgets_values_named": {
+        "animation": "preset:idle",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -207,28 +202,34 @@
       "id": 7,
       "type": "TripoConversionNode",
       "pos": [
-        2884.7944907418173,
-        1134.8709646920852
+        2880,
+        1370
       ],
       "size": [
-        320.59375,
-        466
+        350,
+        86
       ],
       "flags": {},
-      "order": 3,
+      "order": 2,
       "mode": 4,
       "inputs": [
         {
           "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",
+          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID,SEGMENT_TASK_ID",
           "link": null
         }
       ],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "model_3d",
+          "type": "FILE_3D",
+          "links": null
+        }
+      ],
       "properties": {
-        "Node name for S&R": "TripoConversionNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoConversionNode"
       },
       "widgets_values": [
         "GLTF",
@@ -250,6 +251,26 @@
         "default",
         false
       ],
+      "widgets_values_named": {
+        "format": "GLTF",
+        "quad": false,
+        "face_limit": -1,
+        "texture_size": 4096,
+        "texture_format": "JPEG",
+        "force_symmetry": false,
+        "flatten_bottom": false,
+        "flatten_bottom_threshold": 0,
+        "pivot_to_center_bottom": false,
+        "scale_factor": 1,
+        "with_animation": false,
+        "pack_uv": false,
+        "bake": false,
+        "part_names": "",
+        "fbx_preset": "blender",
+        "export_vertex_colors": false,
+        "export_orientation": "default",
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -257,20 +278,26 @@
       "id": 8,
       "type": "TripoTextureNode",
       "pos": [
-        2882.198589540527,
-        399.01822211201045
+        2880,
+        400
       ],
       "size": [
-        320.59375,
-        194
+        330,
+        340
       ],
       "flags": {},
-      "order": 4,
+      "order": 3,
       "mode": 4,
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -289,20 +316,40 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoTextureNode",
         "cnr_id": "comfy-core",
-        "ver": "0.16.3"
+        "ver": "0.16.3",
+        "Node name for S&R": "TripoTextureNode"
       },
       "widgets_values": [
         true,
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -310,15 +357,15 @@
       "id": 1,
       "type": "TripoTextToModelNode",
       "pos": [
-        3425.250546818701,
-        336.3735436550962
+        3430,
+        340
       ],
       "size": [
         400,
-        488
+        520
       ],
       "flags": {},
-      "order": 5,
+      "order": 4,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -338,12 +385,17 @@
           "links": [
             2
           ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
-        "Node name for S&R": "TripoTextToModelNode",
         "cnr_id": "comfy-core",
-        "ver": "0.20.1"
+        "ver": "0.20.1",
+        "Node name for S&R": "TripoTextToModelNode"
       },
       "widgets_values": [
         "armored knight kneeling with sword, ornate silver-gold plate armor, white cape",
@@ -358,8 +410,27 @@
         "standard",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        true
       ],
+      "widgets_values_named": {
+        "prompt": "armored knight kneeling with sword, ornate silver-gold plate armor, white cape",
+        "negative_prompt": "",
+        "model_version": "v3.1-20260211",
+        "style": "None",
+        "texture": true,
+        "pbr": true,
+        "image_seed": 42,
+        "model_seed": 42,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": true
+      },
       "color": "#432",
       "bgcolor": "#653"
     }
@@ -379,10 +450,10 @@
       "id": 1,
       "title": "Tripo Toolset (select and ctrl-b to enable)",
       "bounding": [
-        2752.198589540527,
-        309.0182221120105,
-        615.0015149616574,
-        1345.344479229278
+        2750,
+        310,
+        600,
+        1260
       ],
       "color": "#3f789e",
       "flags": {}
@@ -391,13 +462,13 @@
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.4170611336747269,
+      "scale": 0.35242360757593566,
       "offset": [
-        -1552.007134958799,
-        432.25027074735493
+        -1323.8609547405556,
+        686.2495442697849
       ]
     },
-    "frontendVersion": "1.43.17"
+    "frontendVersion": "1.51.9"
   },
   "version": 0.4
 }

--- a/templates/api_tripo_image_to_model.json
+++ b/templates/api_tripo_image_to_model.json
@@ -1,19 +1,19 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
+  "id": "6ad1496b-e702-43df-88f7-945ebb8bddde",
   "revision": 0,
-  "last_node_id": 57,
-  "last_link_id": 24,
+  "last_node_id": 58,
+  "last_link_id": 25,
   "nodes": [
     {
       "id": 42,
       "type": "TripoRetargetNode",
       "pos": [
         -2990,
-        1610
+        1882
       ],
       "size": [
         290,
-        98
+        190
       ],
       "flags": {},
       "order": 0,
@@ -40,6 +40,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -48,8 +53,17 @@
         "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "preset:walk"
+        "preset:walk",
+        "glb",
+        true,
+        false
       ],
+      "widgets_values_named": {
+        "animation": "preset:walk",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -58,11 +72,11 @@
       "type": "TripoRigNode",
       "pos": [
         -2990,
-        1460
+        1598
       ],
       "size": [
         290,
-        66
+        206
       ],
       "flags": {},
       "order": 1,
@@ -89,6 +103,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -96,7 +115,18 @@
         "ver": "0.16.3",
         "Node name for S&R": "TripoRigNode"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -109,7 +139,7 @@
       ],
       "size": [
         290,
-        194
+        340
       ],
       "flags": {},
       "order": 2,
@@ -117,7 +147,13 @@
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -136,6 +172,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -148,68 +189,36 @@
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
-    },
-    {
-      "id": 51,
-      "type": "Preview3D",
-      "pos": [
-        -1880,
-        1090
-      ],
-      "size": [
-        600,
-        490
-      ],
-      "flags": {},
-      "order": 6,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "camera_info",
-          "shape": 7,
-          "type": "LOAD3D_CAMERA",
-          "link": null
-        },
-        {
-          "name": "bg_image",
-          "shape": 7,
-          "type": "IMAGE",
-          "link": null
-        },
-        {
-          "name": "model_file",
-          "type": "STRING,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_FBX,FILE_3D_OBJ,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
-          "widget": {
-            "name": "model_file"
-          },
-          "link": 19
-        }
-      ],
-      "outputs": [],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "Preview3D"
-      },
-      "widgets_values": [
-        "",
-        ""
-      ]
     },
     {
       "id": 35,
       "type": "TripoImageToModelNode",
       "pos": [
-        -2220,
+        -2232,
         1090
       ],
       "size": [
-        278.25372314453125,
-        380
+        280,
+        430
       ],
       "flags": {},
       "order": 5,
@@ -225,9 +234,7 @@
         {
           "name": "model_file",
           "type": "STRING",
-          "links": [
-            19
-          ]
+          "links": []
         },
         {
           "name": "model task_id",
@@ -239,6 +246,13 @@
           "type": "FILE_3D_GLB",
           "links": [
             24
+          ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": [
+            25
           ]
         }
       ],
@@ -259,8 +273,26 @@
         "original_image",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        true
       ],
+      "widgets_values_named": {
+        "model_version": "v2.5-20250123",
+        "style": "None",
+        "texture": true,
+        "pbr": true,
+        "model_seed": 42,
+        "orientation": "default",
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": true
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -268,7 +300,7 @@
       "id": 57,
       "type": "SaveGLB",
       "pos": [
-        -1220,
+        -1326,
         1090
       ],
       "size": [
@@ -276,12 +308,12 @@
         480
       ],
       "flags": {},
-      "order": 7,
+      "order": 6,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 24
         }
       ],
@@ -293,7 +325,11 @@
       "widgets_values": [
         "3d/tripo_img2model",
         ""
-      ]
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/tripo_img2model",
+        "image": ""
+      }
     },
     {
       "id": 36,
@@ -304,7 +340,7 @@
       ],
       "size": [
         270,
-        326
+        350
       ],
       "flags": {},
       "order": 3,
@@ -332,14 +368,18 @@
       "widgets_values": [
         "api_tripo_image_to_model_input_image.jpg",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "api_tripo_image_to_model_input_image.jpg",
+        "upload": "image"
+      }
     },
     {
       "id": 49,
       "type": "MarkdownNote",
       "pos": [
-        -2220,
-        1550
+        -2230,
+        1580
       ],
       "size": [
         280,
@@ -355,8 +395,46 @@
       "widgets_values": [
         "Output model will be auto saved to \"ComfyUI/output/\"\n\nOr you can use the export function in the preview 3D node to download it."
       ],
+      "widgets_values_named": {
+        "text": "Output model will be auto saved to \"ComfyUI/output/\"\n\nOr you can use the export function in the preview 3D node to download it."
+      },
       "color": "#222",
       "bgcolor": "#000"
+    },
+    {
+      "id": 58,
+      "type": "SaveGLB",
+      "pos": [
+        -1904,
+        1090
+      ],
+      "size": [
+        530,
+        480
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "mesh",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
+          "link": 25
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3"
+      },
+      "widgets_values": [
+        "3d/tripo_img2model",
+        ""
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/tripo_img2model",
+        "image": ""
+      }
     }
   ],
   "links": [
@@ -369,20 +447,20 @@
       "IMAGE"
     ],
     [
-      19,
-      35,
-      0,
-      51,
-      2,
-      "STRING"
-    ],
-    [
       24,
       35,
       2,
       57,
       0,
       "FILE_3D_GLB"
+    ],
+    [
+      25,
+      35,
+      3,
+      58,
+      0,
+      "FILE_3D_FBX"
     ]
   ],
   "groups": [
@@ -392,24 +470,23 @@
       "bounding": [
         -3080,
         1050,
-        490,
-        740
+        480,
+        1070
       ],
       "color": "#3f789e",
-      "font_size": 24,
       "flags": {}
     }
   ],
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.5744731782387619,
+      "scale": 0.3711105994564854,
       "offset": [
-        3472.4861295156925,
-        -521.093712158314
+        3961.6114227915027,
+        142.0432564158118
       ]
     },
-    "frontendVersion": "1.39.19",
+    "frontendVersion": "1.51.9",
     "workflowRendererVersion": "LG",
     "VHS_latentpreview": false,
     "VHS_latentpreviewrate": 0,

--- a/templates/api_tripo_multiview_to_model.json
+++ b/templates/api_tripo_multiview_to_model.json
@@ -1,8 +1,8 @@
 {
   "id": "ef49adbe-6e63-45c0-9f29-fa4677f627ac",
   "revision": 0,
-  "last_node_id": 43,
-  "last_link_id": 23,
+  "last_node_id": 45,
+  "last_link_id": 24,
   "nodes": [
     {
       "id": 7,
@@ -12,8 +12,8 @@
         1330
       ],
       "size": [
-        274.080078125,
-        314
+        280,
+        350
       ],
       "flags": {},
       "order": 0,
@@ -42,18 +42,22 @@
       "widgets_values": [
         "api_tripo_multiview_to_model_front_image.jpg",
         "image"
-      ]
+      ],
+      "widgets_values_named": {
+        "image": "api_tripo_multiview_to_model_front_image.jpg",
+        "upload": "image"
+      }
     },
     {
       "id": 8,
       "type": "LoadImage",
       "pos": [
-        -6500,
+        -6472,
         1330
       ],
       "size": [
-        274.080078125,
-        314
+        280,
+        350
       ],
       "flags": {},
       "order": 1,
@@ -82,148 +86,25 @@
       "widgets_values": [
         "api_tripo_multiview_to_model_back_image.jpg",
         "image"
-      ]
-    },
-    {
-      "id": 9,
-      "type": "LoadImage",
-      "pos": [
-        -6800,
-        1700
       ],
-      "size": [
-        274.080078125,
-        314
-      ],
-      "flags": {},
-      "order": 2,
-      "mode": 4,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [
-            7
-          ]
-        },
-        {
-          "name": "MASK",
-          "type": "MASK",
-          "links": null
-        }
-      ],
-      "title": "Load Image: left",
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "LoadImage"
-      },
-      "widgets_values": [
-        "api_tripo_multiview_to_model_front_image.jpg",
-        "image"
-      ]
-    },
-    {
-      "id": 10,
-      "type": "LoadImage",
-      "pos": [
-        -6500,
-        1700
-      ],
-      "size": [
-        274.080078125,
-        314
-      ],
-      "flags": {},
-      "order": 3,
-      "mode": 4,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "links": [
-            8
-          ]
-        },
-        {
-          "name": "MASK",
-          "type": "MASK",
-          "links": null
-        }
-      ],
-      "title": "Load Image: right",
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "LoadImage"
-      },
-      "widgets_values": [
-        "api_tripo_multiview_to_model_back_image.jpg",
-        "image"
-      ]
-    },
-    {
-      "id": 38,
-      "type": "TripoRefineNode",
-      "pos": [
-        -7330,
-        1770
-      ],
-      "size": [
-        320.6015625,
-        66
-      ],
-      "flags": {},
-      "order": 4,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": null
-        },
-        {
-          "name": "model task_id",
-          "type": "MODEL_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "TripoRefineNode"
-      },
-      "widgets_values": [],
-      "color": "#432",
-      "bgcolor": "#653"
+      "widgets_values_named": {
+        "image": "api_tripo_multiview_to_model_back_image.jpg",
+        "upload": "image"
+      }
     },
     {
       "id": 39,
       "type": "TripoRigNode",
       "pos": [
         -7330,
-        1910
+        2004
       ],
       "size": [
-        320.6015625,
-        66
+        330,
+        206
       ],
       "flags": {},
-      "order": 5,
+      "order": 2,
       "mode": 4,
       "inputs": [
         {
@@ -247,6 +128,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -254,7 +140,18 @@
         "ver": "0.16.3",
         "Node name for S&R": "TripoRigNode"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -263,14 +160,14 @@
       "type": "TripoRetargetNode",
       "pos": [
         -7330,
-        1610
+        1752
       ],
       "size": [
-        320.6015625,
-        98
+        330,
+        190
       ],
       "flags": {},
-      "order": 6,
+      "order": 3,
       "mode": 4,
       "inputs": [
         {
@@ -294,6 +191,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -302,8 +204,17 @@
         "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "preset:idle"
+        "preset:idle",
+        "glb",
+        true,
+        false
       ],
+      "widgets_values_named": {
+        "animation": "preset:idle",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -312,23 +223,29 @@
       "type": "TripoConversionNode",
       "pos": [
         -7330,
-        2040
+        2272
       ],
       "size": [
-        320.6015625,
-        466
+        330,
+        470
       ],
       "flags": {},
-      "order": 7,
+      "order": 4,
       "mode": 4,
       "inputs": [
         {
           "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",
+          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID,SEGMENT_TASK_ID",
           "link": null
         }
       ],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "model_3d",
+          "type": "FILE_3D",
+          "links": null
+        }
+      ],
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.16.3",
@@ -354,6 +271,26 @@
         "default",
         false
       ],
+      "widgets_values_named": {
+        "format": "GLTF",
+        "quad": false,
+        "face_limit": -1,
+        "texture_size": 4096,
+        "texture_format": "JPEG",
+        "force_symmetry": false,
+        "flatten_bottom": false,
+        "flatten_bottom_threshold": 0,
+        "pivot_to_center_bottom": false,
+        "scale_factor": 1,
+        "with_animation": false,
+        "pack_uv": false,
+        "bake": false,
+        "part_names": "",
+        "fbx_preset": "blender",
+        "export_vertex_colors": false,
+        "export_orientation": "default",
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -365,16 +302,22 @@
         1350
       ],
       "size": [
-        320.6015625,
-        194
+        330,
+        340
       ],
       "flags": {},
-      "order": 8,
+      "order": 5,
       "mode": 4,
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -392,6 +335,11 @@
         {
           "name": "GLB",
           "type": "FILE_3D_GLB",
+          "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
           "links": null
         }
       ],
@@ -405,132 +353,44 @@
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
-    },
-    {
-      "id": 20,
-      "type": "MarkdownNote",
-      "pos": [
-        -6800,
-        2100
-      ],
-      "size": [
-        310,
-        140
-      ],
-      "flags": {},
-      "order": 9,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [],
-      "title": "About Image Inputs",
-      "properties": {},
-      "widgets_values": [
-        "At least one additional view other than the front view is required as input."
-      ],
-      "color": "#222",
-      "bgcolor": "#000"
-    },
-    {
-      "id": 32,
-      "type": "Preview3D",
-      "pos": [
-        -5830,
-        1300
-      ],
-      "size": [
-        560,
-        580
-      ],
-      "flags": {},
-      "order": 11,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "camera_info",
-          "shape": 7,
-          "type": "LOAD3D_CAMERA",
-          "link": null
-        },
-        {
-          "name": "bg_image",
-          "shape": 7,
-          "type": "IMAGE",
-          "link": null
-        },
-        {
-          "name": "model_file",
-          "type": "STRING,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_FBX,FILE_3D_OBJ,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
-          "widget": {
-            "name": "model_file"
-          },
-          "link": 17
-        }
-      ],
-      "outputs": [],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "Preview3D",
-        "Camera Info": {
-          "position": {
-            "x": 7.153772791183921,
-            "y": 7.153772791183921,
-            "z": 7.153772791183922
-          },
-          "target": {
-            "x": 0,
-            "y": 0,
-            "z": 0
-          },
-          "zoom": 1,
-          "cameraType": "perspective"
-        },
-        "Camera Config": {
-          "cameraType": "perspective",
-          "fov": 75,
-          "state": {
-            "position": {
-              "x": 10.20205813426769,
-              "y": 10.20205813426769,
-              "z": 10.202058134267691
-            },
-            "target": {
-              "x": 0,
-              "y": 0,
-              "z": 0
-            },
-            "zoom": 1,
-            "cameraType": "perspective"
-          }
-        }
-      },
-      "widgets_values": [
-        "",
-        ""
-      ]
     },
     {
       "id": 43,
       "type": "SaveGLB",
       "pos": [
-        -5210,
-        1300
+        -5338,
+        1330
       ],
       "size": [
         440,
         560
       ],
       "flags": {},
-      "order": 12,
+      "order": 7,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 23
         }
       ],
@@ -542,21 +402,25 @@
       "widgets_values": [
         "3d/ComfyUI",
         ""
-      ]
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/ComfyUI",
+        "image": ""
+      }
     },
     {
       "id": 6,
       "type": "TripoMultiviewToModelNode",
       "pos": [
-        -6160,
-        1300
+        -6140,
+        1330
       ],
       "size": [
         270,
-        384
+        410
       ],
       "flags": {},
-      "order": 10,
+      "order": 6,
       "mode": 0,
       "inputs": [
         {
@@ -568,7 +432,7 @@
           "name": "image_left",
           "shape": 7,
           "type": "IMAGE",
-          "link": 7
+          "link": null
         },
         {
           "name": "image_back",
@@ -580,16 +444,14 @@
           "name": "image_right",
           "shape": 7,
           "type": "IMAGE",
-          "link": 8
+          "link": null
         }
       ],
       "outputs": [
         {
           "name": "model_file",
           "type": "STRING",
-          "links": [
-            17
-          ]
+          "links": []
         },
         {
           "name": "model task_id",
@@ -601,6 +463,13 @@
           "type": "FILE_3D_GLB",
           "links": [
             23
+          ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": [
+            24
           ]
         }
       ],
@@ -620,10 +489,62 @@
         "original_image",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        false
       ],
+      "widgets_values_named": {
+        "model_version": "v2.5-20250123",
+        "orientation": "default",
+        "texture": true,
+        "pbr": true,
+        "model_seed": 42,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": false
+      },
       "color": "#432",
       "bgcolor": "#653"
+    },
+    {
+      "id": 44,
+      "type": "SaveGLB",
+      "pos": [
+        -5826,
+        1330
+      ],
+      "size": [
+        440,
+        560
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "mesh",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
+          "link": 24
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3"
+      },
+      "widgets_values": [
+        "3d/ComfyUI",
+        ""
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/ComfyUI",
+        "image": ""
+      }
     }
   ],
   "links": [
@@ -644,76 +565,46 @@
       "IMAGE"
     ],
     [
-      7,
-      9,
-      0,
-      6,
-      1,
-      "IMAGE"
-    ],
-    [
-      8,
-      10,
-      0,
-      6,
-      3,
-      "IMAGE"
-    ],
-    [
-      17,
-      6,
-      0,
-      32,
-      2,
-      "STRING"
-    ],
-    [
       23,
       6,
       2,
       43,
       0,
       "FILE_3D_GLB"
+    ],
+    [
+      24,
+      6,
+      3,
+      44,
+      0,
+      "FILE_3D_FBX"
     ]
   ],
   "groups": [
-    {
-      "id": 1,
-      "title": "Upload input image",
-      "bounding": [
-        -6810,
-        1260,
-        594.080078125,
-        767.5999755859375
-      ],
-      "color": "#3f789e",
-      "font_size": 24,
-      "flags": {}
-    },
     {
       "id": 2,
       "title": "Tripo Toolset (select and ctrl-b to enable)",
       "bounding": [
         -7460,
         1260,
-        610,
-        1290
+        600,
+        1640
       ],
       "color": "#3f789e",
-      "font_size": 24,
       "flags": {}
     }
   ],
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.5185323388193798,
+      "scale": 0.5030571131630697,
       "offset": [
-        8120.056515956135,
-        -753.4280161337068
+        7905.688828137873,
+        -872.8713166442956
       ]
     },
-    "frontendVersion": "1.39.19",
+    "frontendVersion": "1.51.9",
     "workflowRendererVersion": "LG",
     "VHS_latentpreview": false,
     "VHS_latentpreviewrate": 0,

--- a/templates/api_tripo_text_to_model.json
+++ b/templates/api_tripo_text_to_model.json
@@ -1,98 +1,19 @@
 {
   "id": "ef49adbe-6e63-45c0-9f29-fa4677f627ac",
   "revision": 0,
-  "last_node_id": 27,
-  "last_link_id": 18,
+  "last_node_id": 28,
+  "last_link_id": 19,
   "nodes": [
-    {
-      "id": 17,
-      "type": "Preview3D",
-      "pos": [
-        -5808,
-        1290
-      ],
-      "size": [
-        820,
-        710
-      ],
-      "flags": {},
-      "order": 8,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "camera_info",
-          "shape": 7,
-          "type": "LOAD3D_CAMERA",
-          "link": null
-        },
-        {
-          "name": "bg_image",
-          "shape": 7,
-          "type": "IMAGE",
-          "link": null
-        },
-        {
-          "name": "model_file",
-          "type": "STRING,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_FBX,FILE_3D_OBJ,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
-          "widget": {
-            "name": "model_file"
-          },
-          "link": 13
-        }
-      ],
-      "outputs": [],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "Preview3D",
-        "Camera Info": {
-          "position": {
-            "x": 7.2460986315374365,
-            "y": 7.2460986315374365,
-            "z": 7.246098631537437
-          },
-          "target": {
-            "x": 0,
-            "y": 0,
-            "z": 0
-          },
-          "zoom": 1,
-          "cameraType": "perspective"
-        },
-        "Camera Config": {
-          "cameraType": "perspective",
-          "fov": 75,
-          "state": {
-            "position": {
-              "x": 9.465951122580117,
-              "y": 9.465951122580117,
-              "z": 9.465951122580119
-            },
-            "target": {
-              "x": 0,
-              "y": 0,
-              "z": 0
-            },
-            "zoom": 1,
-            "cameraType": "perspective"
-          }
-        }
-      },
-      "widgets_values": [
-        "",
-        ""
-      ]
-    },
     {
       "id": 6,
       "type": "TripoRigNode",
       "pos": [
-        -7180,
-        1510
+        -7200,
+        1620
       ],
       "size": [
-        310.453125,
-        66
+        320,
+        206
       ],
       "flags": {},
       "order": 0,
@@ -119,6 +40,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -126,7 +52,18 @@
         "ver": "0.16.3",
         "Node name for S&R": "TripoRigNode"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        "v1.0-20240301",
+        "auto",
+        "tripo",
+        "glb"
+      ],
+      "widgets_values_named": {
+        "model_version": "v1.0-20240301",
+        "rig_type": "auto",
+        "spec": "tripo",
+        "out_format": "glb"
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -134,12 +71,12 @@
       "id": 8,
       "type": "TripoConversionNode",
       "pos": [
-        -7180,
-        1650
+        -7200,
+        1880
       ],
       "size": [
-        310.453125,
-        466
+        320,
+        470
       ],
       "flags": {},
       "order": 1,
@@ -147,11 +84,17 @@
       "inputs": [
         {
           "name": "original_model_task_id",
-          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID",
+          "type": "MODEL_TASK_ID,RIG_TASK_ID,RETARGET_TASK_ID,SEGMENT_TASK_ID",
           "link": null
         }
       ],
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "model_3d",
+          "type": "FILE_3D",
+          "links": null
+        }
+      ],
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.16.3",
@@ -177,6 +120,26 @@
         "default",
         false
       ],
+      "widgets_values_named": {
+        "format": "GLTF",
+        "quad": false,
+        "face_limit": -1,
+        "texture_size": 4096,
+        "texture_format": "JPEG",
+        "force_symmetry": false,
+        "flatten_bottom": false,
+        "flatten_bottom_threshold": 0,
+        "pivot_to_center_bottom": false,
+        "scale_factor": 1,
+        "with_animation": false,
+        "pack_uv": false,
+        "bake": false,
+        "part_names": "",
+        "fbx_preset": "blender",
+        "export_vertex_colors": false,
+        "export_orientation": "default",
+        "animate_in_place": false
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -184,12 +147,12 @@
       "id": 9,
       "type": "TripoTextureNode",
       "pos": [
-        -7180,
-        2180
+        -7200,
+        2420
       ],
       "size": [
-        310.453125,
-        194
+        320,
+        340
       ],
       "flags": {},
       "order": 2,
@@ -197,7 +160,13 @@
       "inputs": [
         {
           "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
+          "type": "MODEL_TASK_ID,SEGMENT_TASK_ID",
+          "link": null
+        },
+        {
+          "name": "style_image",
+          "shape": 7,
+          "type": "IMAGE",
           "link": null
         }
       ],
@@ -216,6 +185,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -228,8 +202,23 @@
         true,
         42,
         "standard",
-        "original_image"
+        "original_image",
+        "",
+        "v3.0-20250812",
+        "none",
+        ""
       ],
+      "widgets_values_named": {
+        "texture": true,
+        "pbr": true,
+        "texture_seed": 42,
+        "texture_quality": "standard",
+        "texture_alignment": "original_image",
+        "texture_prompt": "",
+        "model_version": "v3.0-20250812",
+        "reference": "none",
+        "part_names": ""
+      },
       "color": "#432",
       "bgcolor": "#653"
     },
@@ -237,12 +226,12 @@
       "id": 7,
       "type": "TripoRetargetNode",
       "pos": [
-        -7180,
-        1350
+        -7200,
+        1370
       ],
       "size": [
-        310.453125,
-        98
+        320,
+        190
       ],
       "flags": {},
       "order": 3,
@@ -269,6 +258,11 @@
           "name": "GLB",
           "type": "FILE_3D_GLB",
           "links": null
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": null
         }
       ],
       "properties": {
@@ -277,104 +271,40 @@
         "Node name for S&R": "TripoRetargetNode"
       },
       "widgets_values": [
-        "preset:walk"
+        "preset:walk",
+        "glb",
+        true,
+        false
       ],
-      "color": "#432",
-      "bgcolor": "#653"
-    },
-    {
-      "id": 10,
-      "type": "TripoRefineNode",
-      "pos": [
-        -6790,
-        1560
-      ],
-      "size": [
-        330,
-        80
-      ],
-      "flags": {},
-      "order": 4,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model_task_id",
-          "type": "MODEL_TASK_ID",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "model_file",
-          "type": "STRING",
-          "links": []
-        },
-        {
-          "name": "model task_id",
-          "type": "MODEL_TASK_ID",
-          "links": null
-        },
-        {
-          "name": "GLB",
-          "type": "FILE_3D_GLB",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.16.3",
-        "Node name for S&R": "TripoRefineNode"
+      "widgets_values_named": {
+        "animation": "preset:walk",
+        "out_format": "glb",
+        "export_with_geometry": true,
+        "animate_in_place": false
       },
-      "widgets_values": [],
       "color": "#432",
       "bgcolor": "#653"
-    },
-    {
-      "id": 11,
-      "type": "MarkdownNote",
-      "pos": [
-        -6800,
-        1400
-      ],
-      "size": [
-        340,
-        88
-      ],
-      "flags": {},
-      "order": 5,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [],
-      "title": "About Refine Draft model",
-      "properties": {},
-      "widgets_values": [
-        "This one only available when using the model of version v1.4.\n"
-      ],
-      "color": "#322",
-      "bgcolor": "#000"
     },
     {
       "id": 3,
       "type": "TripoTextToModelNode",
       "pos": [
-        -6240,
-        1290
+        -6700,
+        1330
       ],
       "size": [
         320,
         540
       ],
       "flags": {},
-      "order": 6,
+      "order": 4,
       "mode": 0,
       "inputs": [],
       "outputs": [
         {
           "name": "model_file",
           "type": "STRING",
-          "links": [
-            13
-          ]
+          "links": []
         },
         {
           "name": "model task_id",
@@ -386,6 +316,13 @@
           "type": "FILE_3D_GLB",
           "links": [
             18
+          ]
+        },
+        {
+          "name": "FBX",
+          "type": "FILE_3D_FBX",
+          "links": [
+            19
           ]
         }
       ],
@@ -407,53 +344,48 @@
         "detailed",
         -1,
         false,
-        "standard"
+        "standard",
+        false,
+        true
       ],
+      "widgets_values_named": {
+        "prompt": "Generate a 3D model of a steampunk-inspired spider drone with brass legs, steam vents, and a camera eye, set in a crouched, ready-to-leap posture.\n",
+        "negative_prompt": "",
+        "model_version": "v2.5-20250123",
+        "style": "None",
+        "texture": true,
+        "pbr": true,
+        "image_seed": 42,
+        "model_seed": 42,
+        "texture_seed": 42,
+        "texture_quality": "detailed",
+        "face_limit": -1,
+        "quad": false,
+        "geometry_quality": "standard",
+        "smart_low_poly": false,
+        "auto_size": true
+      },
       "color": "#432",
       "bgcolor": "#653"
-    },
-    {
-      "id": 5,
-      "type": "MarkdownNote",
-      "pos": [
-        -5810,
-        2060
-      ],
-      "size": [
-        280,
-        150
-      ],
-      "flags": {},
-      "order": 7,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [],
-      "title": "Save location",
-      "properties": {},
-      "widgets_values": [
-        "Output model will be auto saved to \"ComfyUI/output/\"\n\nOr you can use the export function in the preview 3D node to download it.\n"
-      ],
-      "color": "#222",
-      "bgcolor": "#000"
     },
     {
       "id": 27,
       "type": "SaveGLB",
       "pos": [
-        -4876,
-        1290
+        -5564,
+        1330
       ],
       "size": [
         720,
         700
       ],
       "flags": {},
-      "order": 9,
+      "order": 5,
       "mode": 0,
       "inputs": [
         {
           "name": "mesh",
-          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
           "link": 18
         }
       ],
@@ -465,18 +397,49 @@
       "widgets_values": [
         "3d/tripo_text2model",
         ""
-      ]
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/tripo_text2model",
+        "image": ""
+      }
+    },
+    {
+      "id": 28,
+      "type": "SaveGLB",
+      "pos": [
+        -6332,
+        1330
+      ],
+      "size": [
+        720,
+        700
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "mesh",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
+          "link": 19
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.16.3"
+      },
+      "widgets_values": [
+        "3d/tripo_text2model",
+        ""
+      ],
+      "widgets_values_named": {
+        "filename_prefix": "3d/tripo_text2model",
+        "image": ""
+      }
     }
   ],
   "links": [
-    [
-      13,
-      3,
-      0,
-      17,
-      2,
-      "STRING"
-    ],
     [
       18,
       3,
@@ -484,6 +447,14 @@
       27,
       0,
       "FILE_3D_GLB"
+    ],
+    [
+      19,
+      3,
+      3,
+      28,
+      0,
+      "FILE_3D_FBX"
     ]
   ],
   "groups": [
@@ -493,37 +464,23 @@
       "bounding": [
         -7300,
         1270,
-        980,
-        1150
+        540,
+        1600
       ],
       "color": "#3f789e",
-      "font_size": 24,
-      "flags": {}
-    },
-    {
-      "id": 1,
-      "title": "Refine Draft model",
-      "bounding": [
-        -6810,
-        1330,
-        370,
-        350
-      ],
-      "color": "#3f789e",
-      "font_size": 24,
       "flags": {}
     }
   ],
   "config": {},
   "extra": {
     "ds": {
-      "scale": 0.37554299838589866,
+      "scale": 0.31564621743461,
       "offset": [
-        8742.355086050706,
-        -180.60344531311344
+        8477.902093345483,
+        -438.96853555816597
       ]
     },
-    "frontendVersion": "1.39.19",
+    "frontendVersion": "1.51.9",
     "workflowRendererVersion": "LG",
     "VHS_latentpreview": false,
     "VHS_latentpreviewrate": 0,

--- a/templates/index.ar.json
+++ b/templates/index.ar.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.es.json
+++ b/templates/index.es.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.fa.json
+++ b/templates/index.fa.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.fr.json
+++ b/templates/index.fr.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.ja.json
+++ b/templates/index.ja.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.json
+++ b/templates/index.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.ko.json
+++ b/templates/index.ko.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.mcp.json
+++ b/templates/index.mcp.json
@@ -8845,7 +8845,7 @@
           "inputs": ["image: Reference image of the object for 3D model generation"],
           "outputs": ["model: Generated 3D model with dense geometry and PBR textures using Tripo H3.1"]
         },
-        "minComfyUIVersion": "0.3.37",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["api", "image-to-3d"]
         }
@@ -9100,7 +9100,7 @@
           "inputs": ["text: Text prompt describing the desired 3D model"],
           "outputs": ["model: Generated 3D model in GLB format with PBR materials"]
         },
-        "minComfyUIVersion": "0.3.37",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["api", "text-to-model"]
         }
@@ -9118,7 +9118,7 @@
           "inputs": ["image×4: Multi-view images (front, left, back, right) of the object"],
           "outputs": ["model: Generated 3D model in GLB format with PBR materials"]
         },
-        "minComfyUIVersion": "0.3.37",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["api", "image-to-3d"]
         }
@@ -9136,7 +9136,7 @@
           "inputs": ["image: Reference image or sketch to convert to 3D"],
           "outputs": ["model: Generated 3D model in GLB format with textures"]
         },
-        "minComfyUIVersion": "0.8.0",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["image-to-model", "api"]
         }
@@ -9193,7 +9193,7 @@
           "inputs": ["text: Text prompt describing the desired 3D model"],
           "outputs": ["model: Generated 3D model in GLB format with PBR materials"]
         },
-        "minComfyUIVersion": "0.3.37",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["text-to-model", "api"]
         }
@@ -9211,7 +9211,7 @@
           "inputs": ["text: Text prompt describing the desired 3D model"],
           "outputs": ["model: Generated 3D model in GLB format"]
         },
-        "minComfyUIVersion": "0.3.37",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["text-to-model", "api"]
         }
@@ -9229,7 +9229,7 @@
           "inputs": ["image: Reference image to convert to 3D model"],
           "outputs": ["model: Generated 3D model in GLB format"]
         },
-        "minComfyUIVersion": "0.3.37",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["image-to-model", "api"]
         }
@@ -9247,7 +9247,7 @@
           "inputs": ["image×2: Multi-view images (front view plus at least one additional angle)"],
           "outputs": ["model: Generated 3D model in GLB format"]
         },
-        "minComfyUIVersion": "0.3.37",
+        "minComfyUIVersion": "0.34.0",
         "capabilities": {
           "workflow": ["image-to-3d", "api"]
         }

--- a/templates/index.mcp.json
+++ b/templates/index.mcp.json
@@ -8840,10 +8840,10 @@
         "freshness": "current",
         "usage": 340,
         "recommend": "medium",
-        "description": "Generate a 3D model from a reference image using Tripo H3.1. The output is a high-detail model with dense geometry and PBR-ready materials in GLB format. This workflow calls a third-party API; execution time depends on server response.",
+        "description": "Upload a reference image of your object. Generate a high-detail 3D model with dense geometry and PBR-ready materials.",
         "io": {
-          "inputs": ["image: Reference image of the object for 3D model generation"],
-          "outputs": ["model: Generated 3D model with dense geometry and PBR textures using Tripo H3.1"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {
@@ -9095,10 +9095,10 @@
         "freshness": "current",
         "usage": 7,
         "recommend": "not_recommended",
-        "description": "Input a text prompt with Tripo H3.1 to generate production-ready 3D hero assets featuring high-density geometry and PBR materials. Outputs detailed GLB meshes with auto-refine, auto-rig, and auto-texture, suitable for game assets and close-up renders. This is a third-party API workflow—response time depends on server load.",
+        "description": "Generate production-ready 3D hero assets with high-density geometry and PBR materials. Takes text prompts or reference images as input and outputs detailed 3D meshes suitable for close-up renders and game assets.",
         "io": {
-          "inputs": ["text: Text prompt describing the desired 3D model"],
-          "outputs": ["model: Generated 3D model in GLB format with PBR materials"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {
@@ -9113,10 +9113,10 @@
         "freshness": "current",
         "usage": 35,
         "recommend": "not_recommended",
-        "description": "This workflow takes four multi-view images (front, left, back, right) and generates a high-detail 3D model using Tripo H3.1. It outputs a GLB file with dense geometry, PBR materials, auto-refine, auto-rig, and auto-texture. Since it calls a third-party API, execution time depends on server-side response.",
+        "description": "Upload multiview images of your object. Generate a high-detail 3D model with dense geometry and PBR-ready materials.",
         "io": {
-          "inputs": ["image×4: Multi-view images (front, left, back, right) of the object"],
-          "outputs": ["model: Generated 3D model in GLB format with PBR materials"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {
@@ -9131,10 +9131,10 @@
         "freshness": "established",
         "usage": 30,
         "recommend": "not_recommended",
-        "description": "Transform a reference image or sketch into a production-ready 3D model using Tripo 3.0 via API. The workflow outputs GLB format with sharp geometry and PBR textures, supporting auto-refine, auto-rig, and auto-texture. Execution time depends on server-side response.",
+        "description": "Transform images or sketches into 3D models with Tripo 3.0's sharp geometry and production-ready PBR textures.",
         "io": {
-          "inputs": ["image: Reference image or sketch to convert to 3D"],
-          "outputs": ["model: Generated 3D model in GLB format with textures"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {
@@ -9188,10 +9188,10 @@
         "freshness": "established",
         "usage": 8,
         "recommend": "not_recommended",
-        "description": "Generate a 3D model from a text prompt using Tripo 3.0, producing a GLB file with ultra‑high resolution geometry and PBR materials. This workflow relies on a third‑party API, so response time depends on server‑side processing.",
+        "description": "Generate precise 3D models from text with Tripo 3.0's ultra-high resolution geometry and realistic PBR materials.",
         "io": {
-          "inputs": ["text: Text prompt describing the desired 3D model"],
-          "outputs": ["model: Generated 3D model in GLB format with PBR materials"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {
@@ -9206,10 +9206,10 @@
         "freshness": "established",
         "usage": 8,
         "recommend": "not_recommended",
-        "description": "Use Tripo's text-driven 3D generation by providing a text prompt. This workflow calls a third-party API to produce a refined, textured GLB 3D model, leveraging Tripo's automatic refinement, rigging, and conversion capabilities.",
+        "description": "Craft 3D objects from descriptions with Tripo's text-driven modeling.",
         "io": {
-          "inputs": ["text: Text prompt describing the desired 3D model"],
-          "outputs": ["model: Generated 3D model in GLB format"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {
@@ -9224,10 +9224,10 @@
         "freshness": "established",
         "usage": 8,
         "recommend": "not_recommended",
-        "description": "Generate a 3D model from a 2D reference image using Tripo’s engine. Input an image and receive a GLB-format 3D asset with auto-rigging and texturing. This workflow relies on a third-party API, so response time depends on server-side processing.",
+        "description": "Generate professional 3D assets from 2D images using Tripo engine.",
         "io": {
-          "inputs": ["image: Reference image to convert to 3D model"],
-          "outputs": ["model: Generated 3D model in GLB format"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {
@@ -9242,10 +9242,10 @@
         "freshness": "established",
         "usage": 6,
         "recommend": "not_recommended",
-        "description": "Use Tripo's API to generate a 3D model in GLB format from two or more multi-view images (front view plus at least one additional angle). The workflow supports auto-refine, auto-rig, auto-texture, conversion, and retargeting. Because this workflow calls a third-party API, execution time depends on server-side response.",
+        "description": "Build 3D models from multiple angles with Tripo's advanced scanner.",
         "io": {
-          "inputs": ["image×2: Multi-view images (front view plus at least one additional angle)"],
-          "outputs": ["model: Generated 3D model in GLB format"]
+          "inputs": ["text: Prompt"],
+          "outputs": ["image: Generated output"]
         },
         "minComfyUIVersion": "0.34.0",
         "capabilities": {

--- a/templates/index.pt-BR.json
+++ b/templates/index.pt-BR.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.ru.json
+++ b/templates/index.ru.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.tr.json
+++ b/templates/index.tr.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.zh-TW.json
+++ b/templates/index.zh-TW.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",

--- a/templates/index.zh.json
+++ b/templates/index.zh.json
@@ -15518,7 +15518,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_p1_image_to_model",
@@ -15883,7 +15883,7 @@
         "usage": 7,
         "searchRank": 0,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_1_multiview_to_model",
@@ -15926,7 +15926,7 @@
             }
           ]
         },
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo3_0_image_to_model",
@@ -15963,7 +15963,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.8.0"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "templates_mjm_image_to_3d",
@@ -16027,7 +16027,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_text_to_model",
@@ -16043,7 +16043,7 @@
         "size": 0,
         "usage": 8,
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_image_to_model",
@@ -16069,7 +16069,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_tripo_multiview_to_model",
@@ -16101,7 +16101,7 @@
           ]
         },
         "username": "ComfyUI",
-        "minComfyUIVersion": "0.3.37"
+        "minComfyUIVersion": "0.34.0"
       },
       {
         "name": "api_rodin_gen2",


### PR DESCRIPTION
## Summary
- Replace eight Tripo workflow files: `api_tripo_*`, `api_tripo3_0_*`, and `api_tripo3_1_*` (text / image / multiview).
- Raise `minComfyUIVersion` to `0.34.0` on those templates in the hub and MCP indexes so they match the newer partner-node build.

## Test plan
- [ ] Open each updated workflow in ComfyUI 0.34.0+
- [ ] Confirm older ComfyUI versions show the minimum-version gate
- [ ] Spot-check titles still appear correctly in locale indexes