### PR TITLE
Publish MAI Image 2.6 thumbnails in media-assets-01 (0.11.59)

### DIFF
--- a/packages/media_assets_01/pyproject.toml
+++ b/packages/media_assets_01/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-workflow-templates-media-assets-01"
-version = "0.1.43"
+version = "0.1.44"
 description = "Media assets bundle 01 for ComfyUI workflow templates"
 readme = {text = "Media assets bundle 01 for ComfyUI workflow templates.", content-type = "text/plain"}
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui_workflow_templates"
-version = "0.11.58"
+version = "0.11.59"
 description = "ComfyUI workflow templates package"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -24,19 +24,19 @@ dependencies = [
     "comfyui-workflow-templates-media-video==0.3.101",
     "comfyui-workflow-templates-media-image==0.3.160",
     "comfyui-workflow-templates-media-other==0.3.229",
-    "comfyui-workflow-templates-media-assets-01==0.1.43",
+    "comfyui-workflow-templates-media-assets-01==0.1.44",
 ]
 
 [project.optional-dependencies]
 json = ["comfyui-workflow-templates-json==0.1.74"]
-assets = ["comfyui-workflow-templates-media-assets-01==0.1.43"]
+assets = ["comfyui-workflow-templates-media-assets-01==0.1.44"]
 api = ["comfyui-workflow-templates-media-api==0.3.84"]
 video = ["comfyui-workflow-templates-media-video==0.3.101"]
 image = ["comfyui-workflow-templates-media-image==0.3.160"]
 other = ["comfyui-workflow-templates-media-other==0.3.229"]
 all = [
     "comfyui-workflow-templates-json==0.1.74",
-    "comfyui-workflow-templates-media-assets-01==0.1.43",
+    "comfyui-workflow-templates-media-assets-01==0.1.44",
     "comfyui-workflow-templates-media-api==0.3.84",
     "comfyui-workflow-templates-media-video==0.3.101",
     "comfyui-workflow-templates-media-image==0.3.160",


### PR DESCRIPTION
## Summary
- `media-assets-01` 0.1.43 (from #1247) never included the MAI Image 2.6 `-1.webp` files added in #1254.
- #1256 bumped `json`/`core` to 0.11.58 but CI did not bump `01`, because those PRs only changed workflow JSON and `thumbnail/*.png` (outside `templates/` media globs).
- Bump `media-assets-01` to 0.1.44 and meta to 0.11.59 so the next PyPI publish ships the previews ComfyUI actually loads.

## Test plan
- [ ] After publish, confirm `comfyui-workflow-templates-media-assets-01==0.1.44` contains `api_openrouter_mai_image_26_*`-1.webp
- [ ] In ComfyUI, confirm MAI Image 2.6 / Flash image-edit cards show thumbnails