### PR TITLE
feat(site): curated descriptions for the four entity-graph workflows

### DIFF
--- a/site/scripts/i18n/build-content-source.ts
+++ b/site/scripts/i18n/build-content-source.ts
@@ -34,6 +34,7 @@ import {
   type WorkflowSourceHashes,
 } from '../../src/lib/i18n/schema';
 import { SUPPORTED_HUB_LOCALES } from '../../src/lib/i18n/locales';
+import { getWorkflowCopy, WORKFLOW_COPY, type WorkflowCopy } from '../../src/data/workflow-copy';
 import { LOCALE_INDEX_FILES } from '../lib/constants';
 
 const I18N_DIR = path.join(process.cwd(), 'src', 'i18n');
@@ -71,6 +72,26 @@ export function extractContent(entry: Record<string, unknown>): WorkflowContent 
     suggestedUseCases: asStringArray(entry.suggestedUseCases),
     faqItems: asFaqItems(entry.faqItems),
   };
+}
+
+/**
+ * Fold the curated English override (`src/data/workflow-copy.ts`) into one
+ * workflow's extracted content, so the English content-of-record — and every
+ * machine translation lobe derives from it — carries the text the English page
+ * renders rather than the hub prose it replaces. Same gate as the page: the copy
+ * applies only while the hub still serves the exact text the entry replaced;
+ * once the hub record is updated the hub text passes through and its changed
+ * hash re-translates the field like any other edit. Temporary stopgap, tracked
+ * in GTM-470; delete this together with workflow-copy.ts.
+ */
+export function applyCuratedCopy(
+  shareId: string,
+  content: WorkflowContent,
+  copy: Record<string, WorkflowCopy> = WORKFLOW_COPY
+): WorkflowContent {
+  const curated = getWorkflowCopy(shareId, content.extendedDescription, copy);
+  if (!curated.extendedDescription) return content;
+  return { ...content, extendedDescription: curated.extendedDescription };
 }
 
 /** Stable 12-hex sha256 of a value (deterministic: fields are built in fixed order). */
@@ -247,10 +268,21 @@ async function main(): Promise<void> {
 
   const english: Record<string, WorkflowContent> = {};
   const nameByShareId: Record<string, string> = {};
+  let curatedApplied = 0;
+  let curatedRetired = 0;
   for (const entry of entries) {
     const shareId = asString(entry.shareId);
     if (!shareId) continue;
-    english[shareId] = extractContent(entry);
+    const extracted = extractContent(entry);
+    const curated = getWorkflowCopy(shareId, extracted.extendedDescription);
+    if (curated.status === 'applied') curatedApplied += 1;
+    if (curated.status === 'retired') {
+      curatedRetired += 1;
+      console.warn(
+        `[i18n] hub record for ${shareId} changed; curated override retired — delete its entry in src/data/workflow-copy.ts (GTM-470)`
+      );
+    }
+    english[shareId] = applyCuratedCopy(shareId, extracted);
     nameByShareId[shareId] = asString(entry.name);
   }
 
@@ -300,7 +332,8 @@ async function main(): Promise<void> {
     `[i18n] content source: ${Object.keys(english).length} workflows, ` +
       `${seededTotal} human seeds across ${SUPPORTED_HUB_LOCALES.length - 1} locales, ` +
       `${staleFieldTotal} changed field(s) across ${Object.keys(stale).length} workflows pruned for re-translation, ` +
-      `${orphanTotal} orphaned machine entr(ies) removed for workflows no longer in the index.`
+      `${orphanTotal} orphaned machine entr(ies) removed for workflows no longer in the index, ` +
+      `${curatedApplied} curated override(s) applied, ${curatedRetired} retired.`
   );
 }
 

--- a/site/src/data/curated-workflow-keys.ts
+++ b/site/src/data/curated-workflow-keys.ts
@@ -1,0 +1,27 @@
+/**
+ * Key resolution shared by every curated per-workflow data file
+ * (`workflow-entity-graphs.ts`, `workflow-copy.ts`).
+ *
+ * Curated data is keyed by the template's snake_case `name` — its
+ * `templates/index.json` filename — because that is what a human editing these
+ * files can recognise. The local content collection exposes exactly that, but
+ * the hub API (`/api/hub/workflows/index`, the primary source in preview and
+ * production builds) exposes the share id instead, so a bare lookup by `name`
+ * misses on every deployed page. Map the share id back to the filename key here
+ * so both indexes resolve to the same entry.
+ */
+const SHARE_ID_TO_KEY: Record<string, string> = {
+  b37902cee452: 'video_ltx2_5_i2v',
+  cd0c4f9f61a4: 'api_seedance2_5_r2v',
+  a781503cf508: 'video_minimax_h3_i2v',
+  '9394f9968da3': 'video_wan_animate2',
+};
+
+/**
+ * The curated-data key for a workflow, given either its snake_case template
+ * name or its hub share id. Unmapped values pass through unchanged, so a plain
+ * template name still works and an unknown share id simply finds no entry.
+ */
+export function curatedKey(nameOrShareId: string): string {
+  return SHARE_ID_TO_KEY[nameOrShareId] ?? nameOrShareId;
+}

