### PR TITLE
test(site): pin the recommended workflow @graph, trim hub whitespace

### DIFF
--- a/site/src/lib/structured-data.ts
+++ b/site/src/lib/structured-data.ts
@@ -86,6 +86,15 @@ export function serializeJsonLdForScript(value: unknown): string {
 }
 
 /**
+ * Hub copy occasionally carries trailing blank lines from the generator. They
+ * are invisible in rendered HTML but land verbatim inside JSON-LD strings, so
+ * every string this module emits from hub content is trimmed on the way in.
+ */
+function clean(value: string): string {
+  return value.trim();
+}
+
+/**
  * schema.org `FAQPage` JSON-LD for a workflow's FAQ section, or `null` when
  * there are no items (so the caller can skip emitting an empty graph).
  */
@@ -96,8 +105,8 @@ export function buildFaqJsonLd(faqItems: FaqItem[] | undefined) {
     '@type': 'FAQPage',
     mainEntity: faqItems.map((item) => ({
       '@type': 'Question',
-      name: item.question,
-      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+      name: clean(item.question),
+      acceptedAnswer: { '@type': 'Answer', text: clean(item.answer) },
     })),
   };
 }
@@ -184,10 +193,10 @@ export function buildSoftwareApplicationJsonLd(params: {
   return {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
-    name: params.name,
+    name: clean(params.name),
     applicationCategory: 'MultimediaApplication',
     operatingSystem: 'Windows, macOS, Linux',
-    description: params.description,
+    description: clean(params.description),
     ...(featureList?.length ? { featureList } : {}),
   };
 }
@@ -333,7 +342,7 @@ export function buildWorkflowGraphJsonLd(params: {
     ...(entityGraph.identifier ? { identifier: entityGraph.identifier } : {}),
     ...(publishedDate ? { datePublished: publishedDate } : {}),
     ...(image ? { image } : {}),
-    description,
+    description: clean(description),
     ...(entityGraph.keywords ? { keywords: entityGraph.keywords } : {}),
     creator: { '@id': ORGANIZATION_ID },
     runtimePlatform: { '@id': COMFYUI_ID },
@@ -374,8 +383,8 @@ export function buildWorkflowGraphJsonLd(params: {
       '@id': faqId,
       mainEntity: faqItems!.map((f) => ({
         '@type': 'Question',
-        name: f.question,
-        acceptedAnswer: { '@type': 'Answer', text: f.answer },
+        name: clean(f.question),
+        acceptedAnswer: { '@type': 'Answer', text: clean(f.answer) },
       })),
     });
   }

--- a/site/tests/fixtures/workflow-schema/9394f9968da3.json
+++ b/site/tests/fixtures/workflow-schema/9394f9968da3.json
@@ -1,0 +1,524 @@
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://comfy.org/#website",
+      "name": "Comfy",
+      "url": "https://comfy.org",
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "hasPart": [
+        {
+          "@type": "Blog",
+          "name": "Comfy Blog",
+          "url": "https://blog.comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://comfy.org/#organization",
+      "name": "Comfy Org",
+      "url": "https://comfy.org",
+      "sameAs": [
+        "https://github.com/Comfy-Org",
+        "https://discord.gg/comfyorg",
+        "https://x.com/ComfyUI",
+        "https://www.linkedin.com/company/comfyui",
+        "https://www.instagram.com/comfyui",
+        "https://www.youtube.com/@comfyorg"
+      ],
+      "contactPoint": [
+        {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "email": "hello@comfy.org",
+          "url": "https://support.comfy.org/"
+        },
+        {
+          "@type": "ContactPoint",
+          "contactType": "press",
+          "email": "press@comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://comfy.org/#comfyui",
+      "name": "ComfyUI",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "sameAs": [
+        "https://en.wikipedia.org/wiki/ComfyUI",
+        "https://github.com/Comfy-Org/ComfyUI",
+        "https://comfy.org"
+      ],
+      "softwareHelp": {
+        "@type": "CreativeWork",
+        "name": "ComfyUI Docs",
+        "url": "https://docs.comfy.org"
+      }
+    },
+    {
+      "@type": "WebPage",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#webpage",
+      "url": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/",
+      "headline": "Wan Animate 2: Motion Transfer - ComfyUI Workflow",
+      "isPartOf": {
+        "@id": "https://comfy.org/#website"
+      },
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "datePublished": "2026-08-08",
+      "inLanguage": "en",
+      "breadcrumb": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#workflow"
+      },
+      "hasPart": [
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#faq"
+        }
+      ],
+      "about": [
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#workflow"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-motion"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-computervision"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-business"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-audiovideo"
+        }
+      ],
+      "mentions": [
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-character"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-camera"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-extraction"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-frames"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-skeleton"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-reference"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-identity"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-computer-vision"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-rendering"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-gpu"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-image-stabilization"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-display-res"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-workflow"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-footage"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-quality"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-communication"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-control"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-surround-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-high-fidelity"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-video-editing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-frame-rate"
+        }
+      ]
+    },
+    {
+      "@type": [
+        "SoftwareApplication",
+        "TechArticle"
+      ],
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#workflow",
+      "name": "Wan Animate 2: Motion Transfer",
+      "headline": "Wan Animate 2: Motion Transfer",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "datePublished": "2026-08-08",
+      "image": "https://comfy-hub-assets.comfy.org/uploads/e3f316c3-9a84-4f91-b77e-760caeb3cf6e.mp4",
+      "description": "Animate a still character using a driving video with Wan Animate 2, transferring motion directly from video frames without any pose extraction or skeleton preprocessing. The output preserves the reference character's identity while generating a fresh background and camera movement from your text prompt. Ideal for motion transfer, action mimicry, and character animation replacement projects.",
+      "keywords": "Image Generation, Motion Control, Video, Motion Transfer, Wan Animate 2, ComfyUI Workflow",
+      "creator": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "runtimePlatform": {
+        "@id": "https://comfy.org/#comfyui"
+      },
+      "isRelatedTo": [
+        {
+          "@type": "WebPage",
+          "name": "Image Generation Workflows",
+          "url": "https://comfy.org/workflows/category/image/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Motion Control Workflows",
+          "url": "https://comfy.org/workflows/tag/motion-control/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Video Workflows",
+          "url": "https://comfy.org/workflows/tag/video/"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-motion",
+      "name": "Motion",
+      "sameAs": "https://en.wikipedia.org/wiki/Motion_(physics)"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-character",
+      "name": "Character",
+      "sameAs": "https://en.wikipedia.org/wiki/Character_(arts)"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-camera",
+      "name": "Camera",
+      "sameAs": "https://en.wikipedia.org/wiki/Camera"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-extraction",
+      "name": "Pose Extraction",
+      "sameAs": "https://en.wikipedia.org/wiki/Pose_estimation"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-frames",
+      "name": "Video Frames",
+      "sameAs": "https://en.wikipedia.org/wiki/Film_frame"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-skeleton",
+      "name": "Skeletal Preprocessing",
+      "sameAs": "https://en.wikipedia.org/wiki/Skeletal_animation"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-reference",
+      "name": "Reference",
+      "sameAs": "https://en.wikipedia.org/wiki/Citation"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-identity",
+      "name": "Identity",
+      "sameAs": "https://en.wikipedia.org/wiki/Identity_(social_science)"
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-computervision",
+      "name": "Computer Vision & Rendering",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-computer-vision"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-rendering"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-gpu"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-image-stabilization"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-display-res"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-computer-vision",
+      "name": "Computer Vision",
+      "sameAs": "https://en.wikipedia.org/wiki/Computer_vision",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-computervision"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-rendering",
+      "name": "Rendering (Computer Graphics)",
+      "sameAs": "https://en.wikipedia.org/wiki/Rendering_(computer_graphics)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-computervision"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-gpu",
+      "name": "Graphics Processing Unit",
+      "sameAs": "https://en.wikipedia.org/wiki/Graphics_processing_unit",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-computervision"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-image-stabilization",
+      "name": "Image Stabilization",
+      "sameAs": "https://en.wikipedia.org/wiki/Image_stabilization",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-computervision"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-display-res",
+      "name": "Display Resolution",
+      "sameAs": "https://en.wikipedia.org/wiki/Display_resolution",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-computervision"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-business",
+      "name": "Production & Business",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-workflow"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-footage"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-quality"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-communication"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-control"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-workflow",
+      "name": "Workflow",
+      "sameAs": "https://en.wikipedia.org/wiki/Workflow",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-footage",
+      "name": "Footage",
+      "sameAs": "https://en.wikipedia.org/wiki/Footage",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-quality",
+      "name": "Quality (Business)",
+      "sameAs": "https://en.wikipedia.org/wiki/Quality_(business)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-communication",
+      "name": "Communication",
+      "sameAs": "https://en.wikipedia.org/wiki/Communication",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-control",
+      "name": "Control (Management)",
+      "sameAs": "https://en.wikipedia.org/wiki/Control_(management)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-audiovideo",
+      "name": "Audio & Video",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-surround-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-high-fidelity"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-video-editing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-frame-rate"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-sound",
+      "name": "Sound",
+      "sameAs": "https://en.wikipedia.org/wiki/Sound",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-surround-sound",
+      "name": "Surround Sound",
+      "sameAs": "https://en.wikipedia.org/wiki/Surround_sound",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-high-fidelity",
+      "name": "High Fidelity",
+      "sameAs": "https://en.wikipedia.org/wiki/High_fidelity",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-video-editing",
+      "name": "Video Editing",
+      "sameAs": "https://en.wikipedia.org/wiki/Video_editing",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#e-frame-rate",
+      "name": "Frame Rate",
+      "sameAs": "https://en.wikipedia.org/wiki/Frame_rate",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://comfy.org"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Workflows",
+          "item": "https://comfy.org/workflows/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Wan Animate 2: Motion Transfer",
+          "item": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/"
+        }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://comfy.org/workflows/9394f9968da3-9394f9968da3/#faq",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Do I need OpenPose or a skeleton extraction step?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. Wan-Animate-2 performs direct motion transfer from the driving video frames. The workflow does not require keypoints or pose preprocessing."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I keep the character identity consistent?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Use a clean, well-lit reference image with minimal occlusion and a simple background. Keep the aspect ratio consistent, and avoid prompts that describe a different character or facial features that conflict with your reference."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I match the timing and duration of the driving video?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "GetVideoComponents provides fps for the driving clip, pass that to CreateVideo so playback matches the source timing. To retime, adjust the fps in CreateVideo (higher fps = faster playback, lower fps = slower)."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "My clip is long. How do I process the whole video?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Native loop support is still under review. For now, duplicate the \"Motion Transfer (Wan Animate 2)\" subgraph: enable the bypassed copy (Ctrl+B), ensure its prompt and size match the first, connect its image output to BatchImagesNode, then copy-paste (Ctrl+C, Ctrl+Shift+V) enough segments to cover the full driving video."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/site/tests/fixtures/workflow-schema/README.md
+++ b/site/tests/fixtures/workflow-schema/README.md
@@ -1,0 +1,19 @@
+# Recommended workflow `@graph` fixtures
+
+One file per curated workflow detail page, named by hub share id. Each is the
+JSON-LD `@graph` from the client's schema recommendation, transcribed verbatim
+— the document `buildWorkflowGraphJsonLd` and `WORKFLOW_ENTITY_GRAPHS` were
+built to reproduce (#1205).
+
+`workflow-schema-recommendation.test.ts` rebuilds each graph from the repo's own
+curated data and asserts it still matches. Page-level values the hub owns —
+title, image, short description, FAQ — are fed to the builder from the fixture,
+so the test pins what this repo controls: the entity nodes, their categories and
+cross-references, and node order. Hub copy drifting is a content question, not a
+build regression, and is deliberately out of scope here.
+
+The one permitted difference is `Organization.logo`, which the site adds
+site-wide in `src/lib/site-entities.ts` and the recommendation omits.
+
+Do not edit these by hand to make a test pass. They change only when the client
+issues a new recommendation.

--- a/site/tests/fixtures/workflow-schema/a781503cf508.json
+++ b/site/tests/fixtures/workflow-schema/a781503cf508.json
@@ -1,0 +1,642 @@
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://comfy.org/#website",
+      "name": "Comfy",
+      "url": "https://comfy.org",
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "hasPart": [
+        {
+          "@type": "Blog",
+          "name": "Comfy Blog",
+          "url": "https://blog.comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://comfy.org/#organization",
+      "name": "Comfy Org",
+      "url": "https://comfy.org",
+      "sameAs": [
+        "https://github.com/Comfy-Org",
+        "https://discord.gg/comfyorg",
+        "https://x.com/ComfyUI",
+        "https://www.linkedin.com/company/comfyui",
+        "https://www.instagram.com/comfyui",
+        "https://www.youtube.com/@comfyorg"
+      ],
+      "contactPoint": [
+        {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "email": "hello@comfy.org",
+          "url": "https://support.comfy.org/"
+        },
+        {
+          "@type": "ContactPoint",
+          "contactType": "press",
+          "email": "press@comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://comfy.org/#comfyui",
+      "name": "ComfyUI",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "sameAs": [
+        "https://en.wikipedia.org/wiki/ComfyUI",
+        "https://github.com/Comfy-Org/ComfyUI",
+        "https://comfy.org"
+      ],
+      "softwareHelp": {
+        "@type": "CreativeWork",
+        "name": "ComfyUI Docs",
+        "url": "https://docs.comfy.org"
+      }
+    },
+    {
+      "@type": "WebPage",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#webpage",
+      "url": "https://comfy.org/workflows/a781503cf508-a781503cf508/",
+      "headline": "MiniMax H3: Image to Video - ComfyUI Workflow",
+      "isPartOf": {
+        "@id": "https://comfy.org/#website"
+      },
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "datePublished": "2026-08-03",
+      "inLanguage": "en",
+      "breadcrumb": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#workflow"
+      },
+      "hasPart": [
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#faq"
+        }
+      ],
+      "about": [
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#workflow"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-workflow"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-video"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-image"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-business"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files"
+        }
+      ],
+      "mentions": [
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-audio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-resolution"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-mp4"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-clip"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-model"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-input"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-reference"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-video-editing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-1080p"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-motion-graphics"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-digital-audio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-stereo-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-aspect-ratio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-api"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-point-click"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-data"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-infosec"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-pixel"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-frame-rate"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-4k"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-webcam"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-website"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-jpeg"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-png"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-download"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-url"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-data-center"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-file-system"
+        }
+      ]
+    },
+    {
+      "@type": [
+        "SoftwareApplication",
+        "TechArticle"
+      ],
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#workflow",
+      "name": "MiniMax H3: Image to Video",
+      "headline": "MiniMax H3: Image to Video",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "datePublished": "2026-08-03",
+      "image": "https://comfy-hub-assets.comfy.org/uploads/22c1098d-1f6e-4d25-82f6-2c74c72cb665.mp4",
+      "description": "Turn a starting image into a short, high-quality video clip with MiniMax H3, a unified multimodal model that generates visuals and synchronized audio in a single pass. The workflow takes 1 input image and produces 1 video output, with optional text or reference media to steer motion, style, or sound. Ideal for rapid concept visualization, character-driven animation tests, and creating shareable social media clips with built-in sound design.",
+      "keywords": "Image Generation, Video, Image to Video, MiniMax H3, ComfyUI Workflow",
+      "creator": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "runtimePlatform": {
+        "@id": "https://comfy.org/#comfyui"
+      },
+      "isRelatedTo": [
+        {
+          "@type": "WebPage",
+          "name": "Image Generation Workflows",
+          "url": "https://comfy.org/workflows/category/image/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Video Workflows",
+          "url": "https://comfy.org/workflows/tag/video/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Image to Video Workflows",
+          "url": "https://comfy.org/workflows/tag/image-to-video/"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-workflow",
+      "name": "Workflow",
+      "sameAs": "https://en.wikipedia.org/wiki/Workflow"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-video",
+      "name": "Video",
+      "sameAs": "https://en.wikipedia.org/wiki/Video"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-image",
+      "name": "Image",
+      "sameAs": "https://en.wikipedia.org/wiki/Image"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-audio",
+      "name": "Audio",
+      "sameAs": "https://en.wikipedia.org/wiki/Sound"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-resolution",
+      "name": "Resolution",
+      "sameAs": "https://en.wikipedia.org/wiki/Display_resolution"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-mp4",
+      "name": "MP4",
+      "sameAs": "https://en.wikipedia.org/wiki/MPEG-4"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-clip",
+      "name": "Clip",
+      "sameAs": "https://en.wikipedia.org/wiki/Video_clip"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-model",
+      "name": "Model",
+      "sameAs": "https://en.wikipedia.org/wiki/Model"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-input",
+      "name": "Input",
+      "sameAs": "https://en.wikipedia.org/wiki/Information"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-reference",
+      "name": "Reference",
+      "sameAs": "https://en.wikipedia.org/wiki/Citation"
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo",
+      "name": "Audio & Video",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-video-editing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-1080p"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-motion-graphics"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-digital-audio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-stereo-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-aspect-ratio"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-video-editing",
+      "name": "Video Editing",
+      "sameAs": "https://en.wikipedia.org/wiki/Video_editing",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-1080p",
+      "name": "1080p",
+      "sameAs": "https://en.wikipedia.org/wiki/1080p",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-motion-graphics",
+      "name": "Motion Graphics",
+      "sameAs": "https://en.wikipedia.org/wiki/Motion_graphics",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-digital-audio",
+      "name": "Digital Audio",
+      "sameAs": "https://en.wikipedia.org/wiki/Digital_audio",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-stereo-sound",
+      "name": "Stereophonic Sound",
+      "sameAs": "https://en.wikipedia.org/wiki/Stereophonic_sound",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-aspect-ratio",
+      "name": "Display Aspect Ratio",
+      "sameAs": "https://en.wikipedia.org/wiki/Display_aspect_ratio",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology",
+      "name": "Technology",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-api"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-point-click"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-data"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-infosec"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-pixel"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-frame-rate"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-4k"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-api",
+      "name": "API",
+      "sameAs": "https://en.wikipedia.org/wiki/API",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-point-click",
+      "name": "Point and Click",
+      "sameAs": "https://en.wikipedia.org/wiki/Point_and_click",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-data",
+      "name": "Data",
+      "sameAs": "https://en.wikipedia.org/wiki/Data",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-infosec",
+      "name": "Information Security",
+      "sameAs": "https://en.wikipedia.org/wiki/Information_security",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-pixel",
+      "name": "Pixel",
+      "sameAs": "https://en.wikipedia.org/wiki/Pixel",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-frame-rate",
+      "name": "Frame Rate",
+      "sameAs": "https://en.wikipedia.org/wiki/Frame_rate",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-4k",
+      "name": "4K Resolution",
+      "sameAs": "https://en.wikipedia.org/wiki/4K_resolution",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-business",
+      "name": "Business",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-webcam"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-website"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-webcam",
+      "name": "Webcam",
+      "sameAs": "https://en.wikipedia.org/wiki/Webcam",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-website",
+      "name": "Website",
+      "sameAs": "https://en.wikipedia.org/wiki/Website",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files",
+      "name": "Files & Storage",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-jpeg"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-png"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-download"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-url"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-data-center"
+        },
+        {
+          "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-file-system"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-jpeg",
+      "name": "JPEG",
+      "sameAs": "https://en.wikipedia.org/wiki/JPEG",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-png",
+      "name": "PNG",
+      "sameAs": "https://en.wikipedia.org/wiki/PNG",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-download",
+      "name": "Download",
+      "sameAs": "https://en.wikipedia.org/wiki/Download",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-url",
+      "name": "URL",
+      "sameAs": "https://en.wikipedia.org/wiki/URL",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-data-center",
+      "name": "Data Center",
+      "sameAs": "https://en.wikipedia.org/wiki/Data_center",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#e-file-system",
+      "name": "File System",
+      "sameAs": "https://en.wikipedia.org/wiki/File_system",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#cat-files"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://comfy.org"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Workflows",
+          "item": "https://comfy.org/workflows/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "MiniMax H3: Image to Video",
+          "item": "https://comfy.org/workflows/a781503cf508-a781503cf508/"
+        }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://comfy.org/workflows/a781503cf508-a781503cf508/#faq",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Which files do I need to download for MiniMax H3 to generate video and audio?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Download the MiniMax video VAE (minimax_h3_video_vae_fp16.safetensors) and audio VAE (minimax_h3_audio_vae_fp32.safetensors) from the links in the workflow notes. In the MiniMax H3 node (id: 4c314f31-ecda-4b08-ae98-faaba1bf613f), set the paths if the node exposes them, then reload models if required."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I pick the right resolution?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Use ResolutionSelector with a megapixel budget that matches your GPU VRAM. The ImageScaleToTotalPixels node will output dimensions that are multiples of 32 and preserve your input image's aspect via GetImageSize. If you encounter OOM errors, lower the MP target or shorten the duration."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I get silent video only?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. In the MiniMax H3 node, disable audio generation (if exposed) or ignore the audio output when wiring to SaveVideo. The SaveVideo node will still write the video stream as MP4."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I control motion and style?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Your input image anchors style and identity. For motion, add concise guidance in the MiniMax H3 node (e.g., camera moves, tempo, ambience). Keep prompts short and concrete. For stronger effects, try a higher duration or different seed; for more subtle motion, reduce duration or simplify the guidance."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/site/tests/fixtures/workflow-schema/b37902cee452.json
+++ b/site/tests/fixtures/workflow-schema/b37902cee452.json
@@ -1,0 +1,656 @@
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://comfy.org/#website",
+      "name": "Comfy",
+      "url": "https://comfy.org",
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "hasPart": [
+        {
+          "@type": "Blog",
+          "name": "Comfy Blog",
+          "url": "https://blog.comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://comfy.org/#organization",
+      "name": "Comfy Org",
+      "url": "https://comfy.org",
+      "sameAs": [
+        "https://github.com/Comfy-Org",
+        "https://discord.gg/comfyorg",
+        "https://x.com/ComfyUI",
+        "https://www.linkedin.com/company/comfyui",
+        "https://www.instagram.com/comfyui",
+        "https://www.youtube.com/@comfyorg"
+      ],
+      "contactPoint": [
+        {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "email": "hello@comfy.org",
+          "url": "https://support.comfy.org/"
+        },
+        {
+          "@type": "ContactPoint",
+          "contactType": "press",
+          "email": "press@comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://comfy.org/#comfyui",
+      "name": "ComfyUI",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "sameAs": [
+        "https://en.wikipedia.org/wiki/ComfyUI",
+        "https://github.com/Comfy-Org/ComfyUI",
+        "https://comfy.org"
+      ],
+      "softwareHelp": {
+        "@type": "CreativeWork",
+        "name": "ComfyUI Docs",
+        "url": "https://docs.comfy.org"
+      }
+    },
+    {
+      "@type": "WebPage",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#webpage",
+      "url": "https://comfy.org/workflows/b37902cee452-b37902cee452/",
+      "headline": "LTX-2.5: Image to Video - ComfyUI Workflow",
+      "isPartOf": {
+        "@id": "https://comfy.org/#website"
+      },
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "datePublished": "2026-08-12",
+      "inLanguage": "en",
+      "breadcrumb": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#workflow"
+      },
+      "hasPart": [
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#faq"
+        }
+      ],
+      "about": [
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#workflow"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-video"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-image"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-business"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-software"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+        }
+      ],
+      "mentions": [
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-api"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-open-source"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-codec"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-data"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-accessibility"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-hdr"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-motion-interp"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-hardware"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-gpu"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-prompt-eng"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-library"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-load"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-footage"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-camera"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-rendering"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-quality"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-manufacturing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-image-format"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-display-res"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-pixel"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-frame-rate"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-aspect-ratio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-subtitles"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-1080p"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-motion-blur"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-mpeg4"
+        }
+      ]
+    },
+    {
+      "@type": [
+        "SoftwareApplication",
+        "TechArticle"
+      ],
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#workflow",
+      "name": "LTX-2.5: Image to Video",
+      "headline": "LTX-2.5: Image to Video",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "identifier": "6e397a2b-68f7-48f6-8930-f3a5491a163c",
+      "datePublished": "2026-08-12",
+      "image": "https://comfy-hub-assets.comfy.org/uploads/3797af8e-2d26-4c76-a61a-138647979889.mp4",
+      "description": "Generate video from a single image using LTX-2.5, producing a high-fidelity clip with industry-leading pixel quality and native multishot capability that holds character, environment, and lighting across connected scenes. Ideal for cinematic production, VFX shot creation, and content pipelines requiring fast, locally deployable video generation.",
+      "keywords": "Image Generation, Image to Video, LTX-2.5, ComfyUI Workflow",
+      "creator": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "runtimePlatform": {
+        "@id": "https://comfy.org/#comfyui"
+      },
+      "isRelatedTo": [
+        {
+          "@type": "WebPage",
+          "name": "Image Generation Workflows",
+          "url": "https://comfy.org/workflows/category/image/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Image to Video Workflows",
+          "url": "https://comfy.org/workflows/tag/image-to-video/"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-video",
+      "name": "Video",
+      "sameAs": "https://en.wikipedia.org/wiki/Video"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-image",
+      "name": "Image",
+      "sameAs": "https://en.wikipedia.org/wiki/Image"
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology",
+      "name": "Technology",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-api"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-open-source"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-codec"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-data"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-accessibility"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-hdr"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-motion-interp"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-image-format"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-api",
+      "name": "API",
+      "sameAs": "https://en.wikipedia.org/wiki/API",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-open-source",
+      "name": "Open-source software",
+      "sameAs": "https://en.wikipedia.org/wiki/Open-source_software",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-codec",
+      "name": "Codec",
+      "sameAs": "https://en.wikipedia.org/wiki/Codec",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-data",
+      "name": "Data",
+      "sameAs": "https://en.wikipedia.org/wiki/Data",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-accessibility",
+      "name": "Accessibility",
+      "sameAs": "https://en.wikipedia.org/wiki/Accessibility",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-hdr",
+      "name": "High Dynamic Range",
+      "sameAs": "https://en.wikipedia.org/wiki/High_dynamic_range",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-motion-interp",
+      "name": "Motion Interpolation",
+      "sameAs": "https://en.wikipedia.org/wiki/Motion_interpolation",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-image-format",
+      "name": "Image File Format",
+      "sameAs": "https://en.wikipedia.org/wiki/Image_file_format",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-business",
+      "name": "Business & Production",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-footage"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-camera"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-rendering"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-quality"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-manufacturing"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-footage",
+      "name": "Footage",
+      "sameAs": "https://en.wikipedia.org/wiki/Footage",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-camera",
+      "name": "Camera",
+      "sameAs": "https://en.wikipedia.org/wiki/Camera",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-rendering",
+      "name": "Rendering (Computer Graphics)",
+      "sameAs": "https://en.wikipedia.org/wiki/Rendering_(computer_graphics)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-quality",
+      "name": "Quality (Business)",
+      "sameAs": "https://en.wikipedia.org/wiki/Quality_(business)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-manufacturing",
+      "name": "Manufacturing",
+      "sameAs": "https://en.wikipedia.org/wiki/Manufacturing",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-software",
+      "name": "Software & Development",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-prompt-eng"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-library"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-hardware"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-gpu"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-load"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-prompt-eng",
+      "name": "Prompt Engineering",
+      "sameAs": "https://en.wikipedia.org/wiki/Prompt_engineering",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-software"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-library",
+      "name": "Library (Computing)",
+      "sameAs": "https://en.wikipedia.org/wiki/Library_(computing)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-software"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-hardware",
+      "name": "Computer Hardware",
+      "sameAs": "https://en.wikipedia.org/wiki/Computer_hardware",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-software"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-gpu",
+      "name": "Graphics Processing Unit",
+      "sameAs": "https://en.wikipedia.org/wiki/Graphics_processing_unit",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-software"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-load",
+      "name": "Load (Computing)",
+      "sameAs": "https://en.wikipedia.org/wiki/Load_(computing)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-software"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo",
+      "name": "Audio & Video",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-display-res"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-pixel"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-frame-rate"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-aspect-ratio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-subtitles"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-sound"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-1080p"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-motion-blur"
+        },
+        {
+          "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-mpeg4"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-display-res",
+      "name": "Display Resolution",
+      "sameAs": "https://en.wikipedia.org/wiki/Display_resolution",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-pixel",
+      "name": "Pixel",
+      "sameAs": "https://en.wikipedia.org/wiki/Pixel",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-frame-rate",
+      "name": "Frame Rate",
+      "sameAs": "https://en.wikipedia.org/wiki/Frame_rate",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-aspect-ratio",
+      "name": "Display Aspect Ratio",
+      "sameAs": "https://en.wikipedia.org/wiki/Display_aspect_ratio",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-subtitles",
+      "name": "Subtitles",
+      "sameAs": "https://en.wikipedia.org/wiki/Subtitles",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-sound",
+      "name": "Sound",
+      "sameAs": "https://en.wikipedia.org/wiki/Sound",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-1080p",
+      "name": "1080p",
+      "sameAs": "https://en.wikipedia.org/wiki/1080p",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-motion-blur",
+      "name": "Motion Blur",
+      "sameAs": "https://en.wikipedia.org/wiki/Motion_blur",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#e-mpeg4",
+      "name": "MPEG-4",
+      "sameAs": "https://en.wikipedia.org/wiki/MPEG-4",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://comfy.org"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Workflows",
+          "item": "https://comfy.org/workflows/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "LTX-2.5: Image to Video",
+          "item": "https://comfy.org/workflows/b37902cee452-b37902cee452/"
+        }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://comfy.org/workflows/b37902cee452-b37902cee452/#faq",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Why does the workflow use ResolutionSelector and multiples of 32?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "LTX-2.5 (like many diffusion models) operates on stride-aligned dimensions. Using multiples of 32 prevents internal padding/resize artifacts, improves stability, and is more VRAM-efficient. The ResolutionSelector node helps you pick valid 16:9 sizes (e.g., 1056x608 for ~0.6 MP)."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How long can my clip be, and what affects render time?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Clip duration is frames ÷ FPS (e.g., 96 frames at 24 FPS ≈ 4 seconds). Render time and memory scale with resolution, frame count, and motion complexity. Start with modest settings (e.g., 0.6–0.8 MP, 64–96 frames, 16–24 FPS) and increase as your VRAM and iteration time allow."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I keep the subject stable and avoid jitter?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Use a clean, high-resolution source image with a clear subject and lighting. Keep output resolution stride-aligned, reduce motion intensity for more conservative movement, and consider raising FPS while keeping motion moderate. Re-seed if you see unwanted artifacts; stability often improves after a few trials."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does this support multishot timelines?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "This template focuses on a single image-to-video clip. LTX-2.5 is designed to maintain coherent style and identity across shots, but to build a multishot timeline in ComfyUI, duplicate this block with Subgraph, render each shot, and stitch the resulting clips in your editor (or a separate combine step)."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/site/tests/fixtures/workflow-schema/cd0c4f9f61a4.json
+++ b/site/tests/fixtures/workflow-schema/cd0c4f9f61a4.json
@@ -1,0 +1,638 @@
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://comfy.org/#website",
+      "name": "Comfy",
+      "url": "https://comfy.org",
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "hasPart": [
+        {
+          "@type": "Blog",
+          "name": "Comfy Blog",
+          "url": "https://blog.comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://comfy.org/#organization",
+      "name": "Comfy Org",
+      "url": "https://comfy.org",
+      "sameAs": [
+        "https://github.com/Comfy-Org",
+        "https://discord.gg/comfyorg",
+        "https://x.com/ComfyUI",
+        "https://www.linkedin.com/company/comfyui",
+        "https://www.instagram.com/comfyui",
+        "https://www.youtube.com/@comfyorg"
+      ],
+      "contactPoint": [
+        {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "email": "hello@comfy.org",
+          "url": "https://support.comfy.org/"
+        },
+        {
+          "@type": "ContactPoint",
+          "contactType": "press",
+          "email": "press@comfy.org"
+        }
+      ]
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://comfy.org/#comfyui",
+      "name": "ComfyUI",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "sameAs": [
+        "https://en.wikipedia.org/wiki/ComfyUI",
+        "https://github.com/Comfy-Org/ComfyUI",
+        "https://comfy.org"
+      ],
+      "softwareHelp": {
+        "@type": "CreativeWork",
+        "name": "ComfyUI Docs",
+        "url": "https://docs.comfy.org"
+      }
+    },
+    {
+      "@type": "WebPage",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#webpage",
+      "url": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/",
+      "headline": "Seedance 2.5: Reference to Video - ComfyUI Workflow",
+      "isPartOf": {
+        "@id": "https://comfy.org/#website"
+      },
+      "publisher": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "datePublished": "2026-08-08",
+      "inLanguage": "en",
+      "breadcrumb": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#breadcrumb"
+      },
+      "mainEntity": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#workflow"
+      },
+      "hasPart": [
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#faq"
+        }
+      ],
+      "about": [
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#workflow"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-reference"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-video"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-business"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-technology"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing"
+        }
+      ],
+      "mentions": [
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-audio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-motion"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-style"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-rhythm"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-ecommerce"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-product"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-advertising"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-video-editing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-sound-effect"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-cinematic"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-1080p"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-motion-blur"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-microphone"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-camera"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-footage"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-quality"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-business-process"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-display-res"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-aspect-ratio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-image-stabilization"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-frame-rate"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-4k"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-branding"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-personalization"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-product-demo"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-digital-marketing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-target-market"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-distribution"
+        }
+      ]
+    },
+    {
+      "@type": [
+        "SoftwareApplication",
+        "TechArticle"
+      ],
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#workflow",
+      "name": "Seedance 2.5: Reference to Video",
+      "headline": "Seedance 2.5: Reference to Video",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "datePublished": "2026-08-08",
+      "image": "https://comfy-hub-assets.comfy.org/uploads/f2e78556-33a9-4499-a40f-0af364af0662.mp4",
+      "description": "Generate reference-driven videos with Seedance 2.5 by supplying up to 20 images, 6 video clips, and 6 audio clips to control character consistency, visual style, and motion rhythm in a single 4-30 second output with synchronized sound and lip-synced dialogue. Ideal for e-commerce product showcases, brand advertising, and character-driven short series.",
+      "keywords": "Image Generation, Partner Nodes, Video, Reference to Video, Seedance 2.5, ComfyUI Workflow",
+      "creator": {
+        "@id": "https://comfy.org/#organization"
+      },
+      "runtimePlatform": {
+        "@id": "https://comfy.org/#comfyui"
+      },
+      "isRelatedTo": [
+        {
+          "@type": "WebPage",
+          "name": "Image Generation Workflows",
+          "url": "https://comfy.org/workflows/category/image/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Partner Node Workflows",
+          "url": "https://comfy.org/workflows/tag/partner-nodes/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Video Workflows",
+          "url": "https://comfy.org/workflows/tag/video/"
+        },
+        {
+          "@type": "WebPage",
+          "name": "Image to Video Workflows",
+          "url": "https://comfy.org/workflows/tag/image-to-video/"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-reference",
+      "name": "Reference",
+      "sameAs": "https://en.wikipedia.org/wiki/Citation"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-video",
+      "name": "Video",
+      "sameAs": "https://en.wikipedia.org/wiki/Video"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-audio",
+      "name": "Audio",
+      "sameAs": "https://en.wikipedia.org/wiki/Sound"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-motion",
+      "name": "Motion",
+      "sameAs": "https://en.wikipedia.org/wiki/Motion_(physics)"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-style",
+      "name": "Visual Style",
+      "sameAs": "https://en.wikipedia.org/wiki/Style_(visual_arts)"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-rhythm",
+      "name": "Rhythm",
+      "sameAs": "https://en.wikipedia.org/wiki/Rhythm"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-ecommerce",
+      "name": "E-commerce",
+      "sameAs": "https://en.wikipedia.org/wiki/E-commerce"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-product",
+      "name": "Product",
+      "sameAs": "https://en.wikipedia.org/wiki/Product_(business)"
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-advertising",
+      "name": "Brand Advertising",
+      "sameAs": "https://en.wikipedia.org/wiki/Advertising"
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo",
+      "name": "Audio & Video",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-video-editing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-sound-effect"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-cinematic"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-1080p"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-motion-blur"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-microphone"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-video-editing",
+      "name": "Video Editing",
+      "sameAs": "https://en.wikipedia.org/wiki/Video_editing",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-sound-effect",
+      "name": "Sound Effect",
+      "sameAs": "https://en.wikipedia.org/wiki/Sound_effect",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-cinematic",
+      "name": "Cinematic Techniques",
+      "sameAs": "https://en.wikipedia.org/wiki/Cinematic_techniques",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-1080p",
+      "name": "1080p",
+      "sameAs": "https://en.wikipedia.org/wiki/1080p",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-motion-blur",
+      "name": "Motion Blur",
+      "sameAs": "https://en.wikipedia.org/wiki/Motion_blur",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-microphone",
+      "name": "Microphone",
+      "sameAs": "https://en.wikipedia.org/wiki/Microphone",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-audiovideo"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-business",
+      "name": "Business & Production",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-camera"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-footage"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-quality"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-business-process"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-camera",
+      "name": "Camera",
+      "sameAs": "https://en.wikipedia.org/wiki/Camera",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-footage",
+      "name": "Footage",
+      "sameAs": "https://en.wikipedia.org/wiki/Footage",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-quality",
+      "name": "Quality (Business)",
+      "sameAs": "https://en.wikipedia.org/wiki/Quality_(business)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-business-process",
+      "name": "Business Process",
+      "sameAs": "https://en.wikipedia.org/wiki/Business_process",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-business"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-technology",
+      "name": "Technology",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-display-res"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-aspect-ratio"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-image-stabilization"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-frame-rate"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-4k"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-display-res",
+      "name": "Display Resolution",
+      "sameAs": "https://en.wikipedia.org/wiki/Display_resolution",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-aspect-ratio",
+      "name": "Display Aspect Ratio",
+      "sameAs": "https://en.wikipedia.org/wiki/Display_aspect_ratio",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-image-stabilization",
+      "name": "Image Stabilization",
+      "sameAs": "https://en.wikipedia.org/wiki/Image_stabilization",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-frame-rate",
+      "name": "Frame Rate",
+      "sameAs": "https://en.wikipedia.org/wiki/Frame_rate",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-4k",
+      "name": "4K Resolution",
+      "sameAs": "https://en.wikipedia.org/wiki/4K_resolution",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-technology"
+      }
+    },
+    {
+      "@type": "DefinedTermSet",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing",
+      "name": "Marketing & Commerce",
+      "hasDefinedTerm": [
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-branding"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-personalization"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-product-demo"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-digital-marketing"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-target-market"
+        },
+        {
+          "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-distribution"
+        }
+      ]
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-branding",
+      "name": "Branding",
+      "sameAs": "https://en.wikipedia.org/wiki/Brand",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-personalization",
+      "name": "Personalization",
+      "sameAs": "https://en.wikipedia.org/wiki/Personalization",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-product-demo",
+      "name": "Product Demonstration",
+      "sameAs": "https://en.wikipedia.org/wiki/Product_demonstration",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-digital-marketing",
+      "name": "Digital Marketing",
+      "sameAs": "https://en.wikipedia.org/wiki/Digital_marketing",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-target-market",
+      "name": "Target Market",
+      "sameAs": "https://en.wikipedia.org/wiki/Target_market",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing"
+      }
+    },
+    {
+      "@type": "DefinedTerm",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#e-distribution",
+      "name": "Distribution",
+      "sameAs": "https://en.wikipedia.org/wiki/Distribution_(marketing)",
+      "inDefinedTermSet": {
+        "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#cat-marketing"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://comfy.org"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Workflows",
+          "item": "https://comfy.org/workflows/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Seedance 2.5: Reference to Video",
+          "item": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/"
+        }
+      ]
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://comfy.org/workflows/cd0c4f9f61a4-cd0c4f9f61a4/#faq",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How many references should I start with?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Begin with a small, curated set: 3–6 strong images for identity/style, 1–2 motion clips, and a single clean audio track. Add more only if you need additional cues. Too many overlapping references can cause conflicts and visual jitter."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I keep the character consistent throughout the clip?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Use clear, front-facing images with consistent lighting and aspect ratio, place your best identity shots early in the list, and increase the image-reference influence in ByteDance2ReferenceNode. Avoid mixing drastically different hairstyles, angles, or outfits unless you intend to change appearance."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "My audio drifts or lip-sync looks off. What can I do?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Use a single, clean vocal track without heavy reverb or background music for best lip-sync. Ensure your target duration and FPS match your audio plan; if the audio is longer than the selected duration, trim it to fit. Re-queue with a fixed seed after adjustments for consistent comparisons."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What affects performance and render time?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Resolution, frame rate, duration, and the number of references all increase compute and memory use. For faster previews, lower resolution and FPS, shorten duration, and limit references. When satisfied with motion and sync, scale up quality for the final render."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/site/tests/unit/workflow-schema-recommendation.test.ts
+++ b/site/tests/unit/workflow-schema-recommendation.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildWorkflowGraphJsonLd } from '../../src/lib/structured-data';
+import { getWorkflowEntityGraph } from '../../src/data/workflow-entity-graphs';
+import { ORGANIZATION_ID } from '../../src/lib/site-entities';
+
+/**
+ * The four pages that carry a client-approved `@graph`. Their recommended
+ * output is committed under tests/fixtures/workflow-schema/ (see the README
+ * there); this rebuilds each one from the repo's curated data and asserts the
+ * builder still reproduces it, node for node and in order.
+ */
+const SHARE_IDS = ['b37902cee452', 'cd0c4f9f61a4', 'a781503cf508', '9394f9968da3'] as const;
+
+type Node = Record<string, unknown>;
+
+function loadFixture(shareId: string): Node[] {
+  const file = path.join(__dirname, '..', 'fixtures', 'workflow-schema', `${shareId}.json`);
+  return (JSON.parse(readFileSync(file, 'utf-8')) as { '@graph': Node[] })['@graph'];
+}
+
+const nodeWithId = (graph: Node[], suffix: string) =>
+  graph.find((node) => typeof node['@id'] === 'string' && (node['@id'] as string).endsWith(suffix));
+
+/**
+ * Rebuild a page's graph using the repo's entity data, with every hub-owned
+ * value (title, image, short description, FAQ, breadcrumb) taken from the
+ * fixture. What is under test is the assembly, not the hub's copy.
+ */
+function rebuild(shareId: string, fixture: Node[]) {
+  const webpage = nodeWithId(fixture, '#webpage')!;
+  const workflow = nodeWithId(fixture, '#workflow')!;
+  const breadcrumb = nodeWithId(fixture, '#breadcrumb') as
+    | { itemListElement: { name: string; item: string }[] }
+    | undefined;
+  const faq = nodeWithId(fixture, '#faq') as
+    | { mainEntity: { name: string; acceptedAnswer: { text: string } }[] }
+    | undefined;
+
+  const entityGraph = getWorkflowEntityGraph(shareId);
+  expect(entityGraph, `${shareId} has no curated entity graph`).toBeDefined();
+
+  return buildWorkflowGraphJsonLd({
+    canonicalUrl: webpage.url as string,
+    title: workflow.name as string,
+    pageHeadline: webpage.headline as string,
+    description: workflow.description as string,
+    image: workflow.image as string | undefined,
+    datePublished: webpage.datePublished as string | undefined,
+    inLanguage: webpage.inLanguage as string,
+    breadcrumbItems: (breadcrumb?.itemListElement ?? []).map((item) => ({
+      name: item.name,
+      item: item.item,
+    })),
+    faqItems: (faq?.mainEntity ?? []).map((question) => ({
+      question: question.name,
+      answer: question.acceptedAnswer.text,
+    })),
+    entityGraph: entityGraph!,
+  });
+}
+
+describe.each(SHARE_IDS)('recommended @graph for %s', (shareId) => {
+  const fixture = loadFixture(shareId);
+  const built = rebuild(shareId, fixture)['@graph'] as Node[];
+
+  it('emits the recommended nodes, in the recommended order', () => {
+    expect(built.map((node) => node['@id'])).toEqual(fixture.map((node) => node['@id']));
+  });
+
+  it('matches the recommendation node for node', () => {
+    for (const [index, expected] of fixture.entries()) {
+      const actual = built[index];
+      if (expected['@id'] === ORGANIZATION_ID) {
+        // The site adds a `logo` the recommendation omits; everything else on
+        // the Organization node must still match exactly.
+        expect(actual, ORGANIZATION_ID).toMatchObject(expected);
+        continue;
+      }
+      expect(actual, String(expected['@id'])).toEqual(expected);
+    }
+  });
+});
+
+/**
+ * The hub's generated copy sometimes ends in blank lines. HTML swallows them;
+ * JSON-LD does not, and today the Seedance 2.5 page ships a `description`
+ * ending in "\n\n" inside its `@graph`.
+ */
+describe('hub whitespace does not reach the emitted graph', () => {
+  const fixture = loadFixture('cd0c4f9f61a4');
+  const workflow = nodeWithId(fixture, '#workflow')!;
+  const webpage = nodeWithId(fixture, '#webpage')!;
+
+  it('trims the workflow description and every FAQ string', () => {
+    const graph = buildWorkflowGraphJsonLd({
+      canonicalUrl: webpage.url as string,
+      title: workflow.name as string,
+      description: `${workflow.description as string}\n\n`,
+      inLanguage: 'en',
+      breadcrumbItems: [],
+      faqItems: [{ question: '  Padded question?  ', answer: 'Padded answer.\n\n' }],
+      entityGraph: getWorkflowEntityGraph('cd0c4f9f61a4')!,
+    })['@graph'] as Node[];
+
+    expect(nodeWithId(graph, '#workflow')!.description).toBe(workflow.description);
+    const faq = nodeWithId(graph, '#faq') as {
+      mainEntity: { name: string; acceptedAnswer: { text: string } }[];
+    };
+    expect(faq.mainEntity[0].name).toBe('Padded question?');
+    expect(faq.mainEntity[0].acceptedAnswer.text).toBe('Padded answer.');
+  });
+});


### PR DESCRIPTION
Stacked on #1251 (retargets to `main` when that merges). Rebased onto the updated #1251 (self-retiring override + i18n fold-in) and latest `main`.

## What

Commits the client's recommended `@graph` for the four curated workflow pages as fixtures, asserts the builder still reproduces them, and trims the hub-sourced strings that reach JSON-LD.

## Why

The `@graph` for these pages has been live since #1205 and, checked against the recommendation, still matches it exactly. The only difference is the site's own `Organization.logo`, which the recommendation omits.

Nothing in the repo records what that output is *supposed* to be, though. A change to `buildWorkflowGraphJsonLd` or to an entry in `WORKFLOW_ENTITY_GRAPHS` (reordering `mentions`, dropping a `DefinedTermSet` member, renaming a fragment id) would reshape the emitted graph with no test failing. These pages are the ones we point at when the entity coverage question comes up, so they are worth pinning.

The second half is a real defect: hub copy sometimes ends in blank lines. HTML swallows them, JSON-LD does not, and `/workflows/cd0c4f9f61a4-cd0c4f9f61a4/` currently ships

```json
"description": "...brand advertising, and character-driven short series.\n\n"
```

inside its `@graph`.

## How

- `site/tests/fixtures/workflow-schema/*.json`: the four recommended graphs, verbatim, named by share id, with a README on provenance and on not editing them to make a test pass.
- `site/tests/unit/workflow-schema-recommendation.test.ts`: rebuilds each graph from the repo's curated data and compares node for node and in order. Page-level values the hub owns (title, image, short description, FAQ) come from the fixture, so the test pins what this repo controls: the entity nodes, their categories and cross-references, and node order. Hub copy drifting is a content question, not a build regression, and is deliberately out of scope.
- `site/src/lib/structured-data.ts`: one `clean()` helper applied to the strings the builders take from hub content (workflow `description`, FAQ question/answer, `SoftwareApplication` name/description).

## Test

- `pnpm test`: 944 passing on this head, including the 9 new ones.
- Rendered all four pages locally after the change: `@graph` node-identical to the fixtures, and no untrimmed string anywhere in the emitted graph (Seedance's trailing `\n\n` is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwLFkwizjC7LymtF1ofwqH
