### PR TITLE
docs: point workflow site links to comfy.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo hosts the official ComfyUI **workflow templates** and **subgraph bluep
 |---------|-------------|----------|
 | **Workflow Templates** | Full standalone workflows for the template picker | `templates/`, `packages/` |
 | **Subgraph Blueprints** | Reusable node components that appear in the node palette | `blueprints/`, `packages/blueprints/` |
-| **Template Site** | Astro SSG that showcases templates at [templates.comfy.org](https://templates.comfy.org) | `site/` |
+| **Template Site** | Astro SSG that showcases templates at [comfy.org/workflows](https://comfy.org/workflows/) | `site/` |
 
 The repository uses a **package-per-media** structure for Python distribution:
 

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Astro 5 static site with Vue 3 interactive islands. Consumes template data from `../templates/` and deploys to templates.comfy.org via Vercel.
+Astro 5 static site with Vue 3 interactive islands. Consumes template data from `../templates/` and deploys to [comfy.org/workflows](https://comfy.org/workflows/) via Vercel.
 
 ## ⚠️ Scope Boundaries
 


### PR DESCRIPTION
Fixes #1244.\n\nThe Template Site is now served at https://comfy.org/workflows/ (verified HTTP 200), while templates.comfy.org currently fails DNS resolution from the audit environment. Update the README overview and site contributor instructions to use the reachable canonical workflow URL.\n\nValidation:\n- git diff --check\n- https://comfy.org/workflows/ returned HTTP 200\n- Confirmed site/astro.config.mjs and site/vercel.json default PUBLIC_SITE_ORIGIN to https://comfy.org\n\nNo build is needed for this documentation-only change.