--- a/site/src/data/workflow-copy.ts
+++ b/site/src/data/workflow-copy.ts
@@ -1,0 +1,80 @@
+/**
+ * Curated English copy for hub workflow detail pages, keyed the same way as
+ * `workflow-entity-graphs.ts` (see `curated-workflow-keys.ts`).
+ *
+ * The hub API is the source for every other workflow's copy. These four pages
+ * carry client-approved prose written to corroborate the entity graph the page
+ * already emits — the schema names `Codec`, `High Dynamic Range`, `Motion
+ * Interpolation`, `Graphics Processing Unit` and the rest, and this text is
+ * where those terms actually appear on the page. Generated hub copy predates
+ * that schema and does not mention them, so it is overridden here rather than
+ * left to drift.
+ *
+ * Transcribed verbatim from the client-provided content recommendation — do not
+ * paraphrase, re-wrap, or extend entries by extrapolation. Paragraphs are stored
+ * one per array element and joined with a blank line, which is the separator
+ * `TemplateDetailPage.astro` splits on.
+ */
+import { curatedKey } from './curated-workflow-keys';
+
+export interface WorkflowCopy {
+  /** Long-form description shown under the hero, one entry per paragraph. */
+  extendedDescription?: readonly string[];
+}
+
+/** A `WorkflowCopy` with its paragraph arrays collapsed to page-ready strings. */
+export interface ResolvedWorkflowCopy {
+  extendedDescription?: string;
+}
+
+export const WORKFLOW_COPY: Record<string, WorkflowCopy> = {
+  // LTX-2.5: Image to Video
+  video_ltx2_5_i2v: {
+    extendedDescription: [
+      "This ComfyUI workflow turns a single still image into a smooth, high-fidelity video using LTX-2.5, Lightricks' open-source video generation model, with full API access for local, self-hosted rendering. The pipeline is intentionally simple and production-minded: LoadImage ingests your source frame, ResolutionSelector locks in a model-friendly pixel size (multiples of 32) and display aspect ratio, the LTX-2.5 generator node (UUID: 6e397a2b-68f7-48f6-8930-f3a5491a163c) synthesizes a coherent motion sequence with high dynamic range and smooth motion interpolation, and SaveVideo encodes the frames to a ready-to-use MP4 using a standard codec. A MarkdownNote in the graph provides in-UI guidance and links.",
+      'Under the hood, LTX-2.5 uses a keyframes-first "Pixel Diffusion" approach to propagate detail and structure consistently across time. This helps preserve subject identity, lighting, and scene composition from your source footage while introducing controllable motion. ResolutionSelector ensures your chosen 16:9 dimensions conform to model stride (multiples of 32), which is critical for rendering stability and VRAM efficiency on your own computer hardware and GPU. Because it runs entirely locally, you keep full control over your data rather than uploading footage to a third-party service.',
+      'The workflow is built for real production use, not just experimentation: quality holds up across longer sequences, output stays consistent frame to frame, and the node library is editable enough to fit into an existing VFX or content pipeline. You can iterate quickly, refine your prompts, tune duration (frames/fps), and adjust motion strength to meet the needs of previz, VFX look development, camera-driven scenes, and multi-format content delivery, whether the final export needs to run at 1080p for social or full native resolution for a hero placement.',
+    ],
+  },
+
+  // Seedance 2.5: Reference to Video
+  api_seedance2_5_r2v: {
+    extendedDescription: [
+      'Seedance 2.5 builds a single 4–30 second video from up to 20 reference images, 6 video clips, and 6 audio clips, giving you direct control over character identity, visual style, and motion rhythm without manual video editing. ByteDance2ReferenceNode reads your strongest identity shots first and blends them with your reference footage and camera angles, so the output holds a consistent look scene to scene rather than drifting the way single-image generators do. The result plays like a shot pulled straight from a camera rather than a generated clip, which is what makes it hold up for cinematic techniques like coordinated framing and lighting across a short series.',
+      "Audio and picture are generated together rather than layered on afterward: feed in a single clean vocal track, recorded close to the microphone, and Seedance 2.5 handles lip-sync, sound effect timing, and motion pacing so dialogue lands on the frame it's spoken in. Display resolution, aspect ratio, and frame rate are all set upfront, and image stabilization keeps handheld-style motion from reading as noisy motion blur. Preview at a lower resolution and shorter duration to confirm sync and motion first, then scale up to full quality, 1080p or higher, once the take is locked, using a fixed seed to keep comparisons consistent between runs.",
+      'Because reference inputs carry brand assets directly into the output, this is built for repeatable commercial work rather than one-off experiments: product demonstration clips, branded short-form ads, and character-driven series that need to hold quality across dozens of variations for different target markets. Swap the reference set and Seedance 2.5 regenerates the same shot with new personalization details for each audience, turning what used to be a manual production step into a business process you can run at the volume digital marketing and e-commerce distribution actually need.',
+    ],
+  },
+
+  // MiniMax H3: Image to Video
+  video_minimax_h3_i2v: {
+    extendedDescription: [
+      "MiniMax H3 turns a single starting image into a short, high-quality video clip in one pass, generating the visuals and the audio together rather than as a separate sound design step. You bring one input image; everything else, motion, style, and sound, is steered with optional short text guidance or reference media rather than a full script. It's built for speed over precision: rapid concept visualization, character animation tests, and shareable social clips that need built-in sound rather than a silent render you edit later.",
+      "ResolutionSelector picks your output size from a megapixel budget rather than a fixed resolution, and ImageScaleToTotalPixels keeps the dimensions as multiples of 32 while preserving your source image's aspect ratio through GetImageSize, so a portrait photo doesn't get stretched into a landscape frame. If you'd rather skip audio entirely, the MiniMax H3 node can generate silent output, and SaveVideo still writes a clean MP4 either way. Before your first render, download the video and audio VAE files listed in the workflow notes and point the node at them, or generation will fail on a missing model.",
+      'Because it runs as a single unified model rather than a video generator bolted to a separate audio tool, output stays synced by construction instead of needing alignment afterward, which is what makes this a fast way to test an idea, a webcam clip, or a website hero visual before committing to a longer, more deliberate production pass.',
+    ],
+  },
+
+  // Wan Animate 2: Motion Transfer
+  video_wan_animate2: {
+    extendedDescription: [
+      "Wan Animate 2 animates a still character by transferring motion directly from a driving video, reading movement straight from the video frames instead of running a separate pose extraction or skeletal animation preprocessing step most motion-transfer workflows require. The reference image anchors the character's identity, while your text prompt generates a fresh background and controls camera movement independently of the motion source, so the same driving clip can drop a character into an entirely different scene. Because there's no computer vision pose pipeline to configure, setup takes a fraction of the time comparable motion-capture-style workflows need.",
+      'GetVideoComponents reads the frame rate straight off your driving clip and CreateVideo matches playback to it, so retiming is a matter of adjusting fps up for faster movement or down for slower rather than re-authoring the whole sequence. Keep your reference image well-lit with minimal occlusion and a consistent aspect ratio and display resolution, since image stabilization only smooths so much before mismatched framing shows up as jitter in the final render.',
+      "For clips longer than a single render pass, duplicate the Motion Transfer subgraph, match its prompt and size to the first copy, and feed both into BatchImagesNode to stitch full-length footage together, a workaround for native looping that's still under review. That segment-and-stitch approach makes this practical for real production use: character animation replacement, action mimicry for previz, and moving a performer's motion into branded footage without re-shooting, all without a dedicated motion-capture pipeline or waiting on a render farm for every iteration.",
+    ],
+  },
+};
+
+/**
+ * Resolve curated copy for a workflow, accepting either the snake_case template
+ * name (local content-collection builds) or the hub share id (preview/prod).
+ * Returns undefined for the workflows that have no curated entry, which is all
+ * but the four above — those keep whatever the hub sends.
+ */
+export function getWorkflowCopy(nameOrShareId: string): ResolvedWorkflowCopy | undefined {
+  const copy = WORKFLOW_COPY[curatedKey(nameOrShareId)];
+  if (!copy) return undefined;
+  return {
+    extendedDescription: copy.extendedDescription?.join('\n\n'),
+  };
+}

--- a/site/src/data/workflow-copy.ts
+++ b/site/src/data/workflow-copy.ts
@@ -2,34 +2,76 @@
  * Curated English copy for hub workflow detail pages, keyed the same way as
  * `workflow-entity-graphs.ts` (see `curated-workflow-keys.ts`).
  *
- * The hub API is the source for every other workflow's copy. These four pages
- * carry client-approved prose written to corroborate the entity graph the page
- * already emits — the schema names `Codec`, `High Dynamic Range`, `Motion
- * Interpolation`, `Graphics Processing Unit` and the rest, and this text is
- * where those terms actually appear on the page. Generated hub copy predates
- * that schema and does not mention them, so it is overridden here rather than
- * left to drift.
+ * TEMPORARY STOPGAP. The hub record's `extended_description` is the durable home
+ * for this copy, and the hub API (`/api/hub/workflows/index`) stays the source
+ * for every other workflow. These four pages carry client-approved prose written
+ * to corroborate the entity graph the page already emits — the schema names
+ * `Codec`, `High Dynamic Range`, `Motion Interpolation`, `Graphics Processing
+ * Unit` and the rest, and this text is where those terms actually appear on the
+ * page. The hub's generated copy predates that schema and does not mention them,
+ * so until the hub records are updated this layer stands in for them.
+ *
+ * The override retires itself. Each entry records a fingerprint of the hub text
+ * it replaces (`replacesHubText`), and `getWorkflowCopy` applies the curated copy
+ * only while the hub still serves exactly that text. The first hub edit — ideally
+ * pasting this copy into the record — makes the hub win again on the next build,
+ * so a hub change is never masked by this file. The same gate runs in
+ * `scripts/i18n/build-content-source.ts`, which folds this copy into the English
+ * content source so the localized routes translate it instead of the hub prose.
+ *
+ * Removal, tracked in GTM-470 (https://linear.app/comfyorg/issue/GTM-470):
+ *   1. Paste each `extendedDescription` (paragraphs joined by a blank line) into
+ *      the hub record via the hub admin panel. The build then logs
+ *      `[workflow-copy] … retired` for that page.
+ *   2. Let the nightly `i18n: Update Hub Translations` run re-translate the field.
+ *   3. Delete this file, its import + call in `pages/workflows/[slug].astro`, the
+ *      `applyCuratedCopy` call in `scripts/i18n/build-content-source.ts`, and
+ *      `tests/unit/workflow-copy.test.ts`. `curated-workflow-keys.ts` stays; the
+ *      entity graphs use it.
  *
  * Transcribed verbatim from the client-provided content recommendation — do not
  * paraphrase, re-wrap, or extend entries by extrapolation. Paragraphs are stored
  * one per array element and joined with a blank line, which is the separator
  * `TemplateDetailPage.astro` splits on.
  */
+import { createHash } from 'node:crypto';
 import { curatedKey } from './curated-workflow-keys';
 
 export interface WorkflowCopy {
+  /**
+   * `hashHubText` of the hub `extendedDescription` this entry stands in for. The
+   * override applies only while the hub still serves that exact text. Same shape
+   * as the per-field hashes in `src/i18n/manifest.json`; for these four entries
+   * it equals `manifest[shareId].fields.extendedDescription` today because the
+   * hub text carries no surrounding whitespace.
+   */
+  replacesHubText: string;
   /** Long-form description shown under the hero, one entry per paragraph. */
   extendedDescription?: readonly string[];
 }
 
-/** A `WorkflowCopy` with its paragraph arrays collapsed to page-ready strings. */
+/**
+ * `applied`: curated copy renders. `retired`: an entry exists but the hub record
+ * has moved on, so the hub text wins and the entry is dead code to delete.
+ * `none`: no curated entry; the hub is the only source.
+ */
+export type WorkflowCopyStatus = 'applied' | 'retired' | 'none';
+
+/** The outcome of `getWorkflowCopy`, paragraph arrays collapsed to a page-ready string. */
 export interface ResolvedWorkflowCopy {
+  status: WorkflowCopyStatus;
   extendedDescription?: string;
+}
+
+/** 12-hex sha256 of the trimmed text: the fingerprint an entry's `replacesHubText` holds. */
+export function hashHubText(text: string): string {
+  return createHash('sha256').update(JSON.stringify(text.trim())).digest('hex').slice(0, 12);
 }
 
 export const WORKFLOW_COPY: Record<string, WorkflowCopy> = {
   // LTX-2.5: Image to Video
   video_ltx2_5_i2v: {
+    replacesHubText: '370eb371eeed',
     extendedDescription: [
       "This ComfyUI workflow turns a single still image into a smooth, high-fidelity video using LTX-2.5, Lightricks' open-source video generation model, with full API access for local, self-hosted rendering. The pipeline is intentionally simple and production-minded: LoadImage ingests your source frame, ResolutionSelector locks in a model-friendly pixel size (multiples of 32) and display aspect ratio, the LTX-2.5 generator node (UUID: 6e397a2b-68f7-48f6-8930-f3a5491a163c) synthesizes a coherent motion sequence with high dynamic range and smooth motion interpolation, and SaveVideo encodes the frames to a ready-to-use MP4 using a standard codec. A MarkdownNote in the graph provides in-UI guidance and links.",
       'Under the hood, LTX-2.5 uses a keyframes-first "Pixel Diffusion" approach to propagate detail and structure consistently across time. This helps preserve subject identity, lighting, and scene composition from your source footage while introducing controllable motion. ResolutionSelector ensures your chosen 16:9 dimensions conform to model stride (multiples of 32), which is critical for rendering stability and VRAM efficiency on your own computer hardware and GPU. Because it runs entirely locally, you keep full control over your data rather than uploading footage to a third-party service.',
@@ -39,6 +81,7 @@ export const WORKFLOW_COPY: Record<string, WorkflowCopy> = {
 
   // Seedance 2.5: Reference to Video
   api_seedance2_5_r2v: {
+    replacesHubText: '1108b1b9746a',
     extendedDescription: [
       'Seedance 2.5 builds a single 4–30 second video from up to 20 reference images, 6 video clips, and 6 audio clips, giving you direct control over character identity, visual style, and motion rhythm without manual video editing. ByteDance2ReferenceNode reads your strongest identity shots first and blends them with your reference footage and camera angles, so the output holds a consistent look scene to scene rather than drifting the way single-image generators do. The result plays like a shot pulled straight from a camera rather than a generated clip, which is what makes it hold up for cinematic techniques like coordinated framing and lighting across a short series.',
       "Audio and picture are generated together rather than layered on afterward: feed in a single clean vocal track, recorded close to the microphone, and Seedance 2.5 handles lip-sync, sound effect timing, and motion pacing so dialogue lands on the frame it's spoken in. Display resolution, aspect ratio, and frame rate are all set upfront, and image stabilization keeps handheld-style motion from reading as noisy motion blur. Preview at a lower resolution and shorter duration to confirm sync and motion first, then scale up to full quality, 1080p or higher, once the take is locked, using a fixed seed to keep comparisons consistent between runs.",
@@ -48,6 +91,7 @@ export const WORKFLOW_COPY: Record<string, WorkflowCopy> = {
 
   // MiniMax H3: Image to Video
   video_minimax_h3_i2v: {
+    replacesHubText: '017974ddfe53',
     extendedDescription: [
       "MiniMax H3 turns a single starting image into a short, high-quality video clip in one pass, generating the visuals and the audio together rather than as a separate sound design step. You bring one input image; everything else, motion, style, and sound, is steered with optional short text guidance or reference media rather than a full script. It's built for speed over precision: rapid concept visualization, character animation tests, and shareable social clips that need built-in sound rather than a silent render you edit later.",
       "ResolutionSelector picks your output size from a megapixel budget rather than a fixed resolution, and ImageScaleToTotalPixels keeps the dimensions as multiples of 32 while preserving your source image's aspect ratio through GetImageSize, so a portrait photo doesn't get stretched into a landscape frame. If you'd rather skip audio entirely, the MiniMax H3 node can generate silent output, and SaveVideo still writes a clean MP4 either way. Before your first render, download the video and audio VAE files listed in the workflow notes and point the node at them, or generation will fail on a missing model.",
@@ -57,6 +101,7 @@ export const WORKFLOW_COPY: Record<string, WorkflowCopy> = {
 
   // Wan Animate 2: Motion Transfer
   video_wan_animate2: {
+    replacesHubText: '244132af9ad1',
     extendedDescription: [
       "Wan Animate 2 animates a still character by transferring motion directly from a driving video, reading movement straight from the video frames instead of running a separate pose extraction or skeletal animation preprocessing step most motion-transfer workflows require. The reference image anchors the character's identity, while your text prompt generates a fresh background and controls camera movement independently of the motion source, so the same driving clip can drop a character into an entirely different scene. Because there's no computer vision pose pipeline to configure, setup takes a fraction of the time comparable motion-capture-style workflows need.",
       'GetVideoComponents reads the frame rate straight off your driving clip and CreateVideo matches playback to it, so retiming is a matter of adjusting fps up for faster movement or down for slower rather than re-authoring the whole sequence. Keep your reference image well-lit with minimal occlusion and a consistent aspect ratio and display resolution, since image stabilization only smooths so much before mismatched framing shows up as jitter in the final render.',
@@ -67,14 +112,21 @@ export const WORKFLOW_COPY: Record<string, WorkflowCopy> = {
 
 /**
  * Resolve curated copy for a workflow, accepting either the snake_case template
- * name (local content-collection builds) or the hub share id (preview/prod).
- * Returns undefined for the workflows that have no curated entry, which is all
- * but the four above — those keep whatever the hub sends.
+ * name (local content-collection builds) or the hub share id (preview/prod), and
+ * the `extendedDescription` the hub currently serves for it. The copy applies
+ * only while that hub text is still the text the entry replaced; empty hub text
+ * (local content-collection builds carry none) counts as unchanged, so the
+ * curated copy renders locally too. Once the hub record changes the status is
+ * `retired` and callers fall back to the hub. `copy` is injectable for tests.
  */
-export function getWorkflowCopy(nameOrShareId: string): ResolvedWorkflowCopy | undefined {
-  const copy = WORKFLOW_COPY[curatedKey(nameOrShareId)];
-  if (!copy) return undefined;
-  return {
-    extendedDescription: copy.extendedDescription?.join('\n\n'),
-  };
+export function getWorkflowCopy(
+  nameOrShareId: string,
+  hubExtendedDescription = '',
+  copy: Record<string, WorkflowCopy> = WORKFLOW_COPY
+): ResolvedWorkflowCopy {
+  const entry = copy[curatedKey(nameOrShareId)];
+  if (!entry) return { status: 'none' };
+  const hubText = hubExtendedDescription.trim();
+  if (hubText && hashHubText(hubText) !== entry.replacesHubText) return { status: 'retired' };
+  return { status: 'applied', extendedDescription: entry.extendedDescription?.join('\n\n') };
 }

--- a/site/src/data/workflow-entity-graphs.ts
+++ b/site/src/data/workflow-entity-graphs.ts
@@ -2,12 +2,13 @@
  * Curated `DefinedTerm`/`DefinedTermSet` entity data for `buildWorkflowGraphJsonLd`
  * (see ../lib/structured-data.ts), keyed by the template's snake_case `name`
  * (its `templates/index.json` filename). Look these up via `getWorkflowEntityGraph`,
- * which also accepts the hub share id (see `SHARE_ID_TO_KEY` at the bottom).
+ * which also accepts the hub share id (see `curated-workflow-keys.ts`).
  * Transcribed verbatim from the client-provided schema recommendation — do not
  * add entries by automatic detection or extrapolation. `id` values are local
  * `@graph` fragment identifiers, resolved against the page's own canonical URL
  * at build time (e.g. `{canonicalUrl}#e-api`).
  */
+import { curatedKey } from './curated-workflow-keys';
 
 export interface WorkflowEntityCoreTopic {
   id: string;
@@ -757,23 +758,6 @@ export const WORKFLOW_ENTITY_GRAPHS: Record<string, WorkflowEntityGraph> = {
   },
 };
 
-/**
- * The `@graph` builder is called with the workflow's `name` from whichever index
- * the build used. The local content collection (`templates/index.json`) exposes
- * the snake_case filename, but the hub API (`/api/hub/workflows/index`, the
- * primary source in preview/prod builds) exposes the share id instead — so a
- * bare `WORKFLOW_ENTITY_GRAPHS[name]` lookup misses on deployed pages. Map the
- * share id back to the filename key here so both indexes resolve.
- */
-const SHARE_ID_TO_KEY: Record<string, string> = {
-  b37902cee452: 'video_ltx2_5_i2v',
-  cd0c4f9f61a4: 'api_seedance2_5_r2v',
-  a781503cf508: 'video_minimax_h3_i2v',
-  '9394f9968da3': 'video_wan_animate2',
-};
-
 export function getWorkflowEntityGraph(nameOrShareId: string): WorkflowEntityGraph | undefined {
-  return (
-    WORKFLOW_ENTITY_GRAPHS[nameOrShareId] ?? WORKFLOW_ENTITY_GRAPHS[SHARE_ID_TO_KEY[nameOrShareId]]
-  );
+  return WORKFLOW_ENTITY_GRAPHS[curatedKey(nameOrShareId)];
 }

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -32,6 +32,7 @@ import {
   buildWorkflowGraphJsonLd,
 } from '../../lib/structured-data';
 import { getWorkflowEntityGraph } from '../../data/workflow-entity-graphs';
+import { getWorkflowCopy } from '../../data/workflow-copy';
 import { buildToolbarLabels } from '../../lib/toolbar';
 
 import { localizeUrl } from '../../i18n/utils';
@@ -101,6 +102,9 @@ if (!entry) {
 }
 
 const locale = DEFAULT_LOCALE;
+// Client-approved copy for the handful of workflows that carry a curated entity
+// graph (see workflow-copy.ts); every other workflow renders the hub's own text.
+const curatedCopy = getWorkflowCopy(entry.name);
 const data = {
   name: entry.name,
   shareId: entry.shareId || '',
@@ -115,7 +119,7 @@ const data = {
   username: entry.profile?.username || entry.username || '',
   date: entry.date || '',
   tutorialUrl: entry.tutorialUrl,
-  extendedDescription: entry.extendedDescription || '',
+  extendedDescription: curatedCopy?.extendedDescription || entry.extendedDescription || '',
   metaDescription: entry.metaDescription || entry.description || '',
   howToUse: entry.howToUse || [],
   suggestedUseCases: entry.suggestedUseCases || [],

--- a/site/src/pages/workflows/[slug].astro
+++ b/site/src/pages/workflows/[slug].astro
@@ -103,8 +103,16 @@ if (!entry) {
 
 const locale = DEFAULT_LOCALE;
 // Client-approved copy for the handful of workflows that carry a curated entity
-// graph (see workflow-copy.ts); every other workflow renders the hub's own text.
-const curatedCopy = getWorkflowCopy(entry.name);
+// graph. Temporary stopgap until the hub records carry this text (GTM-470): it
+// applies only while the hub still serves the text it replaced, so a hub edit is
+// never masked. Every other workflow renders the hub's own text.
+const copyKey = entry.shareId || entry.name;
+const curatedCopy = getWorkflowCopy(copyKey, entry.extendedDescription || '');
+if (curatedCopy.status === 'retired') {
+  console.warn(
+    `[workflow-copy] hub record for ${copyKey} changed; curated override retired — delete its entry in workflow-copy.ts (GTM-470)`
+  );
+}
 const data = {
   name: entry.name,
   shareId: entry.shareId || '',
@@ -119,7 +127,7 @@ const data = {
   username: entry.profile?.username || entry.username || '',
   date: entry.date || '',
   tutorialUrl: entry.tutorialUrl,
-  extendedDescription: curatedCopy?.extendedDescription || entry.extendedDescription || '',
+  extendedDescription: curatedCopy.extendedDescription || entry.extendedDescription || '',
   metaDescription: entry.metaDescription || entry.description || '',
   howToUse: entry.howToUse || [],
   suggestedUseCases: entry.suggestedUseCases || [],

--- a/site/tests/unit/i18n-build-content-source.test.ts
+++ b/site/tests/unit/i18n-build-content-source.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyCuratedCopy,
   extractContent,
   hashContent,
   hashValue,
@@ -9,6 +10,7 @@ import {
   buildHumanSeed,
 } from '../../scripts/i18n/build-content-source';
 import type { WorkflowContent } from '../../src/lib/i18n/schema';
+import { hashHubText, type WorkflowCopy } from '../../src/data/workflow-copy';
 
 describe('extractContent', () => {
   it('normalizes the 7 fields and drops unknown keys', () => {
@@ -157,5 +159,55 @@ describe('hashValue', () => {
   it('is a stable 12-hex string', () => {
     expect(hashValue(['a', 'b'])).toMatch(/^[0-9a-f]{12}$/);
     expect(hashValue(['a', 'b'])).toBe(hashValue(['a', 'b']));
+  });
+});
+
+describe('applyCuratedCopy', () => {
+  const STALE_HUB_TEXT = 'Generated hub prose the client asked us to replace.';
+  const CURATED: Record<string, WorkflowCopy> = {
+    demo_workflow: {
+      replacesHubText: hashHubText(STALE_HUB_TEXT),
+      extendedDescription: ['Approved paragraph one.', 'Approved paragraph two.'],
+    },
+  };
+  const hubEntry = (extendedDescription: string): WorkflowContent => ({
+    title: 'T',
+    description: 'D',
+    metaDescription: 'M',
+    extendedDescription,
+    howToUse: ['h'],
+    suggestedUseCases: ['u'],
+    faqItems: [{ question: 'q', answer: 'a' }],
+  });
+
+  it('swaps in the curated extendedDescription while the hub still serves the replaced text', () => {
+    const out = applyCuratedCopy('demo_workflow', hubEntry(STALE_HUB_TEXT), CURATED);
+    expect(out.extendedDescription).toBe('Approved paragraph one.\n\nApproved paragraph two.');
+  });
+
+  it('touches no other field, so only extendedDescription goes stale for re-translation', () => {
+    const before = hubEntry(STALE_HUB_TEXT);
+    const after = applyCuratedCopy('demo_workflow', before, CURATED);
+    expect({ ...after, extendedDescription: before.extendedDescription }).toEqual(before);
+    expect(staleFields({ x: hashContent(before) }, { x: hashContent(after) })).toEqual({
+      x: ['extendedDescription'],
+    });
+  });
+
+  it('passes the hub text through once the hub record has changed', () => {
+    const updated = hubEntry(`${STALE_HUB_TEXT} Edited in the hub.`);
+    expect(applyCuratedCopy('demo_workflow', updated, CURATED)).toBe(updated);
+  });
+
+  it('leaves uncurated workflows untouched', () => {
+    const plain = hubEntry('Ordinary hub prose.');
+    expect(applyCuratedCopy('some_other_workflow', plain, CURATED)).toBe(plain);
+  });
+
+  it('resolves the real table by hub share id', () => {
+    // The pipeline keys everything by shareId; the curated table is keyed by
+    // template name, and the shared resolver bridges the two.
+    const out = applyCuratedCopy('b37902cee452', hubEntry(''));
+    expect(out.extendedDescription).toContain('LTX-2.5');
   });
 });

--- a/site/tests/unit/workflow-copy.test.ts
+++ b/site/tests/unit/workflow-copy.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { WORKFLOW_COPY, getWorkflowCopy } from '../../src/data/workflow-copy';
+import { WORKFLOW_ENTITY_GRAPHS } from '../../src/data/workflow-entity-graphs';
+import { curatedKey } from '../../src/data/curated-workflow-keys';
+
+/** Share ids for the curated pages, in the same order as WORKFLOW_COPY. */
+const SHARE_IDS: Record<string, string> = {
+  video_ltx2_5_i2v: 'b37902cee452',
+  api_seedance2_5_r2v: 'cd0c4f9f61a4',
+  video_minimax_h3_i2v: 'a781503cf508',
+  video_wan_animate2: '9394f9968da3',
+};
+
+describe('curatedKey', () => {
+  it('maps a hub share id to its template-name key', () => {
+    expect(curatedKey('b37902cee452')).toBe('video_ltx2_5_i2v');
+  });
+
+  it('passes an unmapped value through unchanged', () => {
+    expect(curatedKey('video_ltx2_5_i2v')).toBe('video_ltx2_5_i2v');
+    expect(curatedKey('some_other_template')).toBe('some_other_template');
+  });
+});
+
+describe('getWorkflowCopy', () => {
+  it('resolves by template name and by share id alike', () => {
+    for (const [key, shareId] of Object.entries(SHARE_IDS)) {
+      const byName = getWorkflowCopy(key);
+      const byShareId = getWorkflowCopy(shareId);
+      expect(byName, key).toBeDefined();
+      expect(byShareId).toEqual(byName);
+    }
+  });
+
+  it('returns undefined for a workflow with no curated copy', () => {
+    // The overwhelming majority of the hub — these pages keep the hub's own text.
+    expect(getWorkflowCopy('image_flux_krea_dev')).toBeUndefined();
+    expect(getWorkflowCopy('ffffffffffff')).toBeUndefined();
+  });
+
+  it('joins paragraphs with the blank line the detail page splits on', () => {
+    const copy = getWorkflowCopy('video_ltx2_5_i2v');
+    const paragraphs = WORKFLOW_COPY.video_ltx2_5_i2v.extendedDescription ?? [];
+    expect(copy?.extendedDescription?.split('\n\n')).toEqual([...paragraphs]);
+  });
+});
+
+describe('WORKFLOW_COPY', () => {
+  it('only covers workflows that also carry a curated entity graph', () => {
+    for (const key of Object.keys(WORKFLOW_COPY)) {
+      expect(WORKFLOW_ENTITY_GRAPHS[key], key).toBeDefined();
+    }
+  });
+
+  it('stores clean, non-empty paragraphs', () => {
+    for (const [key, copy] of Object.entries(WORKFLOW_COPY)) {
+      const paragraphs = copy.extendedDescription ?? [];
+      expect(paragraphs.length, key).toBeGreaterThan(0);
+      for (const paragraph of paragraphs) {
+        expect(paragraph, key).toBe(paragraph.trim());
+        expect(paragraph.length, key).toBeGreaterThan(0);
+        // A paragraph carrying its own blank line would split into two on the
+        // page and silently desync from what was signed off.
+        expect(paragraph, key).not.toContain('\n');
+      }
+    }
+  });
+
+  // The reason this copy exists: the page's @graph names entities that the
+  // hub's generated prose never mentions, leaving the schema uncorroborated.
+  it('mentions the entities its page already declares', () => {
+    for (const [key, copy] of Object.entries(WORKFLOW_COPY)) {
+      const prose = (copy.extendedDescription ?? []).join(' ').toLowerCase();
+      const graph = WORKFLOW_ENTITY_GRAPHS[key];
+      const terms = [...graph.coreTopics, ...graph.entities].map((term) =>
+        // "Rendering (Computer Graphics)" is written as "rendering" in prose.
+        term.name.replace(/\s*\(.*?\)/, '').toLowerCase()
+      );
+      const mentioned = terms.filter((term) => prose.includes(term));
+      expect(
+        mentioned.length,
+        `${key} mentions ${mentioned.length} of ${terms.length}`
+      ).toBeGreaterThanOrEqual(10);
+    }
+  });
+});

--- a/site/tests/unit/workflow-copy.test.ts
+++ b/site/tests/unit/workflow-copy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { WORKFLOW_COPY, getWorkflowCopy } from '../../src/data/workflow-copy';
+import {
+  WORKFLOW_COPY,
+  getWorkflowCopy,
+  hashHubText,
+  type WorkflowCopy,
+} from '../../src/data/workflow-copy';
 import { WORKFLOW_ENTITY_GRAPHS } from '../../src/data/workflow-entity-graphs';
 import { curatedKey } from '../../src/data/curated-workflow-keys';
 
@@ -9,6 +14,16 @@ const SHARE_IDS: Record<string, string> = {
   api_seedance2_5_r2v: 'cd0c4f9f61a4',
   video_minimax_h3_i2v: 'a781503cf508',
   video_wan_animate2: '9394f9968da3',
+};
+
+/** A one-entry table whose replaced hub text is known, for exercising the gate. */
+const STALE_HUB_TEXT = 'Generated hub prose the client asked us to replace.';
+const CURATED_TEXT = 'Approved paragraph one.\n\nApproved paragraph two.';
+const CURATED: Record<string, WorkflowCopy> = {
+  demo_workflow: {
+    replacesHubText: hashHubText(STALE_HUB_TEXT),
+    extendedDescription: ['Approved paragraph one.', 'Approved paragraph two.'],
+  },
 };
 
 describe('curatedKey', () => {
@@ -22,26 +37,66 @@ describe('curatedKey', () => {
   });
 });
 
+describe('hashHubText', () => {
+  it('is a stable 12-hex fingerprint that ignores surrounding whitespace', () => {
+    expect(hashHubText(STALE_HUB_TEXT)).toMatch(/^[0-9a-f]{12}$/);
+    expect(hashHubText(`\n\n${STALE_HUB_TEXT}\n`)).toBe(hashHubText(STALE_HUB_TEXT));
+    expect(hashHubText(`${STALE_HUB_TEXT} edited`)).not.toBe(hashHubText(STALE_HUB_TEXT));
+  });
+});
+
 describe('getWorkflowCopy', () => {
   it('resolves by template name and by share id alike', () => {
     for (const [key, shareId] of Object.entries(SHARE_IDS)) {
       const byName = getWorkflowCopy(key);
       const byShareId = getWorkflowCopy(shareId);
-      expect(byName, key).toBeDefined();
+      expect(byName.status, key).toBe('applied');
       expect(byShareId).toEqual(byName);
     }
   });
 
-  it('returns undefined for a workflow with no curated copy', () => {
+  it('reports no entry for a workflow with no curated copy', () => {
     // The overwhelming majority of the hub — these pages keep the hub's own text.
-    expect(getWorkflowCopy('image_flux_krea_dev')).toBeUndefined();
-    expect(getWorkflowCopy('ffffffffffff')).toBeUndefined();
+    expect(getWorkflowCopy('image_flux_krea_dev')).toEqual({ status: 'none' });
+    expect(getWorkflowCopy('ffffffffffff', 'whatever the hub says')).toEqual({ status: 'none' });
+  });
+
+  it('applies while the hub still serves the text the entry replaced', () => {
+    expect(getWorkflowCopy('demo_workflow', STALE_HUB_TEXT, CURATED)).toEqual({
+      status: 'applied',
+      extendedDescription: CURATED_TEXT,
+    });
+    // Trailing blank lines from the hub generator are not a content change.
+    expect(getWorkflowCopy('demo_workflow', `${STALE_HUB_TEXT}\n\n`, CURATED).status).toBe(
+      'applied'
+    );
+  });
+
+  it('applies when the hub sends no text at all (local content-collection builds)', () => {
+    expect(getWorkflowCopy('demo_workflow', '', CURATED).status).toBe('applied');
+    expect(getWorkflowCopy('demo_workflow', undefined, CURATED).status).toBe('applied');
+  });
+
+  it('retires the moment the hub record changes, so the hub wins', () => {
+    const edited = getWorkflowCopy(
+      'demo_workflow',
+      `${STALE_HUB_TEXT} Now with a sentence added in the hub.`,
+      CURATED
+    );
+    expect(edited).toEqual({ status: 'retired' });
+    expect(edited.extendedDescription).toBeUndefined();
+  });
+
+  it('retires once the hub carries the curated copy itself', () => {
+    // The intended end state: the hub record was updated to this text, the
+    // override is a no-op and the entry can be deleted.
+    expect(getWorkflowCopy('demo_workflow', CURATED_TEXT, CURATED)).toEqual({ status: 'retired' });
   });
 
   it('joins paragraphs with the blank line the detail page splits on', () => {
     const copy = getWorkflowCopy('video_ltx2_5_i2v');
     const paragraphs = WORKFLOW_COPY.video_ltx2_5_i2v.extendedDescription ?? [];
-    expect(copy?.extendedDescription?.split('\n\n')).toEqual([...paragraphs]);
+    expect(copy.extendedDescription?.split('\n\n')).toEqual([...paragraphs]);
   });
 });
 
@@ -49,6 +104,12 @@ describe('WORKFLOW_COPY', () => {
   it('only covers workflows that also carry a curated entity graph', () => {
     for (const key of Object.keys(WORKFLOW_COPY)) {
       expect(WORKFLOW_ENTITY_GRAPHS[key], key).toBeDefined();
+    }
+  });
+
+  it('records the fingerprint of the hub text every entry replaces', () => {
+    for (const [key, copy] of Object.entries(WORKFLOW_COPY)) {
+      expect(copy.replacesHubText, key).toMatch(/^[0-9a-f]{12}$/);
     }
   });
 


### PR DESCRIPTION
## What

Adds the client-provided replacement descriptions for the four workflow detail pages that already carry a curated JSON-LD `@graph`, as a **temporary, self-retiring override** until the hub records carry the same text.

| Page | URL |
| --- | --- |
| LTX-2.5: Image to Video | `/workflows/b37902cee452-b37902cee452/` |
| Seedance 2.5: Reference to Video | `/workflows/cd0c4f9f61a4-cd0c4f9f61a4/` |
| MiniMax H3: Image to Video | `/workflows/a781503cf508-a781503cf508/` |
| Wan Animate 2: Motion Transfer | `/workflows/9394f9968da3-9394f9968da3/` |

## Why

#1205 shipped the client-approved `@graph` for these four pages: `WebSite`, `Organization`, `ComfyUI`, `WebPage`, the workflow node, and 23 to 31 `DefinedTerm`s each. The prose on those same pages still comes from the hub's generated copy, which predates the schema and never mentions the entities the markup declares: `Codec`, `High Dynamic Range`, `Motion Interpolation`, `Graphics Processing Unit`, `Display Aspect Ratio`, `Footage`, `1080p`. The page asserts a topic in structured data that its own body text does not support, which is the gap the content recommendation was written to close.

Each new description is three paragraphs (today's are one or two) and works the declared entities into real prose rather than a keyword list.

## How

Same shape as the entity graphs, deliberately:

- `site/src/data/workflow-copy.ts`: the four descriptions, transcribed verbatim, one array element per paragraph (the detail page splits on a blank line). Each entry also records `replacesHubText`, the fingerprint of the hub text it stands in for.
- `site/src/data/curated-workflow-keys.ts`: the share id to template-name map, lifted out of `workflow-entity-graphs.ts` so both curated files resolve keys identically. Deployed builds see the hub share id; local content-collection builds see the snake_case filename.
- `site/src/pages/workflows/[slug].astro`: looks the copy up by share id, runs the hub's current `extendedDescription` through the gate, prefers the curated text, falls back to the hub value.
- `site/scripts/i18n/build-content-source.ts`: `applyCuratedCopy` runs the same gate when the nightly pipeline builds `content/en.json`, so the localized routes translate the curated text instead of the hub prose.

Any workflow without a curated entry is untouched and keeps the hub's copy.

## Stopgap, not a second source of truth (review feedback)

Review feedback: the hub/CMS is the durable home for this content, an override must not mask future hub edits, the localized pages must not be left on the old text, and the removal should be tracked. Addressed as follows.

- **A hub edit is never masked.** The curated copy applies only while the hub still serves exactly the text it replaced. `replacesHubText` is the same 12-hex hash the i18n manifest keeps per field; for these four it equals `manifest[shareId].fields.extendedDescription` on `main` today. The first edit to a hub record, ideally pasting this copy in, makes the hub win again on the next build, and the build logs `[workflow-copy] hub record for <shareId> changed; curated override retired`.
- **Localized pages follow automatically.** The nightly `i18n: Update Hub Translations` run (or a manual dispatch) builds its English source through the same gate. Verified against the production index (647 approved workflows): 4 override(s) applied, 0 retired; for those four share ids only the `extendedDescription` hash changes and only that field is pruned from the machine locale files, so lobe re-translates exactly that field into all 10 locales in the usual automation PR.
- **Removal is written down.** Steps are in the `workflow-copy.ts` header and tracked in [GTM-470](https://linear.app/comfyorg/issue/GTM-470): update the four hub records, let the nightly run re-translate, then delete `workflow-copy.ts`, its two call sites and its test. `curated-workflow-keys.ts` stays, the entity graphs use it.

## Scope

- **The emitted `@graph` is unchanged by this PR.** Verified against the recommendation for all four pages: identical apart from the site's own `Organization.logo`. #1252 pins it with fixtures.
- Only `extendedDescription` is overridden. Title, short description, meta description, FAQ and the JSON-LD `description` stay hub-sourced.

## Test

- `site/tests/unit/workflow-copy.test.ts`: key resolution by name and share id; the gate applies on the recorded hub text and on empty hub text, tolerates trailing blank lines, and retires on any change including the hub carrying the curated text itself; paragraph hygiene; the invariant that curated copy only exists where a curated graph does; a guard that each description still mentions at least 10 of the entities its page declares.
- `site/tests/unit/i18n-build-content-source.test.ts`: `applyCuratedCopy` swaps only `extendedDescription`, passes the hub text through once the record changed, leaves uncurated workflows untouched, resolves the real table by share id.
- `pnpm test` 935 passing, `astro check` 0 errors.
- Preview: all four pages render the three curated paragraphs (preview comment below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwLFkwizjC7LymtF1ofwqH
